### PR TITLE
test(timeout): implement tests for timeout

### DIFF
--- a/packages/stryker/src/test-runner/TimeoutDecorator.ts
+++ b/packages/stryker/src/test-runner/TimeoutDecorator.ts
@@ -1,8 +1,7 @@
 import { RunOptions, RunResult, RunStatus } from 'stryker-api/test_runner';
 import TestRunnerDecorator from './TestRunnerDecorator';
 import { getLogger } from 'stryker-api/logging';
-import { TIMEOUT_EXPIRED, timeout } from '../utils/objectUtils';
-
+import { TimeoutExpired, timeout } from '../utils/objectUtils';
 
 /**
  * Wraps a test runner and implements the timeout functionality.
@@ -14,7 +13,7 @@ export default class TimeoutDecorator extends TestRunnerDecorator {
   async run(options: RunOptions): Promise<RunResult> {
     this.log.debug('Starting timeout timer (%s ms) for a test run', options.timeout);
     const result = await timeout(super.run(options), options.timeout);
-    if (result === TIMEOUT_EXPIRED) {
+    if (result === TimeoutExpired) {
       return this.handleTimeout();
     } else {
       return result;

--- a/packages/stryker/src/utils/Task.ts
+++ b/packages/stryker/src/utils/Task.ts
@@ -38,13 +38,10 @@ export class Task<T = void> {
 
 /**
  * A task that can expire after the given time.
- * If that happens, the inner promise is resolved
  */
-export class ExpirableTask<T = void> extends Task<T | TimeoutExpired> {
+export class ExpirableTask<T = void> extends Task<T | typeof TimeoutExpired> {
   constructor(timeoutMS: number) {
     super();
-    this._promise = timeout(this._promise, timeoutMS).then(val => {
-      return val;
-    });
+    this._promise = timeout(this._promise, timeoutMS);
   }
 }

--- a/packages/stryker/src/utils/objectUtils.ts
+++ b/packages/stryker/src/utils/objectUtils.ts
@@ -102,11 +102,10 @@ export function kill(pid: number): Promise<void> {
   });
 }
 
-export type TimeoutExpired = 'TIMEOUT_EXPIRED';
-export const TIMEOUT_EXPIRED: TimeoutExpired = 'TIMEOUT_EXPIRED';
-export function timeout<T>(promise: Promise<T>, ms: number): Promise<T | TimeoutExpired> {
-  const sleep = new Promise<T | TimeoutExpired>((res, rej) => {
-    const timer = setTimeout(() => res(TIMEOUT_EXPIRED), ms);
+export const TimeoutExpired: unique symbol = Symbol('TimeoutExpired');
+export function timeout<T>(promise: Promise<T>, ms: number): Promise<T | typeof TimeoutExpired> {
+  const sleep = new Promise<T | typeof TimeoutExpired>((res, rej) => {
+    const timer = setTimeout(() => res(TimeoutExpired), ms);
     promise.then(result => {
       clearTimeout(timer);
       res(result);
@@ -115,7 +114,6 @@ export function timeout<T>(promise: Promise<T>, ms: number): Promise<T | Timeout
       rej(error);
     });
   });
-
   return sleep;
 }
 

--- a/packages/stryker/test/unit/utils/objectUtilsSpec.ts
+++ b/packages/stryker/test/unit/utils/objectUtilsSpec.ts
@@ -1,0 +1,34 @@
+import * as sut from '../../../src/utils/objectUtils';
+import { expect } from 'chai';
+import { match } from 'sinon';
+import { Task } from '../../../src/utils/Task';
+
+describe('objectUtils', () => {
+  describe('timeout', () => {
+    it('should timeout a promise after a set period', async () => {
+      const task = new Task();
+      const actual = await sut.timeout(task.promise, 0);
+      expect(actual).eq(sut.TimeoutExpired);
+      task.resolve(undefined);
+    });
+
+    it('should remove any nodejs timers when promise resolves', async () => {
+      // Arrange
+      const expectedTimer = 234;
+      const setTimeoutStub = sandbox.stub(global, 'setTimeout');
+      const clearTimeoutStub = sandbox.stub(global, 'clearTimeout');
+      setTimeoutStub.returns(expectedTimer);
+      const expectedResult = 'expectedResult';
+      const p = Promise.resolve(expectedResult);
+      const delay = 10;
+
+      // Act
+      const result = await sut.timeout(p, delay);
+
+      // Assert
+      expect(result).eq(expectedResult);
+      expect(clearTimeoutStub).calledWith(expectedTimer);
+      expect(setTimeoutStub).calledWith(match.func, delay);
+    });
+  });
+});


### PR DESCRIPTION
Implement unit tests for the timeout function that was hastily implemented to fix #1063 