### PR TITLE
build(deps): bump log4js from 6.2.1 to 6.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "inquirer": "~7.3.2",
     "lodash.flatmap": "~4.5.0",
     "lodash.groupby": "~4.6.0",
-    "log4js": "~6.2.1",
+    "log4js": "~6.3.0",
     "minimatch": "~3.0.4",
     "mkdirp": "~1.0.3",
     "mutation-testing-elements": "~1.4.3",

--- a/packages/core/test/helpers/producers.ts
+++ b/packages/core/test/helpers/producers.ts
@@ -82,6 +82,7 @@ export const logger = (): Mock<Logger> => {
   return {
     _log: sinon.stub(),
     addContext: sinon.stub(),
+    category: 'category',
     clearContext: sinon.stub(),
     debug: sinon.stub(),
     error: sinon.stub(),

--- a/packages/core/test/helpers/producers.ts
+++ b/packages/core/test/helpers/producers.ts
@@ -82,7 +82,7 @@ export const logger = (): Mock<Logger> => {
   return {
     _log: sinon.stub(),
     addContext: sinon.stub(),
-    category: 'category',
+    category: 'out',
     clearContext: sinon.stub(),
     debug: sinon.stub(),
     error: sinon.stub(),


### PR DESCRIPTION
closes: #2346