### PR TITLE
linting: new linting configuration - import and import member ordering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,15 +20,28 @@ module.exports = {
     ],
 
     // import rules
-    'import/newline-after-import': 1,
+    'import/newline-after-import': ['error', { 'count': 1 }],
     'import/order': [
       'error',
       {
         'newlines-between': 'always-and-inside-groups',
-        'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
+        'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        'alphabetize': {
+          'order': 'asc',
+          'caseInsensitive': true,
+        }
       }
     ],
     'import/no-default-export': 'error',
+    // small help from eslint is needed -> sort members of import
+    // import { b, a } from 'c' -> import { a, b } from 'c'
+    'sort-imports': ['error', {
+      'ignoreCase': true,
+      'ignoreDeclarationSort': true,
+      'ignoreMemberSort': false,
+      'memberSyntaxSortOrder': ["none", "all", "multiple", "single"],
+      'allowSeparatedGroups': true
+    }],
 
     // prettier rules
     'prettier/prettier': ['error'],
@@ -82,6 +95,7 @@ module.exports = {
     
     // fix - serarate PR
     '@typescript-eslint/init-declarations': 'off',
+    '@typescript-eslint/no-unused-expressions': 'off',
 
     // Long term to fix
     '@typescript-eslint/no-explicit-any': 'off',
@@ -96,17 +110,16 @@ module.exports = {
     // useful
     '@typescript-eslint/no-type-alias': 'off', // it is useful!
     '@typescript-eslint/no-use-before-define': 'off', // we use it e.x in injections
-    '@typescript-eslint/no-confusing-void-expression': 'off', // sometimes usable
+    '@typescript-eslint/no-confusing-void-expression': 'off', // sometimes usable, explicitly showing our intention
     '@typescript-eslint/no-invalid-this': 'off', // we promise to be careful
     '@typescript-eslint/no-dynamic-delete': 'off', // we promise to be careful
-    '@typescript-eslint/no-non-null-assertion': 'off', // sometimes usable
+    '@typescript-eslint/no-non-null-assertion': 'off', // we like it, we use it.
 
     // can't do nothing about it
-    '@typescript-eslint/consistent-type-imports': 'off',
-    '@typescript-eslint/prefer-readonly-parameter-types': 'off',
+    '@typescript-eslint/consistent-type-imports': 'off', // breaks with injections
+    '@typescript-eslint/prefer-readonly-parameter-types': 'off', // somehow doesn't work properly
     '@typescript-eslint/no-unsafe-assignment': 'off',
-    '@typescript-eslint/no-unused-expressions': 'off',
-    '@typescript-eslint/strict-boolean-expressions': 'off',
+    '@typescript-eslint/strict-boolean-expressions': 'off', // we do not like it, we sometimes want more wide check
     '@typescript-eslint/no-unsafe-return': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',

--- a/packages/api/src/core/file.ts
+++ b/packages/api/src/core/file.ts
@@ -1,4 +1,4 @@
-import { Surrializable, surrial } from 'surrial';
+import { surrial, Surrializable } from 'surrial';
 
 /**
  * Represents a file within Stryker. Could be a strictly in-memory file.

--- a/packages/api/src/core/mutant.ts
+++ b/packages/api/src/core/mutant.ts
@@ -1,5 +1,5 @@
-import { Range } from './range';
 import { Location } from './location';
+import { Range } from './range';
 
 /**
  * Represents a mutant

--- a/packages/api/src/plugin/plugins.ts
+++ b/packages/api/src/plugin/plugins.ts
@@ -1,8 +1,8 @@
 import { InjectableClass, InjectableFunction, InjectionToken } from 'typed-inject';
 
+import { Checker } from '../check';
 import { Reporter } from '../report';
 import { TestRunner } from '../test-runner';
-import { Checker } from '../check';
 
 import { PluginContext } from './contexts';
 import { PluginKind } from './plugin-kind';

--- a/packages/api/src/test-runner/run-options.ts
+++ b/packages/api/src/test-runner/run-options.ts
@@ -1,4 +1,4 @@
-import { Mutant, CoverageAnalysis } from '../core';
+import { CoverageAnalysis, Mutant } from '../core';
 
 export interface RunOptions {
   /**

--- a/packages/api/src/test-runner/run-result-helpers.ts
+++ b/packages/api/src/test-runner/run-result-helpers.ts
@@ -1,8 +1,8 @@
-import { TestStatus } from './test-status';
 import { DryRunResult } from './dry-run-result';
-import { MutantRunResult, MutantRunStatus } from './mutant-run-result';
 import { DryRunStatus } from './dry-run-status';
+import { MutantRunResult, MutantRunStatus } from './mutant-run-result';
 import { FailedTestResult } from './test-result';
+import { TestStatus } from './test-status';
 
 export function toMutantRunResult(dryRunResult: DryRunResult): MutantRunResult {
   switch (dryRunResult.status) {

--- a/packages/api/src/test-runner/test-runner.ts
+++ b/packages/api/src/test-runner/test-runner.ts
@@ -1,6 +1,6 @@
-import { DryRunOptions, MutantRunOptions } from './run-options';
 import { DryRunResult } from './dry-run-result';
 import { MutantRunResult } from './mutant-run-result';
+import { DryRunOptions, MutantRunOptions } from './run-options';
 
 export interface TestRunner {
   init?(): Promise<void>;

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -1,8 +1,8 @@
 import 'source-map-support/register';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/api/test/unit/plugin/plugins.spec.ts
+++ b/packages/api/test/unit/plugin/plugins.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { tokens, commonTokens, PluginKind, declareClassPlugin, declareFactoryPlugin } from '../../../src/plugin';
 import { Logger } from '../../../logging';
 import { MutantResult } from '../../../report';
+import { commonTokens, declareClassPlugin, declareFactoryPlugin, PluginKind, tokens } from '../../../src/plugin';
 
 describe('plugins', () => {
   describe(declareClassPlugin.name, () => {

--- a/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
+++ b/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { TestStatus, toMutantRunResult, DryRunStatus, MutantRunResult, MutantRunStatus } from '../../../src/test-runner';
+import { DryRunStatus, MutantRunResult, MutantRunStatus, TestStatus, toMutantRunResult } from '../../../src/test-runner';
 
 describe('runResultHelpers', () => {
   describe(toMutantRunResult.name, () => {

--- a/packages/core/src/checker/checker-facade.ts
+++ b/packages/core/src/checker/checker-facade.ts
@@ -1,14 +1,13 @@
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
 import { Mutant, StrykerOptions } from '@stryker-mutator/api/core';
 
-import { tokens, Disposable } from 'typed-inject';
 import { commonTokens } from '@stryker-mutator/api/plugin';
+import { Disposable, tokens } from 'typed-inject';
 
 import { ChildProcessProxy } from '../child-proxy/child-process-proxy';
-import { LoggingClientContext } from '../logging';
-import { coreTokens } from '../di';
-
 import { Worker } from '../concurrent/pool';
+import { coreTokens } from '../di';
+import { LoggingClientContext } from '../logging';
 
 import { CheckerWorker } from './checker-worker';
 

--- a/packages/core/src/checker/checker-worker.ts
+++ b/packages/core/src/checker/checker-worker.ts
@@ -1,7 +1,7 @@
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { StrykerOptions, Mutant } from '@stryker-mutator/api/core';
+import { Mutant, StrykerOptions } from '@stryker-mutator/api/core';
 
-import { PluginKind, tokens, commonTokens, PluginContext, Injector } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, PluginKind, tokens } from '@stryker-mutator/api/plugin';
 
 import { StrykerError } from '@stryker-mutator/util';
 

--- a/packages/core/src/child-proxy/child-process-proxy-worker.ts
+++ b/packages/core/src/child-proxy/child-process-proxy-worker.ts
@@ -8,7 +8,7 @@ import { buildChildProcessInjector } from '../di';
 import { LogConfigurator } from '../logging';
 import { deserialize, serialize } from '../utils/object-utils';
 
-import { autoStart, CallMessage, ParentMessage, ParentMessageKind, WorkerMessage, WorkerMessageKind, InitMessage } from './message-protocol';
+import { autoStart, CallMessage, InitMessage, ParentMessage, ParentMessageKind, WorkerMessage, WorkerMessageKind } from './message-protocol';
 
 export class ChildProcessProxyWorker {
   private log?: Logger;

--- a/packages/core/src/child-proxy/child-process-proxy.ts
+++ b/packages/core/src/child-proxy/child-process-proxy.ts
@@ -3,7 +3,7 @@ import os from 'os';
 
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
 import { PluginContext } from '@stryker-mutator/api/plugin';
-import { isErrnoException, Task, ExpirableTask } from '@stryker-mutator/util';
+import { ExpirableTask, isErrnoException, Task } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 import { Disposable, InjectableClass, InjectionToken } from 'typed-inject';
 

--- a/packages/core/src/concurrent/concurrency-token-provider.ts
+++ b/packages/core/src/concurrent/concurrency-token-provider.ts
@@ -1,10 +1,10 @@
 import os from 'os';
 
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { ReplaySubject, Observable, range } from 'rxjs';
-import { Disposable, tokens } from 'typed-inject';
-import { commonTokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens } from '@stryker-mutator/api/plugin';
+import { Observable, range, ReplaySubject } from 'rxjs';
+import { Disposable, tokens } from 'typed-inject';
 
 export class ConcurrencyTokenProvider implements Disposable {
   private readonly concurrencyCheckers: number;

--- a/packages/core/src/concurrent/pool.ts
+++ b/packages/core/src/concurrent/pool.ts
@@ -1,9 +1,9 @@
-import { Observable, Subject, merge, zip } from 'rxjs';
-import { mergeMap, filter, shareReplay, tap } from 'rxjs/operators';
-import { notEmpty } from '@stryker-mutator/util';
-import { Disposable, tokens } from 'typed-inject';
-import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { Checker } from '@stryker-mutator/api/check';
+import { TestRunner } from '@stryker-mutator/api/test-runner';
+import { notEmpty } from '@stryker-mutator/util';
+import { merge, Observable, Subject, zip } from 'rxjs';
+import { filter, mergeMap, shareReplay, tap } from 'rxjs/operators';
+import { Disposable, tokens } from 'typed-inject';
 
 import { coreTokens } from '../di';
 

--- a/packages/core/src/config/build-schema-with-plugin-contributions.ts
+++ b/packages/core/src/config/build-schema-with-plugin-contributions.ts
@@ -1,7 +1,7 @@
-import { commonTokens, PluginResolver, tokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
-import type { JSONSchema7 } from 'json-schema';
+import { commonTokens, PluginResolver, tokens } from '@stryker-mutator/api/plugin';
 import { I } from '@stryker-mutator/util';
+import type { JSONSchema7 } from 'json-schema';
 
 import { coreTokens } from '../di';
 

--- a/packages/core/src/config/config-reader.ts
+++ b/packages/core/src/config/config-reader.ts
@@ -8,8 +8,8 @@ import { deepMerge } from '@stryker-mutator/util';
 import { coreTokens } from '../di';
 import { ConfigError } from '../errors';
 
-import { defaultOptions, OptionsValidator } from './options-validator';
 import { createConfig } from './create-config';
+import { defaultOptions, OptionsValidator } from './options-validator';
 
 export const CONFIG_SYNTAX_HELP = `
 /**

--- a/packages/core/src/config/create-config.ts
+++ b/packages/core/src/config/create-config.ts
@@ -1,5 +1,5 @@
+import { PartialStrykerOptions, StrykerOptions } from '@stryker-mutator/api/core';
 import { deepMerge } from '@stryker-mutator/util';
-import { StrykerOptions, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
 /**
  * Adds a `set` method to the options object that can be used as a shorthand to

--- a/packages/core/src/config/options-validator.ts
+++ b/packages/core/src/config/options-validator.ts
@@ -1,16 +1,16 @@
 import os from 'os';
 
-import Ajv, { ValidateFunction } from 'ajv';
-import { StrykerOptions, strykerCoreSchema } from '@stryker-mutator/api/core';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
-import { noopLogger, propertyPath, deepFreeze, PropertyPathBuilder } from '@stryker-mutator/util';
+import { strykerCoreSchema, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+import { deepFreeze, noopLogger, propertyPath, PropertyPathBuilder } from '@stryker-mutator/util';
+import Ajv, { ValidateFunction } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
 
 import { coreTokens } from '../di';
 import { ConfigError } from '../errors';
-import { isWarningEnabled } from '../utils/object-utils';
 import { CommandTestRunner } from '../test-runner/command-test-runner';
+import { isWarningEnabled } from '../utils/object-utils';
 
 import { describeErrors } from './validation-errors';
 

--- a/packages/core/src/di/build-main-injector.ts
+++ b/packages/core/src/di/build-main-injector.ts
@@ -1,15 +1,15 @@
-import execa from 'execa';
-import { StrykerOptions, strykerCoreSchema, PartialStrykerOptions } from '@stryker-mutator/api/core';
+import { PartialStrykerOptions, strykerCoreSchema, StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens, Injector, PluginContext, PluginKind, tokens } from '@stryker-mutator/api/plugin';
 import { Reporter } from '@stryker-mutator/api/report';
 import { I } from '@stryker-mutator/util';
+import execa from 'execa';
 
-import { readConfig, buildSchemaWithPluginContributions, OptionsValidator, validateOptions, markUnknownOptions } from '../config';
+import { buildSchemaWithPluginContributions, markUnknownOptions, OptionsValidator, readConfig, validateOptions } from '../config';
 import { ConfigReader } from '../config/config-reader';
 import { BroadcastReporter } from '../reporters/broadcast-reporter';
+import { UnexpectedExitHandler } from '../unexpected-exit-handler';
 import { TemporaryDirectory } from '../utils/temporary-directory';
 import { Timer } from '../utils/timer';
-import { UnexpectedExitHandler } from '../unexpected-exit-handler';
 
 import { pluginResolverFactory } from './factory-methods';
 

--- a/packages/core/src/di/plugin-loader.ts
+++ b/packages/core/src/di/plugin-loader.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import { readdirSync } from 'fs';
+import path from 'path';
 
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, Plugin, PluginKind, PluginResolver, Plugins } from '@stryker-mutator/api/plugin';

--- a/packages/core/src/di/provide-logger.ts
+++ b/packages/core/src/di/provide-logger.ts
@@ -1,7 +1,7 @@
-import { Injector, Scope } from 'typed-inject';
+import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { commonTokens } from '@stryker-mutator/api/plugin';
-import { LoggerFactoryMethod, Logger } from '@stryker-mutator/api/logging';
 import { getLogger } from 'log4js';
+import { Injector, Scope } from 'typed-inject';
 
 export function provideLogger(injector: Injector): LoggerProvider {
   return injector.provideValue(commonTokens.getLogger, getLogger).provideFactory(commonTokens.logger, loggerFactory, Scope.Transient);

--- a/packages/core/src/initializer/gitignore-writer.ts
+++ b/packages/core/src/initializer/gitignore-writer.ts
@@ -1,5 +1,5 @@
-import os from 'os';
 import { existsSync, promises as fs } from 'fs';
+import os from 'os';
 
 import { tokens } from '@stryker-mutator/api/plugin';
 

--- a/packages/core/src/initializer/index.ts
+++ b/packages/core/src/initializer/index.ts
@@ -3,13 +3,13 @@ import { RestClient } from 'typed-rest-client';
 
 import { provideLogger } from '../di';
 
+import { GitignoreWriter } from './gitignore-writer';
 import * as initializerTokens from './initializer-tokens';
 import { NpmClient } from './npm-client';
 import { StrykerConfigWriter } from './stryker-config-writer';
 import { StrykerInitializer } from './stryker-initializer';
 import { StrykerInquirer } from './stryker-inquirer';
 import { strykerPresets } from './stryker-presets';
-import { GitignoreWriter } from './gitignore-writer';
 
 const BASE_NPM_SEARCH = 'https://api.npms.io';
 const BASE_NPM_PACKAGE = 'https://www.unpkg.com';

--- a/packages/core/src/initializer/presets/vue-js-preset.ts
+++ b/packages/core/src/initializer/presets/vue-js-preset.ts
@@ -1,5 +1,5 @@
-import inquirer from 'inquirer';
 import { File, PartialStrykerOptions } from '@stryker-mutator/api/core';
+import inquirer from 'inquirer';
 
 import { Preset } from './preset';
 import { PresetConfiguration } from './preset-configuration';

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -1,17 +1,17 @@
 import childProcess from 'child_process';
 import { promises as fsPromises } from 'fs';
 
-import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { notEmpty } from '@stryker-mutator/util';
 
+import { GitignoreWriter } from './gitignore-writer';
 import { NpmClient } from './npm-client';
 import { PackageInfo } from './package-info';
 import { Preset } from './presets/preset';
 import { PromptOption } from './prompt-option';
 import { StrykerConfigWriter } from './stryker-config-writer';
 import { StrykerInquirer } from './stryker-inquirer';
-import { GitignoreWriter } from './gitignore-writer';
 
 import { initializerTokens } from '.';
 

--- a/packages/core/src/input/input-file-resolver.ts
+++ b/packages/core/src/input/input-file-resolver.ts
@@ -1,19 +1,19 @@
-import { StringDecoder } from 'string_decoder';
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
+import { StringDecoder } from 'string_decoder';
 
-import { from } from 'rxjs';
-import { filter, map, mergeMap, toArray } from 'rxjs/operators';
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { SourceFile } from '@stryker-mutator/api/report';
-import { childProcessAsPromised, isErrnoException, normalizeWhitespaces, StrykerError, notEmpty } from '@stryker-mutator/util';
+import { childProcessAsPromised, isErrnoException, normalizeWhitespaces, notEmpty, StrykerError } from '@stryker-mutator/util';
+import { from } from 'rxjs';
+import { filter, map, mergeMap, toArray } from 'rxjs/operators';
 
+import { defaultOptions } from '../config/options-validator';
 import { coreTokens } from '../di';
 import { StrictReporter } from '../reporters/strict-reporter';
 import { glob, MAX_CONCURRENT_FILE_IO } from '../utils/file-utils';
-import { defaultOptions } from '../config/options-validator';
 
 import { InputFileCollection } from './input-file-collection';
 

--- a/packages/core/src/logging/log-configurator.ts
+++ b/packages/core/src/logging/log-configurator.ts
@@ -3,8 +3,8 @@ import log4js from 'log4js';
 
 import { getFreePort } from '../utils/net-utils';
 
-import { LoggingClientContext } from './logging-client-context';
 import { minLevel } from './log-utils';
+import { LoggingClientContext } from './logging-client-context';
 
 const enum AppenderName {
   File = 'file',

--- a/packages/core/src/mutants/find-mutant-test-coverage.ts
+++ b/packages/core/src/mutants/find-mutant-test-coverage.ts
@@ -1,10 +1,10 @@
-import { CompleteDryRunResult, TestResult } from '@stryker-mutator/api/test-runner';
-import { Mutant, CoveragePerTestId } from '@stryker-mutator/api/core';
+import { CoveragePerTestId, Mutant } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 
 import { MatchedMutant } from '@stryker-mutator/api/report';
 
-import { Logger } from '@stryker-mutator/api/logging';
+import { CompleteDryRunResult, TestResult } from '@stryker-mutator/api/test-runner';
 
 import { coreTokens } from '../di';
 import { StrictReporter } from '../reporters/strict-reporter';

--- a/packages/core/src/process/1-prepare-executor.ts
+++ b/packages/core/src/process/1-prepare-executor.ts
@@ -1,10 +1,10 @@
 import { PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens, Injector, tokens } from '@stryker-mutator/api/plugin';
 
-import { LogConfigurator } from '../logging';
-import { buildMainInjector, coreTokens, CliOptionsProvider } from '../di';
-import { InputFileResolver } from '../input/input-file-resolver';
+import { buildMainInjector, CliOptionsProvider, coreTokens } from '../di';
 import { ConfigError } from '../errors';
+import { InputFileResolver } from '../input/input-file-resolver';
+import { LogConfigurator } from '../logging';
 
 import { MutantInstrumenterContext } from '.';
 

--- a/packages/core/src/process/2-mutant-instrumenter-executor.ts
+++ b/packages/core/src/process/2-mutant-instrumenter-executor.ts
@@ -1,15 +1,15 @@
-import { Injector, tokens, commonTokens } from '@stryker-mutator/api/plugin';
-import { Instrumenter, InstrumentResult } from '@stryker-mutator/instrumenter';
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
+import { commonTokens, Injector, tokens } from '@stryker-mutator/api/plugin';
+import { Instrumenter, InstrumentResult } from '@stryker-mutator/instrumenter';
 
-import { MainContext, coreTokens } from '../di';
+import { createCheckerFactory } from '../checker/checker-facade';
+import { ConcurrencyTokenProvider, createCheckerPool } from '../concurrent';
+import { coreTokens, MainContext } from '../di';
 import { InputFileCollection } from '../input/input-file-collection';
-import { Sandbox } from '../sandbox/sandbox';
 import { LoggingClientContext } from '../logging';
 
-import { ConcurrencyTokenProvider, createCheckerPool } from '../concurrent';
-import { createCheckerFactory } from '../checker/checker-facade';
 import { createPreprocessor } from '../sandbox';
+import { Sandbox } from '../sandbox/sandbox';
 
 import { DryRunContext } from './3-dry-run-executor';
 

--- a/packages/core/src/process/3-dry-run-executor.ts
+++ b/packages/core/src/process/3-dry-run-executor.ts
@@ -1,35 +1,35 @@
 import { EOL } from 'os';
 
-import { Injector } from 'typed-inject';
-import { I } from '@stryker-mutator/util';
+import { Checker } from '@stryker-mutator/api/check';
+import { Mutant, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
-import { StrykerOptions, Mutant } from '@stryker-mutator/api/core';
 import {
-  DryRunResult,
-  TestRunner,
-  DryRunStatus,
   CompleteDryRunResult,
-  TestStatus,
-  TestResult,
-  FailedTestResult,
+  DryRunResult,
+  DryRunStatus,
   ErrorDryRunResult,
+  FailedTestResult,
+  TestResult,
+  TestRunner,
+  TestStatus,
 } from '@stryker-mutator/api/test-runner';
+import { I } from '@stryker-mutator/util';
 import { of } from 'rxjs';
-import { Checker } from '@stryker-mutator/api/check';
+import { Injector } from 'typed-inject';
 
+import { ConcurrencyTokenProvider } from '../concurrent';
+import { createTestRunnerPool, Pool } from '../concurrent/pool';
 import { coreTokens } from '../di';
-import { Sandbox } from '../sandbox/sandbox';
-import { Timer } from '../utils/timer';
-import { createTestRunnerFactory } from '../test-runner';
-import { MutationTestReportHelper } from '../reporters/mutation-test-report-helper';
 import { ConfigError } from '../errors';
 import { findMutantTestCoverage } from '../mutants';
-import { Pool, createTestRunnerPool } from '../concurrent/pool';
-import { ConcurrencyTokenProvider } from '../concurrent';
+import { MutationTestReportHelper } from '../reporters/mutation-test-report-helper';
+import { Sandbox } from '../sandbox/sandbox';
+import { createTestRunnerFactory } from '../test-runner';
+import { Timer } from '../utils/timer';
 
-import { MutationTestContext } from './4-mutation-test-executor';
 import { MutantInstrumenterContext } from './2-mutant-instrumenter-executor';
+import { MutationTestContext } from './4-mutation-test-executor';
 
 const INITIAL_TEST_RUN_MARKER = 'Initial test run';
 

--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -1,20 +1,20 @@
-import { from, partition, merge, Observable } from 'rxjs';
-import { toArray, map, tap, shareReplay } from 'rxjs/operators';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
+import { Checker, CheckResult, CheckStatus, PassedCheckResult } from '@stryker-mutator/api/check';
 import { StrykerOptions } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { MutantResult } from '@stryker-mutator/api/report';
 import { MutantRunOptions, TestRunner } from '@stryker-mutator/api/test-runner';
-import { Logger } from '@stryker-mutator/api/logging';
 import { I } from '@stryker-mutator/util';
-import { CheckStatus, Checker, CheckResult, PassedCheckResult } from '@stryker-mutator/api/check';
+import { from, merge, Observable, partition } from 'rxjs';
+import { map, shareReplay, tap, toArray } from 'rxjs/operators';
 
+import { ConcurrencyTokenProvider, Pool } from '../concurrent';
 import { coreTokens } from '../di';
-import { StrictReporter } from '../reporters/strict-reporter';
 import { MutantTestCoverage } from '../mutants/find-mutant-test-coverage';
 import { MutationTestReportHelper } from '../reporters/mutation-test-report-helper';
-import { Timer } from '../utils/timer';
-import { Pool, ConcurrencyTokenProvider } from '../concurrent';
+import { StrictReporter } from '../reporters/strict-reporter';
 import { Sandbox } from '../sandbox';
+import { Timer } from '../utils/timer';
 
 import { DryRunContext } from './3-dry-run-executor';
 

--- a/packages/core/src/reporters/ci/provider.ts
+++ b/packages/core/src/reporters/ci/provider.ts
@@ -1,8 +1,8 @@
 import { getEnvironmentVariable } from '../../utils/object-utils';
 
 import { CircleProvider } from './circle-provider';
-import { TravisProvider } from './travis-provider';
 import { GithubActionsCIProvider } from './github-actions-provider';
+import { TravisProvider } from './travis-provider';
 
 /**
  * Represents an object that can provide information about a CI/CD provider.

--- a/packages/core/src/reporters/clear-text-reporter.ts
+++ b/packages/core/src/reporters/clear-text-reporter.ts
@@ -1,10 +1,10 @@
 import os from 'os';
 
-import chalk from 'chalk';
 import { Position, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { MutantResult, MutantStatus, mutationTestReportSchema, Reporter, UndetectedMutantResult } from '@stryker-mutator/api/report';
+import chalk from 'chalk';
 import { calculateMetrics } from 'mutation-testing-metrics';
 import { tokens } from 'typed-inject';
 

--- a/packages/core/src/reporters/clear-text-score-table.ts
+++ b/packages/core/src/reporters/clear-text-score-table.ts
@@ -1,10 +1,10 @@
 import os from 'os';
 
 import { MutationScoreThresholds } from '@stryker-mutator/api/core';
-import { MetricsResult } from 'mutation-testing-metrics';
 
 import chalk from 'chalk';
 import flatMap from 'lodash.flatmap';
+import { MetricsResult } from 'mutation-testing-metrics';
 
 const FILES_ROOT_NAME = 'All files';
 

--- a/packages/core/src/reporters/dashboard-reporter/dashboard-reporter-client.ts
+++ b/packages/core/src/reporters/dashboard-reporter/dashboard-reporter-client.ts
@@ -1,14 +1,14 @@
+import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { StrykerError } from '@stryker-mutator/util';
 import { HttpClient } from 'typed-rest-client/HttpClient';
-import { StrykerOptions } from '@stryker-mutator/api/core';
 
 import { isOK } from '../../utils/net-utils';
 import { getEnvironmentVariable } from '../../utils/object-utils';
 
-import { dashboardReporterTokens } from './tokens';
 import { Report } from './report';
+import { dashboardReporterTokens } from './tokens';
 
 interface ReportResponseBody {
   href: string;

--- a/packages/core/src/reporters/dashboard-reporter/dashboard-reporter.ts
+++ b/packages/core/src/reporters/dashboard-reporter/dashboard-reporter.ts
@@ -1,4 +1,4 @@
-import { StrykerOptions, ReportType } from '@stryker-mutator/api/core';
+import { ReportType, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { mutationTestReportSchema, Reporter } from '@stryker-mutator/api/report';
@@ -7,8 +7,8 @@ import { calculateMetrics } from 'mutation-testing-metrics';
 import { CIProvider } from '../ci/provider';
 
 import { DashboardReporterClient } from './dashboard-reporter-client';
-import { dashboardReporterTokens } from './tokens';
 import { Report } from './report';
+import { dashboardReporterTokens } from './tokens';
 
 export class DashboardReporter implements Reporter {
   public static readonly inject = tokens(

--- a/packages/core/src/reporters/event-recorder-reporter.ts
+++ b/packages/core/src/reporters/event-recorder-reporter.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import { promises as fsPromises } from 'fs';
+import path from 'path';
 
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';

--- a/packages/core/src/reporters/html/html-reporter.ts
+++ b/packages/core/src/reporters/html/html-reporter.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 
-import fileUrl from 'file-url';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { mutationTestReportSchema, Reporter } from '@stryker-mutator/api/report';
+import fileUrl from 'file-url';
 
 import * as ReporterUtil from '../reporter-util';
 

--- a/packages/core/src/reporters/index.ts
+++ b/packages/core/src/reporters/index.ts
@@ -4,10 +4,10 @@ import { ClearTextReporter } from './clear-text-reporter';
 import { dashboardReporterFactory } from './dashboard-reporter';
 import { DotsReporter } from './dots-reporter';
 import { EventRecorderReporter } from './event-recorder-reporter';
-import { ProgressAppendOnlyReporter } from './progress-append-only-reporter';
-import { ProgressBarReporter } from './progress-reporter';
 import { HtmlReporter } from './html/html-reporter';
 import { JsonReporter } from './json-reporter';
+import { ProgressAppendOnlyReporter } from './progress-append-only-reporter';
+import { ProgressBarReporter } from './progress-reporter';
 
 export const strykerPlugins = [
   declareClassPlugin(PluginKind.Reporter, 'clear-text', ClearTextReporter),

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -1,30 +1,30 @@
 import path from 'path';
 
-import { Location, Position, StrykerOptions, Mutant } from '@stryker-mutator/api/core';
+import { CheckResult, CheckStatus, PassedCheckResult } from '@stryker-mutator/api/check';
+import { Location, Mutant, Position, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import {
+  BaseMutantResult,
+  IgnoredMutantResult,
+  InvalidMutantResult,
+  KilledMutantResult,
   MutantResult,
   MutantStatus,
   mutationTestReportSchema,
   Reporter,
   TimeoutMutantResult,
-  InvalidMutantResult,
-  BaseMutantResult,
   UndetectedMutantResult,
-  KilledMutantResult,
-  IgnoredMutantResult,
 } from '@stryker-mutator/api/report';
+import { CompleteDryRunResult, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
 import { normalizeWhitespaces } from '@stryker-mutator/util';
 import { calculateMetrics } from 'mutation-testing-metrics';
-import { CompleteDryRunResult, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
-import { CheckStatus, PassedCheckResult, CheckResult } from '@stryker-mutator/api/check';
 
 import { coreTokens } from '../di';
 import { InputFileCollection } from '../input/input-file-collection';
-import { setExitCode } from '../utils/object-utils';
 import { MutantTestCoverage } from '../mutants/find-mutant-test-coverage';
 import { mutatedLines, originalLines } from '../utils/mutant-utils';
+import { setExitCode } from '../utils/object-utils';
 
 /**
  * A helper class to convert and report mutants that survived or get killed

--- a/packages/core/src/reporters/progress-keeper.ts
+++ b/packages/core/src/reporters/progress-keeper.ts
@@ -1,4 +1,4 @@
-import { MatchedMutant, MutantResult, Reporter, MutantStatus } from '@stryker-mutator/api/report';
+import { MatchedMutant, MutantResult, MutantStatus, Reporter } from '@stryker-mutator/api/report';
 
 import { Timer } from '../utils/timer';
 

--- a/packages/core/src/reporters/reporter-util.ts
+++ b/packages/core/src/reporters/reporter-util.ts
@@ -1,6 +1,6 @@
+import { createReadStream, createWriteStream, promises as fs } from 'fs';
 import path from 'path';
 import { promisify } from 'util';
-import { createReadStream, createWriteStream, promises as fs } from 'fs';
 
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';

--- a/packages/core/src/sandbox/create-preprocessor.ts
+++ b/packages/core/src/sandbox/create-preprocessor.ts
@@ -1,13 +1,13 @@
-import { tokens, Injector, commonTokens, PluginContext } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 
 import { disableTypeChecks } from '@stryker-mutator/instrumenter';
 
 import { coreTokens } from '../di';
 
-import { TSConfigPreprocessor } from './ts-config-preprocessor';
+import { DisableTypeChecksPreprocessor } from './disable-type-checks-preprocessor';
 import { FilePreprocessor } from './file-preprocessor';
 import { MultiPreprocessor } from './multi-preprocessor';
-import { DisableTypeChecksPreprocessor } from './disable-type-checks-preprocessor';
+import { TSConfigPreprocessor } from './ts-config-preprocessor';
 
 createPreprocessor.inject = tokens(commonTokens.injector);
 export function createPreprocessor(injector: Injector<PluginContext>): FilePreprocessor {

--- a/packages/core/src/sandbox/disable-type-checks-preprocessor.ts
+++ b/packages/core/src/sandbox/disable-type-checks-preprocessor.ts
@@ -1,11 +1,11 @@
 import path from 'path';
 
-import minimatch from 'minimatch';
-import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
-import type { disableTypeChecks } from '@stryker-mutator/instrumenter';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+import type { disableTypeChecks } from '@stryker-mutator/instrumenter';
 import { propertyPath, PropertyPathBuilder } from '@stryker-mutator/util';
+import minimatch from 'minimatch';
 
 import { coreTokens } from '../di';
 import { isWarningEnabled } from '../utils/object-utils';

--- a/packages/core/src/sandbox/sandbox.ts
+++ b/packages/core/src/sandbox/sandbox.ts
@@ -1,19 +1,19 @@
-import path from 'path';
 import { promises as fsPromises } from 'fs';
+import path from 'path';
 
+import { File, StrykerOptions } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, Disposable, tokens } from '@stryker-mutator/api/plugin';
+import { I, normalizeWhitespaces } from '@stryker-mutator/util';
 import execa from 'execa';
 import npmRunPath from 'npm-run-path';
-import { StrykerOptions, File } from '@stryker-mutator/api/core';
-import { normalizeWhitespaces, I } from '@stryker-mutator/util';
-import { Logger } from '@stryker-mutator/api/logging';
-import { tokens, commonTokens, Disposable } from '@stryker-mutator/api/plugin';
-import { mergeMap, toArray } from 'rxjs/operators';
 import { from } from 'rxjs';
+import { mergeMap, toArray } from 'rxjs/operators';
 
-import { TemporaryDirectory } from '../utils/temporary-directory';
-import { findNodeModulesList, MAX_CONCURRENT_FILE_IO, moveDirectoryRecursiveSync, symlinkJunction, mkdirp } from '../utils/file-utils';
 import { coreTokens } from '../di';
 import { UnexpectedExitHandler } from '../unexpected-exit-handler';
+import { findNodeModulesList, MAX_CONCURRENT_FILE_IO, mkdirp, moveDirectoryRecursiveSync, symlinkJunction } from '../utils/file-utils';
+import { TemporaryDirectory } from '../utils/temporary-directory';
 
 export class Sandbox implements Disposable {
   private readonly fileMap = new Map<string, string>();

--- a/packages/core/src/sandbox/ts-config-preprocessor.ts
+++ b/packages/core/src/sandbox/ts-config-preprocessor.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 
-import { StrykerOptions, File } from '@stryker-mutator/api/core';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
+import { File, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 
 import { FilePreprocessor } from './file-preprocessor';
 

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -1,12 +1,11 @@
-import commander from 'commander';
-import { DashboardOptions, ALL_REPORT_TYPES, PartialStrykerOptions } from '@stryker-mutator/api/core';
-
+import { ALL_REPORT_TYPES, DashboardOptions, PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { MutantResult } from '@stryker-mutator/api/report';
+import commander from 'commander';
 
+import { defaultOptions } from './config/options-validator';
 import { initializerFactory } from './initializer';
 import { LogConfigurator } from './logging';
 import { Stryker } from './stryker';
-import { defaultOptions } from './config/options-validator';
 
 /**
  * Interpret a command line argument and add it to an object.

--- a/packages/core/src/stryker.ts
+++ b/packages/core/src/stryker.ts
@@ -1,13 +1,12 @@
 import { PartialStrykerOptions } from '@stryker-mutator/api/core';
+import { commonTokens } from '@stryker-mutator/api/plugin';
 import { MutantResult } from '@stryker-mutator/api/report';
 import { createInjector } from 'typed-inject';
 
-import { commonTokens } from '@stryker-mutator/api/plugin';
-
-import { LogConfigurator } from './logging';
-import { PrepareExecutor, MutantInstrumenterExecutor, DryRunExecutor, MutationTestExecutor } from './process';
 import { coreTokens, provideLogger } from './di';
-import { retrieveCause, ConfigError } from './errors';
+import { ConfigError, retrieveCause } from './errors';
+import { LogConfigurator } from './logging';
+import { DryRunExecutor, MutantInstrumenterExecutor, MutationTestExecutor, PrepareExecutor } from './process';
 
 /**
  * The main Stryker class.

--- a/packages/core/src/test-runner/child-process-test-runner-decorator.ts
+++ b/packages/core/src/test-runner/child-process-test-runner-decorator.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { TestRunner, DryRunOptions, MutantRunOptions, MutantRunResult, DryRunResult } from '@stryker-mutator/api/test-runner';
+import { DryRunOptions, DryRunResult, MutantRunOptions, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
 import { ExpirableTask } from '@stryker-mutator/util';
 
 import { ChildProcessCrashedError } from '../child-proxy/child-process-crashed-error';

--- a/packages/core/src/test-runner/child-process-test-runner-worker.ts
+++ b/packages/core/src/test-runner/child-process-test-runner-worker.ts
@@ -1,13 +1,13 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens, Injector, PluginContext, PluginKind, tokens } from '@stryker-mutator/api/plugin';
 import {
-  TestRunner,
   DryRunOptions,
-  MutantRunOptions,
-  MutantRunResult,
   DryRunResult,
   DryRunStatus,
+  MutantRunOptions,
+  MutantRunResult,
   MutantRunStatus,
+  TestRunner,
 } from '@stryker-mutator/api/test-runner';
 
 import { errorToString } from '@stryker-mutator/util';

--- a/packages/core/src/test-runner/command-test-runner.ts
+++ b/packages/core/src/test-runner/command-test-runner.ts
@@ -1,17 +1,17 @@
 import { exec } from 'child_process';
 import os from 'os';
 
-import { StrykerOptions, CommandRunnerOptions, INSTRUMENTER_CONSTANTS } from '@stryker-mutator/api/core';
+import { CommandRunnerOptions, INSTRUMENTER_CONSTANTS, StrykerOptions } from '@stryker-mutator/api/core';
 import {
-  TestRunner,
-  TestStatus,
+  CompleteDryRunResult,
   DryRunOptions,
-  MutantRunOptions,
   DryRunResult,
-  MutantRunResult,
   DryRunStatus,
   ErrorDryRunResult,
-  CompleteDryRunResult,
+  MutantRunOptions,
+  MutantRunResult,
+  TestRunner,
+  TestStatus,
   toMutantRunResult,
 } from '@stryker-mutator/api/test-runner';
 import { errorToString, StrykerError } from '@stryker-mutator/util';

--- a/packages/core/src/test-runner/index.ts
+++ b/packages/core/src/test-runner/index.ts
@@ -1,16 +1,16 @@
-import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+import { TestRunner } from '@stryker-mutator/api/test-runner';
 
-import { LoggingClientContext } from '../logging';
 import { coreTokens } from '../di';
+import { LoggingClientContext } from '../logging';
 import { Sandbox } from '../sandbox/sandbox';
 
-import { RetryDecorator } from './retry-decorator';
-import { TimeoutDecorator } from './timeout-decorator';
 import { ChildProcessTestRunnerDecorator } from './child-process-test-runner-decorator';
 import { CommandTestRunner } from './command-test-runner';
 import { MaxTestRunnerReuseDecorator } from './max-test-runner-reuse-decorator';
+import { RetryDecorator } from './retry-decorator';
+import { TimeoutDecorator } from './timeout-decorator';
 
 createTestRunnerFactory.inject = tokens(commonTokens.options, coreTokens.sandbox, coreTokens.loggingContext);
 export function createTestRunnerFactory(

--- a/packages/core/src/test-runner/max-test-runner-reuse-decorator.ts
+++ b/packages/core/src/test-runner/max-test-runner-reuse-decorator.ts
@@ -1,6 +1,5 @@
-import { MutantRunOptions, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
-
 import { StrykerOptions } from '@stryker-mutator/api/core';
+import { MutantRunOptions, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
 
 import { TestRunnerDecorator } from './test-runner-decorator';
 

--- a/packages/core/src/test-runner/retry-decorator.ts
+++ b/packages/core/src/test-runner/retry-decorator.ts
@@ -1,4 +1,4 @@
-import { DryRunStatus, DryRunResult, DryRunOptions, MutantRunResult, MutantRunOptions, MutantRunStatus } from '@stryker-mutator/api/test-runner';
+import { DryRunOptions, DryRunResult, DryRunStatus, MutantRunOptions, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
 import { errorToString } from '@stryker-mutator/util';
 import { getLogger } from 'log4js';
 

--- a/packages/core/src/test-runner/test-runner-decorator.ts
+++ b/packages/core/src/test-runner/test-runner-decorator.ts
@@ -1,4 +1,4 @@
-import { TestRunner, DryRunOptions, MutantRunOptions, MutantRunResult, DryRunResult } from '@stryker-mutator/api/test-runner';
+import { DryRunOptions, DryRunResult, MutantRunOptions, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
 import { Disposable } from 'typed-inject';
 
 export class TestRunnerDecorator implements Required<TestRunner>, Disposable {

--- a/packages/core/src/test-runner/timeout-decorator.ts
+++ b/packages/core/src/test-runner/timeout-decorator.ts
@@ -1,6 +1,6 @@
-import { DryRunStatus, DryRunResult, DryRunOptions, MutantRunOptions, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
-import { getLogger } from 'log4js';
+import { DryRunOptions, DryRunResult, DryRunStatus, MutantRunOptions, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
 import { ExpirableTask } from '@stryker-mutator/util';
+import { getLogger } from 'log4js';
 
 import { TestRunnerDecorator } from './test-runner-decorator';
 

--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 
 import nodeGlob from 'glob';

--- a/packages/core/src/utils/object-utils.ts
+++ b/packages/core/src/utils/object-utils.ts
@@ -1,6 +1,6 @@
-import treeKill from 'tree-kill';
-import { StrykerError, KnownKeys } from '@stryker-mutator/util';
 import { WarningOptions } from '@stryker-mutator/api/core';
+import { KnownKeys, StrykerError } from '@stryker-mutator/util';
+import treeKill from 'tree-kill';
 
 export { serialize, deserialize } from 'surrial';
 

--- a/packages/core/src/utils/temporary-directory.ts
+++ b/packages/core/src/utils/temporary-directory.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import { createReadStream, createWriteStream } from 'fs';
+import path from 'path';
 
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';

--- a/packages/core/test/helpers/producers.ts
+++ b/packages/core/test/helpers/producers.ts
@@ -1,15 +1,15 @@
 import { CpuInfo } from 'os';
 
+import { Checker } from '@stryker-mutator/api/check';
 import { ClearTextReporterOptions } from '@stryker-mutator/api/core';
+import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { factory } from '@stryker-mutator/test-helpers';
 import { Logger } from 'log4js';
-import sinon from 'sinon';
 import { ReplaySubject } from 'rxjs';
-import { TestRunner } from '@stryker-mutator/api/test-runner';
-import { Checker } from '@stryker-mutator/api/check';
+import sinon from 'sinon';
 
+import { ConcurrencyTokenProvider, Pool } from '../../src/concurrent';
 import { MutantTestCoverage } from '../../src/mutants/find-mutant-test-coverage';
-import { Pool, ConcurrencyTokenProvider } from '../../src/concurrent';
 
 export type Mutable<T> = {
   -readonly [K in keyof T]: T[K];

--- a/packages/core/test/integration/child-proxy/child-process-proxy.it.spec.ts
+++ b/packages/core/test/integration/child-proxy/child-process-proxy.it.spec.ts
@@ -3,11 +3,11 @@ import path from 'path';
 import { File, LogLevel } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens } from '@stryker-mutator/api/plugin';
-import { testInjector, LoggingServer } from '@stryker-mutator/test-helpers';
+import { LoggingServer, testInjector } from '@stryker-mutator/test-helpers';
+import { Task } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import log4js from 'log4js';
 import { filter } from 'rxjs/operators';
-import { Task } from '@stryker-mutator/util';
 
 import { ChildProcessCrashedError } from '../../../src/child-proxy/child-process-crashed-error';
 import { ChildProcessProxy } from '../../../src/child-proxy/child-process-proxy';

--- a/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
+++ b/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
@@ -1,8 +1,8 @@
-import { TestStatus, DryRunStatus } from '@stryker-mutator/api/test-runner';
-import { factory, assertions } from '@stryker-mutator/test-helpers';
+import { CommandRunnerOptions } from '@stryker-mutator/api/core';
+import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { CommandRunnerOptions } from '@stryker-mutator/api/core';
 
 import { CommandTestRunner } from '../../../src/test-runner/command-test-runner';
 import * as objectUtils from '../../../src/utils/object-utils';

--- a/packages/core/test/integration/config-reader/config-reader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/config-reader.it.spec.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 
-import { StrykerOptions, strykerCoreSchema } from '@stryker-mutator/api/core';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { strykerCoreSchema, StrykerOptions } from '@stryker-mutator/api/core';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { ConfigReader } from '../../../src/config/config-reader';
-import { coreTokens } from '../../../src/di';
 import { OptionsValidator } from '../../../src/config/options-validator';
+import { coreTokens } from '../../../src/di';
 import { resolveFromRoot } from '../../helpers/test-utils';
 
 describe(ConfigReader.name, () => {

--- a/packages/core/test/integration/options-validation/options-validation.it.spec.ts
+++ b/packages/core/test/integration/options-validation/options-validation.it.spec.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
-import { testInjector } from '@stryker-mutator/test-helpers';
 import { commonTokens } from '@stryker-mutator/api/plugin';
+import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { createPluginResolverProvider, coreTokens } from '../../../src/di';
+import { coreTokens, createPluginResolverProvider } from '../../../src/di';
 import { resolveFromRoot } from '../../helpers/test-utils';
 
 describe('Options validation integration', () => {

--- a/packages/core/test/integration/test-runner/additional-test-runners.ts
+++ b/packages/core/test/integration/test-runner/additional-test-runners.ts
@@ -1,10 +1,10 @@
+import fs from 'fs';
 import os from 'os';
 import { types } from 'util';
-import fs from 'fs';
 
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens, declareClassPlugin, PluginKind, tokens } from '@stryker-mutator/api/plugin';
-import { TestRunner, DryRunResult, DryRunStatus, MutantRunResult } from '@stryker-mutator/api/test-runner';
+import { DryRunResult, DryRunStatus, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
 import { factory } from '@stryker-mutator/test-helpers';
 
 class CoverageReportingTestRunner implements TestRunner {

--- a/packages/core/test/integration/test-runner/create-test-runner-factory.it.spec.ts
+++ b/packages/core/test/integration/test-runner/create-test-runner-factory.it.spec.ts
@@ -1,16 +1,16 @@
 import fs from 'fs';
 
 import { LogLevel } from '@stryker-mutator/api/core';
+import { DryRunStatus, TestRunner } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, LoggingServer, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import log4js from 'log4js';
 import { toArray } from 'rxjs/operators';
-import { LoggingServer, testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { TestRunner, DryRunStatus } from '@stryker-mutator/api/test-runner';
 
+import { coreTokens } from '../../../src/di';
 import { LoggingClientContext } from '../../../src/logging';
 import { createTestRunnerFactory } from '../../../src/test-runner';
 import { sleep } from '../../helpers/test-utils';
-import { coreTokens } from '../../../src/di';
 
 import { CounterTestRunner } from './additional-test-runners';
 

--- a/packages/core/test/integration/utils/file-utils.it.spec.ts
+++ b/packages/core/test/integration/utils/file-utils.it.spec.ts
@@ -1,13 +1,12 @@
+import { promises as fsPromises } from 'fs';
 import os from 'os';
 import path from 'path';
-import { promises as fsPromises } from 'fs';
 
-import mkdirp from 'mkdirp';
-
-import { expect } from 'chai';
 import { File } from '@stryker-mutator/api/core';
-import nodeGlob from 'glob';
 import { assertions } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import nodeGlob from 'glob';
+import mkdirp from 'mkdirp';
 
 import * as fileUtils from '../../../src/utils/file-utils';
 

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -1,9 +1,9 @@
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
-import { testInjector } from '@stryker-mutator/test-helpers';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/core/test/unit/child-proxy/child-process-proxy.spec.ts
+++ b/packages/core/test/unit/child-proxy/child-process-proxy.spec.ts
@@ -18,9 +18,9 @@ import {
   WorkerMessage,
   WorkerMessageKind,
 } from '../../../src/child-proxy/message-protocol';
+import { OutOfMemoryError } from '../../../src/child-proxy/out-of-memory-error';
 import { LoggingClientContext } from '../../../src/logging';
 import * as objectUtils from '../../../src/utils/object-utils';
-import { OutOfMemoryError } from '../../../src/child-proxy/out-of-memory-error';
 import { currentLogMock } from '../../helpers/log-mock';
 import { Mock } from '../../helpers/producers';
 

--- a/packages/core/test/unit/concurrent/concurrency-token-provider.spec.ts
+++ b/packages/core/test/unit/concurrent/concurrency-token-provider.spec.ts
@@ -1,9 +1,9 @@
 import os from 'os';
 
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { toArray } from 'rxjs/operators';
 import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import { toArray } from 'rxjs/operators';
+import sinon from 'sinon';
 
 import { ConcurrencyTokenProvider } from '../../../src/concurrent';
 import { createCpuInfo } from '../../helpers/producers';

--- a/packages/core/test/unit/concurrent/pool.spec.ts
+++ b/packages/core/test/unit/concurrent/pool.spec.ts
@@ -1,9 +1,9 @@
+import { factory, tick } from '@stryker-mutator/test-helpers';
+import { ExpirableTask, Task } from '@stryker-mutator/util';
 import { expect } from 'chai';
+import { range, ReplaySubject } from 'rxjs';
 import { toArray } from 'rxjs/operators';
 import sinon from 'sinon';
-import { factory, tick } from '@stryker-mutator/test-helpers';
-import { Task, ExpirableTask } from '@stryker-mutator/util';
-import { range, ReplaySubject } from 'rxjs';
 
 import { Pool, Worker } from '../../../src/concurrent';
 

--- a/packages/core/test/unit/config/build-schema-with-plugin-contributions.spec.ts
+++ b/packages/core/test/unit/config/build-schema-with-plugin-contributions.spec.ts
@@ -1,8 +1,8 @@
-import type { JSONSchema7 } from 'json-schema';
-import { expect } from 'chai';
-import { deepFreeze, I } from '@stryker-mutator/util';
-import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { PluginResolver } from '@stryker-mutator/api/plugin';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { deepFreeze, I } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import type { JSONSchema7 } from 'json-schema';
 
 import { buildSchemaWithPluginContributions } from '../../../src/config';
 

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -1,11 +1,11 @@
 import os from 'os';
 
-import sinon from 'sinon';
 import { LogLevel, ReportType, strykerCoreSchema, StrykerOptions } from '@stryker-mutator/api/core';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { OptionsValidator, validateOptions, markUnknownOptions } from '../../../src/config/options-validator';
+import { markUnknownOptions, OptionsValidator, validateOptions } from '../../../src/config/options-validator';
 import { coreTokens } from '../../../src/di';
 import { createCpuInfo } from '../../helpers/producers';
 

--- a/packages/core/test/unit/di/build-main-injector.spec.ts
+++ b/packages/core/test/unit/di/build-main-injector.spec.ts
@@ -1,19 +1,19 @@
+import { PartialStrykerOptions, StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens, PluginKind } from '@stryker-mutator/api/plugin';
 import { Reporter } from '@stryker-mutator/api/report';
 import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { StrykerOptions, PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { createInjector } from 'typed-inject';
 
-import * as optionsValidatorModule from '../../../src/config/options-validator';
-import * as pluginLoaderModule from '../../../src/di/plugin-loader';
 import * as configReaderModule from '../../../src/config/config-reader';
-import { PluginCreator, PluginLoader, coreTokens, provideLogger } from '../../../src/di';
+import * as optionsValidatorModule from '../../../src/config/options-validator';
+import { coreTokens, PluginCreator, PluginLoader, provideLogger } from '../../../src/di';
 import { buildMainInjector, CliOptionsProvider } from '../../../src/di/build-main-injector';
+import * as pluginLoaderModule from '../../../src/di/plugin-loader';
 import * as broadcastReporterModule from '../../../src/reporters/broadcast-reporter';
-import { currentLogMock } from '../../helpers/log-mock';
 import { UnexpectedExitHandler } from '../../../src/unexpected-exit-handler';
+import { currentLogMock } from '../../helpers/log-mock';
 
 describe(buildMainInjector.name, () => {
   let pluginLoaderMock: sinon.SinonStubbedInstance<PluginLoader>;

--- a/packages/core/test/unit/di/plugin-loader.spec.ts
+++ b/packages/core/test/unit/di/plugin-loader.spec.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';

--- a/packages/core/test/unit/initializer/gitignore-writer.spec.ts
+++ b/packages/core/test/unit/initializer/gitignore-writer.spec.ts
@@ -1,12 +1,12 @@
-import os from 'os';
 import fs from 'fs';
+import os from 'os';
 
-import sinon from 'sinon';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { GitignoreWriter } from '../../../src/initializer/gitignore-writer';
 import { initializerTokens } from '../../../src/initializer';
+import { GitignoreWriter } from '../../../src/initializer/gitignore-writer';
 
 const GITIGNORE_FILE = '.gitignore';
 

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 import { IRestResponse, RestClient } from 'typed-rest-client/RestClient';
 
 import { initializerTokens } from '../../../src/initializer';
+import { GitignoreWriter } from '../../../src/initializer/gitignore-writer';
 import { NpmClient } from '../../../src/initializer/npm-client';
 import { PackageInfo } from '../../../src/initializer/package-info';
 import { Preset } from '../../../src/initializer/presets/preset';
@@ -17,7 +18,6 @@ import { StrykerConfigWriter } from '../../../src/initializer/stryker-config-wri
 import { StrykerInitializer } from '../../../src/initializer/stryker-initializer';
 import { StrykerInquirer } from '../../../src/initializer/stryker-inquirer';
 import { Mock } from '../../helpers/producers';
-import { GitignoreWriter } from '../../../src/initializer/gitignore-writer';
 
 describe(StrykerInitializer.name, () => {
   let sut: StrykerInitializer;

--- a/packages/core/test/unit/input/input-file-resolver.spec.ts
+++ b/packages/core/test/unit/input/input-file-resolver.spec.ts
@@ -1,10 +1,10 @@
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import fs from 'fs';
 
 import { File } from '@stryker-mutator/api/core';
 import { SourceFile } from '@stryker-mutator/api/report';
-import { testInjector, factory, assertions, tick } from '@stryker-mutator/test-helpers';
+import { assertions, factory, testInjector, tick } from '@stryker-mutator/test-helpers';
 import { childProcessAsPromised, errorToString, Task } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/packages/core/test/unit/mutants/find-mutant-test-coverage.spec.ts
+++ b/packages/core/test/unit/mutants/find-mutant-test-coverage.spec.ts
@@ -1,12 +1,12 @@
-import sinon from 'sinon';
-import { expect } from 'chai';
-import { factory, testInjector } from '@stryker-mutator/test-helpers';
-import { CompleteDryRunResult } from '@stryker-mutator/api/test-runner';
 import { Mutant } from '@stryker-mutator/api/core';
-import { Reporter, MatchedMutant } from '@stryker-mutator/api/report';
+import { MatchedMutant, Reporter } from '@stryker-mutator/api/report';
+import { CompleteDryRunResult } from '@stryker-mutator/api/test-runner';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { findMutantTestCoverage as sut, MutantTestCoverage } from '../../../src/mutants/find-mutant-test-coverage';
 import { coreTokens } from '../../../src/di';
+import { MutantTestCoverage, findMutantTestCoverage as sut } from '../../../src/mutants/find-mutant-test-coverage';
 
 describe(sut.name, () => {
   let reporterMock: sinon.SinonStubbedInstance<Required<Reporter>>;

--- a/packages/core/test/unit/process/1-prepare-executor.spec.ts
+++ b/packages/core/test/unit/process/1-prepare-executor.spec.ts
@@ -1,21 +1,21 @@
-import { Injector } from 'typed-inject';
-import { expect } from 'chai';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
-import { PartialStrykerOptions, File, LogLevel } from '@stryker-mutator/api/core';
+import { File, LogLevel, PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens } from '@stryker-mutator/api/plugin';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
 import sinon from 'sinon';
+import { Injector } from 'typed-inject';
 
-import { PrepareExecutor } from '../../../src/process';
 import { coreTokens } from '../../../src/di';
-import { LogConfigurator, LoggingClientContext } from '../../../src/logging';
 import * as buildMainInjectorModule from '../../../src/di/build-main-injector';
-import { Timer } from '../../../src/utils/timer';
-import { InputFileResolver } from '../../../src/input/input-file-resolver';
-import { InputFileCollection } from '../../../src/input/input-file-collection';
 
-import { TemporaryDirectory } from '../../../src/utils/temporary-directory';
 import { ConfigError } from '../../../src/errors';
+import { InputFileCollection } from '../../../src/input/input-file-collection';
+import { InputFileResolver } from '../../../src/input/input-file-resolver';
+import { LogConfigurator, LoggingClientContext } from '../../../src/logging';
+import { PrepareExecutor } from '../../../src/process';
+import { TemporaryDirectory } from '../../../src/utils/temporary-directory';
+import { Timer } from '../../../src/utils/timer';
 
 describe(PrepareExecutor.name, () => {
   let cliOptions: PartialStrykerOptions;

--- a/packages/core/test/unit/process/2-mutant-instrumenter-executor.spec.ts
+++ b/packages/core/test/unit/process/2-mutant-instrumenter-executor.spec.ts
@@ -1,20 +1,19 @@
-import sinon from 'sinon';
-import { expect } from 'chai';
-import { File } from '@stryker-mutator/api/core';
-import { Injector } from 'typed-inject';
-import { factory, testInjector } from '@stryker-mutator/test-helpers';
-import { Instrumenter, InstrumentResult, InstrumenterOptions } from '@stryker-mutator/instrumenter';
 import { Checker } from '@stryker-mutator/api/check';
-
+import { File } from '@stryker-mutator/api/core';
+import { Instrumenter, InstrumenterOptions, InstrumentResult } from '@stryker-mutator/instrumenter';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { I } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Injector } from 'typed-inject';
 
-import { DryRunContext, MutantInstrumenterContext, MutantInstrumenterExecutor } from '../../../src/process';
-import { InputFileCollection } from '../../../src/input/input-file-collection';
-import { coreTokens } from '../../../src/di';
-import { createConcurrencyTokenProviderMock, createCheckerPoolMock, ConcurrencyTokenProviderMock } from '../../helpers/producers';
 import { createCheckerFactory } from '../../../src/checker/checker-facade';
-import { createPreprocessor, FilePreprocessor, Sandbox } from '../../../src/sandbox';
 import { Pool } from '../../../src/concurrent';
+import { coreTokens } from '../../../src/di';
+import { InputFileCollection } from '../../../src/input/input-file-collection';
+import { DryRunContext, MutantInstrumenterContext, MutantInstrumenterExecutor } from '../../../src/process';
+import { createPreprocessor, FilePreprocessor, Sandbox } from '../../../src/sandbox';
+import { ConcurrencyTokenProviderMock, createCheckerPoolMock, createConcurrencyTokenProviderMock } from '../../helpers/producers';
 
 describe(MutantInstrumenterExecutor.name, () => {
   let sut: MutantInstrumenterExecutor;

--- a/packages/core/test/unit/process/3-dry-run-executor.spec.ts
+++ b/packages/core/test/unit/process/3-dry-run-executor.spec.ts
@@ -1,20 +1,20 @@
 import { EOL } from 'os';
 
-import { Injector } from 'typed-inject';
+import { CompleteDryRunResult, DryRunResult, ErrorDryRunResult, TestRunner, TimeoutDryRunResult } from '@stryker-mutator/api/test-runner';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
-import sinon from 'sinon';
-import { TestRunner, CompleteDryRunResult, ErrorDryRunResult, TimeoutDryRunResult, DryRunResult } from '@stryker-mutator/api/test-runner';
+import { I } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import { Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
+import sinon from 'sinon';
 
-import { I } from '@stryker-mutator/util';
+import { Injector } from 'typed-inject';
 
-import { Timer } from '../../../src/utils/timer';
-import { DryRunContext, DryRunExecutor, MutationTestContext } from '../../../src/process';
+import { ConcurrencyTokenProvider, Pool } from '../../../src/concurrent';
 import { coreTokens } from '../../../src/di';
 import { ConfigError } from '../../../src/errors';
-import { ConcurrencyTokenProvider, Pool } from '../../../src/concurrent';
+import { DryRunContext, DryRunExecutor, MutationTestContext } from '../../../src/process';
+import { Timer } from '../../../src/utils/timer';
 import { createTestRunnerPoolMock } from '../../helpers/producers';
 
 describe(DryRunExecutor.name, () => {

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -1,22 +1,22 @@
-import sinon from 'sinon';
-import { expect } from 'chai';
-import { testInjector, factory, tick } from '@stryker-mutator/test-helpers';
-import { Reporter } from '@stryker-mutator/api/report';
-import { TestRunner, MutantRunOptions, MutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { mergeMap } from 'rxjs/operators';
-import { Observable } from 'rxjs';
 import { Mutant } from '@stryker-mutator/api/core';
+import { Reporter } from '@stryker-mutator/api/report';
+import { MutantRunOptions, MutantRunResult, MutantRunStatus, TestRunner } from '@stryker-mutator/api/test-runner';
+import { factory, testInjector, tick } from '@stryker-mutator/test-helpers';
 import { I, Task } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import { Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import sinon from 'sinon';
 
-import { MutationTestExecutor } from '../../../src/process';
-import { coreTokens } from '../../../src/di';
-import { createTestRunnerPoolMock, createMutantTestCoverage, createCheckerPoolMock } from '../../helpers/producers';
-import { MutantTestCoverage } from '../../../src/mutants/find-mutant-test-coverage';
-import { MutationTestReportHelper } from '../../../src/reporters/mutation-test-report-helper';
-import { Timer } from '../../../src/utils/timer';
 import { ConcurrencyTokenProvider, Pool } from '../../../src/concurrent';
+import { coreTokens } from '../../../src/di';
+import { MutantTestCoverage } from '../../../src/mutants/find-mutant-test-coverage';
+import { MutationTestExecutor } from '../../../src/process';
+import { MutationTestReportHelper } from '../../../src/reporters/mutation-test-report-helper';
 import { Sandbox } from '../../../src/sandbox';
+import { Timer } from '../../../src/utils/timer';
+import { createCheckerPoolMock, createMutantTestCoverage, createTestRunnerPoolMock } from '../../helpers/producers';
 
 describe(MutationTestExecutor.name, () => {
   let reporterMock: Required<Reporter>;

--- a/packages/core/test/unit/reporters/ci/github-actions-provider.spec.ts
+++ b/packages/core/test/unit/reporters/ci/github-actions-provider.spec.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
 import { StrykerError } from '@stryker-mutator/util';
+import { expect } from 'chai';
 
 import { GithubActionsCIProvider } from '../../../../src/reporters/ci/github-actions-provider';
 import { EnvironmentVariableStore } from '../../../helpers/environment-variable-store';

--- a/packages/core/test/unit/reporters/ci/provider.spec.ts
+++ b/packages/core/test/unit/reporters/ci/provider.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 
+import { CircleProvider } from '../../../../src/reporters/ci/circle-provider';
+import { GithubActionsCIProvider } from '../../../../src/reporters/ci/github-actions-provider';
 import { determineCIProvider } from '../../../../src/reporters/ci/provider';
 import { TravisProvider } from '../../../../src/reporters/ci/travis-provider';
-import { CircleProvider } from '../../../../src/reporters/ci/circle-provider';
 import { EnvironmentVariableStore } from '../../../helpers/environment-variable-store';
-import { GithubActionsCIProvider } from '../../../../src/reporters/ci/github-actions-provider';
 
 describe(determineCIProvider.name, () => {
   const env = new EnvironmentVariableStore();

--- a/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
@@ -1,11 +1,10 @@
 import os from 'os';
 
-import { mutationTestReportSchema, MutantStatus } from '@stryker-mutator/api/report';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { MutantStatus, mutationTestReportSchema } from '@stryker-mutator/api/report';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
-import sinon from 'sinon';
-
 import chalk from 'chalk';
+import sinon from 'sinon';
 
 import { ClearTextReporter } from '../../../src/reporters/clear-text-reporter';
 

--- a/packages/core/test/unit/reporters/clear-text-score-table.spec.ts
+++ b/packages/core/test/unit/reporters/clear-text-score-table.spec.ts
@@ -1,12 +1,12 @@
 import os from 'os';
 
 import { MutationScoreThresholds } from '@stryker-mutator/api/core';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
-import { MetricsResult } from 'mutation-testing-metrics';
 
 import chalk from 'chalk';
 import flatMap from 'lodash.flatmap';
+import { MetricsResult } from 'mutation-testing-metrics';
 
 import { ClearTextScoreTable } from '../../../src/reporters/clear-text-score-table';
 

--- a/packages/core/test/unit/reporters/dashboard-reporter/dashboard-reporter-client.spec.ts
+++ b/packages/core/test/unit/reporters/dashboard-reporter/dashboard-reporter-client.spec.ts
@@ -5,10 +5,10 @@ import { HttpClient } from 'typed-rest-client/HttpClient';
 import { IHttpClientResponse } from 'typed-rest-client/Interfaces';
 
 import { DashboardReporterClient } from '../../../../src/reporters/dashboard-reporter/dashboard-reporter-client';
-import { dashboardReporterTokens } from '../../../../src/reporters/dashboard-reporter/tokens';
-import { Mock, mock } from '../../../helpers/producers';
 import { Report } from '../../../../src/reporters/dashboard-reporter/report';
+import { dashboardReporterTokens } from '../../../../src/reporters/dashboard-reporter/tokens';
 import { EnvironmentVariableStore } from '../../../helpers/environment-variable-store';
+import { Mock, mock } from '../../../helpers/producers';
 
 describe(DashboardReporterClient.name, () => {
   let sut: DashboardReporterClient;

--- a/packages/core/test/unit/reporters/dashboard-reporter/dashboard-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/dashboard-reporter/dashboard-reporter.spec.ts
@@ -1,15 +1,15 @@
+import { ReportType } from '@stryker-mutator/api/core';
 import { mutationTestReportSchema } from '@stryker-mutator/api/report';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { ReportType } from '@stryker-mutator/api/core';
 
 import { CIProvider } from '../../../../src/reporters/ci/provider';
 import { DashboardReporter } from '../../../../src/reporters/dashboard-reporter/dashboard-reporter';
 import { DashboardReporterClient } from '../../../../src/reporters/dashboard-reporter/dashboard-reporter-client';
+import { Report } from '../../../../src/reporters/dashboard-reporter/report';
 import { dashboardReporterTokens } from '../../../../src/reporters/dashboard-reporter/tokens';
 import { mock, Mock } from '../../../helpers/producers';
-import { Report } from '../../../../src/reporters/dashboard-reporter/report';
 
 describe(DashboardReporter.name, () => {
   let dashboardClientMock: Mock<DashboardReporterClient>;

--- a/packages/core/test/unit/reporters/dots-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/dots-reporter.spec.ts
@@ -3,8 +3,8 @@ import os from 'os';
 import { MutantStatus } from '@stryker-mutator/api/report';
 import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import chalk from 'chalk';
+import sinon from 'sinon';
 
 import { DotsReporter } from '../../../src/reporters/dots-reporter';
 

--- a/packages/core/test/unit/reporters/event-recorder-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/event-recorder-reporter.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 import { Reporter } from '@stryker-mutator/api/report';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -1,20 +1,20 @@
-import sinon from 'sinon';
+import { CheckStatus } from '@stryker-mutator/api/check';
 import { File, Location, Range } from '@stryker-mutator/api/core';
 import {
+  IgnoredMutantResult,
+  InvalidMutantResult,
+  KilledMutantResult,
   MutantResult,
   MutantStatus,
   mutationTestReportSchema,
   Reporter,
-  InvalidMutantResult,
-  UndetectedMutantResult,
-  KilledMutantResult,
   TimeoutMutantResult,
-  IgnoredMutantResult,
+  UndetectedMutantResult,
 } from '@stryker-mutator/api/report';
+import { CompleteDryRunResult } from '@stryker-mutator/api/test-runner';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
-import { CompleteDryRunResult } from '@stryker-mutator/api/test-runner';
-import { CheckStatus } from '@stryker-mutator/api/check';
+import sinon from 'sinon';
 
 import { coreTokens } from '../../../src/di';
 import { InputFileCollection } from '../../../src/input/input-file-collection';

--- a/packages/core/test/unit/reporters/progress-append-only-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/progress-append-only-reporter.spec.ts
@@ -1,8 +1,8 @@
 import os from 'os';
 
+import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { factory } from '@stryker-mutator/test-helpers';
 
 import { ProgressAppendOnlyReporter } from '../../../src/reporters/progress-append-only-reporter';
 

--- a/packages/core/test/unit/reporters/progress-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/progress-reporter.spec.ts
@@ -1,8 +1,8 @@
 import { MatchedMutant, MutantStatus } from '@stryker-mutator/api/report';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import ProgressBar from 'progress';
 import { factory } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import ProgressBar from 'progress';
+import sinon from 'sinon';
 
 import * as progressBarModule from '../../../src/reporters/progress-bar';
 import { ProgressBarReporter } from '../../../src/reporters/progress-reporter';

--- a/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/create-preprocessor.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 
-import { testInjector, assertions } from '@stryker-mutator/test-helpers';
 import { File } from '@stryker-mutator/api/core';
+import { assertions, testInjector } from '@stryker-mutator/test-helpers';
 
-import { FilePreprocessor, createPreprocessor } from '../../../src/sandbox';
+import { createPreprocessor, FilePreprocessor } from '../../../src/sandbox';
 
 describe(createPreprocessor.name, () => {
   let sut: FilePreprocessor;

--- a/packages/core/test/unit/sandbox/disable-type-checks-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/disable-type-checks-preprocessor.spec.ts
@@ -2,9 +2,8 @@ import path from 'path';
 
 import { File } from '@stryker-mutator/api/core';
 import { assertions, testInjector } from '@stryker-mutator/test-helpers';
-import sinon from 'sinon';
-
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { coreTokens } from '../../../src/di';
 import { DisableTypeChecksPreprocessor } from '../../../src/sandbox/disable-type-checks-preprocessor';

--- a/packages/core/test/unit/sandbox/multi-preprocessor.spec.ts
+++ b/packages/core/test/unit/sandbox/multi-preprocessor.spec.ts
@@ -1,9 +1,9 @@
-import sinon from 'sinon';
 import { File } from '@stryker-mutator/api/core';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { MultiPreprocessor } from '../../../src/sandbox/multi-preprocessor';
 import { FilePreprocessor } from '../../../src/sandbox';
+import { MultiPreprocessor } from '../../../src/sandbox/multi-preprocessor';
 
 describe(MultiPreprocessor.name, () => {
   describe(MultiPreprocessor.prototype.preprocess.name, () => {

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -1,19 +1,19 @@
-import path from 'path';
 import { promises as fsPromises } from 'fs';
+import path from 'path';
 
+import { File } from '@stryker-mutator/api/core';
+import { factory, testInjector, tick } from '@stryker-mutator/test-helpers';
+import { normalizeWhitespaces, Task } from '@stryker-mutator/util';
+import { expect } from 'chai';
 import execa from 'execa';
 import npmRunPath from 'npm-run-path';
-import { expect } from 'chai';
 import sinon from 'sinon';
-import { testInjector, tick, factory } from '@stryker-mutator/test-helpers';
-import { File } from '@stryker-mutator/api/core';
-import { normalizeWhitespaces, Task } from '@stryker-mutator/util';
 
-import { Sandbox } from '../../../src/sandbox/sandbox';
 import { coreTokens } from '../../../src/di';
-import { TemporaryDirectory } from '../../../src/utils/temporary-directory';
-import * as fileUtils from '../../../src/utils/file-utils';
+import { Sandbox } from '../../../src/sandbox/sandbox';
 import { UnexpectedExitHandler } from '../../../src/unexpected-exit-handler';
+import * as fileUtils from '../../../src/utils/file-utils';
+import { TemporaryDirectory } from '../../../src/utils/temporary-directory';
 
 describe(Sandbox.name, () => {
   let temporaryDirectoryMock: sinon.SinonStubbedInstance<TemporaryDirectory>;

--- a/packages/core/test/unit/sandbox/ts-config-preprocessor.it.spec.ts
+++ b/packages/core/test/unit/sandbox/ts-config-preprocessor.it.spec.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 
-import { expect } from 'chai';
 import { File } from '@stryker-mutator/api/core';
 import { assertions, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
 import { TSConfigPreprocessor } from '../../../src/sandbox/ts-config-preprocessor';
 

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -1,7 +1,7 @@
+import { DashboardOptions, PartialStrykerOptions, ReportType, StrykerOptions } from '@stryker-mutator/api/core';
+import { expect } from 'chai';
 import { Command } from 'commander';
 import sinon from 'sinon';
-import { expect } from 'chai';
-import { DashboardOptions, StrykerOptions, ReportType, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
 import { LogConfigurator } from '../../src/logging';
 import { StrykerCli } from '../../src/stryker-cli';

--- a/packages/core/test/unit/stryker.spec.ts
+++ b/packages/core/test/unit/stryker.spec.ts
@@ -1,17 +1,17 @@
+import { LogLevel, PartialStrykerOptions } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens } from '@stryker-mutator/api/plugin';
+import { MutantResult } from '@stryker-mutator/api/report';
 import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as typedInject from 'typed-inject';
-import { PartialStrykerOptions, LogLevel } from '@stryker-mutator/api/core';
-import { MutantResult } from '@stryker-mutator/api/report';
-import { Logger } from '@stryker-mutator/api/logging';
-import { commonTokens } from '@stryker-mutator/api/plugin';
 
-import { LogConfigurator } from '../../src/logging';
-import { Stryker } from '../../src/stryker';
-import { PrepareExecutor, MutantInstrumenterExecutor, DryRunExecutor, MutationTestExecutor, MutationTestContext } from '../../src/process';
 import { coreTokens } from '../../src/di';
 import { ConfigError } from '../../src/errors';
+import { LogConfigurator } from '../../src/logging';
+import { DryRunExecutor, MutantInstrumenterExecutor, MutationTestContext, MutationTestExecutor, PrepareExecutor } from '../../src/process';
+import { Stryker } from '../../src/stryker';
 import { TemporaryDirectory } from '../../src/utils/temporary-directory';
 
 describe(Stryker.name, () => {

--- a/packages/core/test/unit/test-runner/child-process-test-runner-decorator.spec.ts
+++ b/packages/core/test/unit/test-runner/child-process-test-runner-decorator.spec.ts
@@ -1,9 +1,9 @@
 import { LogLevel, StrykerOptions } from '@stryker-mutator/api/core';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { Task } from '@stryker-mutator/util';
 import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { factory } from '@stryker-mutator/test-helpers';
+import { Task } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { ChildProcessCrashedError } from '../../../src/child-proxy/child-process-crashed-error';
 import { ChildProcessProxy } from '../../../src/child-proxy/child-process-proxy';

--- a/packages/core/test/unit/test-runner/command-test-runner.spec.ts
+++ b/packages/core/test/unit/test-runner/command-test-runner.spec.ts
@@ -1,12 +1,12 @@
 import childProcess from 'child_process';
 import os from 'os';
 
+import { CommandRunnerOptions } from '@stryker-mutator/api/core';
 import { DryRunResult, DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory } from '@stryker-mutator/test-helpers';
 import { errorToString, StrykerError } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { factory, assertions } from '@stryker-mutator/test-helpers';
-import { CommandRunnerOptions } from '@stryker-mutator/api/core';
 
 import { CommandTestRunner } from '../../../src/test-runner/command-test-runner';
 import * as objectUtils from '../../../src/utils/object-utils';

--- a/packages/core/test/unit/test-runner/max-test-runner-reuse-decorator.spec.ts
+++ b/packages/core/test/unit/test-runner/max-test-runner-reuse-decorator.spec.ts
@@ -1,10 +1,10 @@
 import { TestRunner } from '@stryker-mutator/api/test-runner';
+import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { factory } from '@stryker-mutator/test-helpers';
 
-import { TestRunnerDecorator } from '../../../src/test-runner/test-runner-decorator';
 import { MaxTestRunnerReuseDecorator } from '../../../src/test-runner/max-test-runner-reuse-decorator';
+import { TestRunnerDecorator } from '../../../src/test-runner/test-runner-decorator';
 
 describe(MaxTestRunnerReuseDecorator.name, () => {
   let testRunner: sinon.SinonStubbedInstance<Required<TestRunner>>;

--- a/packages/core/test/unit/test-runner/retry-decorator.spec.ts
+++ b/packages/core/test/unit/test-runner/retry-decorator.spec.ts
@@ -1,8 +1,8 @@
 import { Logger } from '@stryker-mutator/api/logging';
+import { DryRunOptions, DryRunResult, MutantRunOptions, MutantRunResult, TestRunner } from '@stryker-mutator/api/test-runner';
+import { assertions, factory } from '@stryker-mutator/test-helpers';
 import { errorToString } from '@stryker-mutator/util';
-import { TestRunner, DryRunOptions, MutantRunOptions, DryRunResult, MutantRunResult } from '@stryker-mutator/api/test-runner';
 import { expect } from 'chai';
-import { factory, assertions } from '@stryker-mutator/test-helpers';
 
 import { ChildProcessCrashedError } from '../../../src/child-proxy/child-process-crashed-error';
 import { OutOfMemoryError } from '../../../src/child-proxy/out-of-memory-error';

--- a/packages/core/test/unit/test-runner/test-runner-decorator.spec.ts
+++ b/packages/core/test/unit/test-runner/test-runner-decorator.spec.ts
@@ -1,7 +1,6 @@
-import { expect } from 'chai';
-
 import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { factory } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
 import { TestRunnerDecorator } from '../../../src/test-runner/test-runner-decorator';
 

--- a/packages/core/test/unit/test-runner/timeout-decorator.spec.ts
+++ b/packages/core/test/unit/test-runner/timeout-decorator.spec.ts
@@ -1,16 +1,15 @@
 import {
-  DryRunStatus,
-  TimeoutDryRunResult,
-  TestRunner,
-  MutantRunStatus,
-  TimeoutMutantRunResult,
   DryRunResult,
+  DryRunStatus,
   MutantRunResult,
+  MutantRunStatus,
+  TestRunner,
+  TimeoutDryRunResult,
+  TimeoutMutantRunResult,
 } from '@stryker-mutator/api/test-runner';
+import { factory } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { factory } from '@stryker-mutator/test-helpers';
 
 import { TimeoutDecorator } from '../../../src/test-runner/timeout-decorator';
 

--- a/packages/core/test/unit/unexpected-exit-handler.spec.ts
+++ b/packages/core/test/unit/unexpected-exit-handler.spec.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 
 import { testInjector } from '@stryker-mutator/test-helpers';
-import sinon from 'sinon';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { coreTokens } from '../../src/di';
 import { UnexpectedExitHandler } from '../../src/unexpected-exit-handler';

--- a/packages/core/test/unit/utils/file-utils.spec.ts
+++ b/packages/core/test/unit/utils/file-utils.spec.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/packages/core/test/unit/utils/temporary-directory.spec.ts
+++ b/packages/core/test/unit/utils/temporary-directory.spec.ts
@@ -1,13 +1,12 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
+import { StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import mkdirp from 'mkdirp';
 import sinon from 'sinon';
-
-import { StrykerOptions } from '@stryker-mutator/api/core';
 
 import * as fileUtils from '../../../src/utils/file-utils';
 import * as objectUtils from '../../../src/utils/object-utils';

--- a/packages/instrumenter/src/instrumenter.ts
+++ b/packages/instrumenter/src/instrumenter.ts
@@ -1,14 +1,14 @@
 import path from 'path';
 
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
-import { Logger } from '@stryker-mutator/api/logging';
 import { File } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 
-import { createParser } from './parsers';
-import { transform, MutantCollector } from './transformers';
-import { print } from './printers';
 import { InstrumentResult } from './instrument-result';
 import { InstrumenterOptions } from './instrumenter-options';
+import { createParser } from './parsers';
+import { print } from './printers';
+import { MutantCollector, transform } from './transformers';
 
 /**
  * The instrumenter is responsible for

--- a/packages/instrumenter/src/mutant-placers/index.ts
+++ b/packages/instrumenter/src/mutant-placers/index.ts
@@ -5,9 +5,9 @@ import { NodePath } from '@babel/core';
 
 import { Mutant } from '../mutant';
 
+import { expressionMutantPlacer } from './expression-mutant-placer';
 import { MutantPlacer } from './mutant-placer';
 import { statementMutantPlacer } from './statement-mutant-placer';
-import { expressionMutantPlacer } from './expression-mutant-placer';
 import { switchCaseMutantPlacer } from './switch-case-mutant-placer';
 
 export const MUTANT_PLACERS = Object.freeze([expressionMutantPlacer, statementMutantPlacer, switchCaseMutantPlacer]);

--- a/packages/instrumenter/src/mutant-placers/statement-mutant-placer.ts
+++ b/packages/instrumenter/src/mutant-placers/statement-mutant-placer.ts
@@ -1,6 +1,6 @@
 import { types } from '@babel/core';
 
-import { mutantTestExpression, createMutatedAst, mutationCoverageSequenceExpression } from '../util/syntax-helpers';
+import { createMutatedAst, mutantTestExpression, mutationCoverageSequenceExpression } from '../util/syntax-helpers';
 
 import { MutantPlacer } from './mutant-placer';
 

--- a/packages/instrumenter/src/mutators/arrow-function-mutator.ts
+++ b/packages/instrumenter/src/mutators/arrow-function-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/block-statement-mutator.ts
+++ b/packages/instrumenter/src/mutators/block-statement-mutator.ts
@@ -1,4 +1,4 @@
-import { types, NodePath } from '@babel/core';
+import { NodePath, types } from '@babel/core';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/boolean-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/boolean-literal-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/equality-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/equality-operator-mutator.ts
@@ -1,4 +1,4 @@
-import { types, NodePath } from '@babel/core';
+import { NodePath, types } from '@babel/core';
 
 import { NodeMutation } from '../mutant';
 import { BinaryOperator } from '../util';

--- a/packages/instrumenter/src/mutators/index.ts
+++ b/packages/instrumenter/src/mutators/index.ts
@@ -4,20 +4,20 @@ import { flatMap } from '@stryker-mutator/util';
 import { NamedNodeMutation } from '../mutant';
 
 import { ArithmeticOperatorMutator } from './arithmetic-operator-mutator';
-import { NodeMutator } from './node-mutator';
-import { BlockStatementMutator } from './block-statement-mutator';
-import { ConditionalExpressionMutator } from './conditional-expression-mutator';
-import { StringLiteralMutator } from './string-literal-mutator';
 import { ArrayDeclarationMutator } from './array-declaration-mutator';
 import { ArrowFunctionMutator } from './arrow-function-mutator';
+import { BlockStatementMutator } from './block-statement-mutator';
 import { BooleanLiteralMutator } from './boolean-literal-mutator';
+import { ConditionalExpressionMutator } from './conditional-expression-mutator';
 import { EqualityOperatorMutator } from './equality-operator-mutator';
 import { LogicalOperatorMutator } from './logical-operator-mutator';
+import { MutatorOptions } from './mutator-options';
+import { NodeMutator } from './node-mutator';
 import { ObjectLiteralMutator } from './object-literal-mutator';
+import { RegexMutator } from './regex-mutator';
+import { StringLiteralMutator } from './string-literal-mutator';
 import { UnaryOperatorMutator } from './unary-operator-mutator';
 import { UpdateOperatorMutator } from './update-operator-mutator';
-import { MutatorOptions } from './mutator-options';
-import { RegexMutator } from './regex-mutator';
 
 export * from './node-mutator';
 export * from './mutator-options';

--- a/packages/instrumenter/src/mutators/logical-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/logical-operator-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/object-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/object-literal-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/regex-mutator.ts
+++ b/packages/instrumenter/src/mutators/regex-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 import * as weaponRegex from 'weapon-regex';
 
 import { NodeMutation } from '../mutant';

--- a/packages/instrumenter/src/mutators/string-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/string-literal-mutator.ts
@@ -1,4 +1,4 @@
-import { types, NodePath } from '@babel/core';
+import { NodePath, types } from '@babel/core';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/unary-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/unary-operator-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/mutators/update-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/update-operator-mutator.ts
@@ -1,5 +1,5 @@
-import * as types from '@babel/types';
 import { NodePath } from '@babel/core';
+import * as types from '@babel/types';
 
 import { NodeMutation } from '../mutant';
 

--- a/packages/instrumenter/src/parsers/html-parser.ts
+++ b/packages/instrumenter/src/parsers/html-parser.ts
@@ -1,11 +1,11 @@
 import type { Element } from 'angular-html-parser/lib/compiler/src/ml_parser/ast';
 import type { ParseLocation } from 'angular-html-parser/lib/compiler/src/parse_util';
 
+import { AstByFormat, AstFormat, HtmlAst, HtmlRootNode, JSAst, ScriptFormat, TSAst } from '../syntax';
 import { offsetLocations } from '../util/syntax-helpers';
-import { HtmlAst, AstFormat, HtmlRootNode, TSAst, JSAst, ScriptFormat, AstByFormat } from '../syntax';
 
-import { ParserContext } from './parser-context';
 import { ParseError } from './parse-error';
+import { ParserContext } from './parser-context';
 
 const TS_SCRIPT_TYPES = Object.freeze(['ts', 'text/typescript', 'typescript']);
 const JS_SCRIPT_TYPES = Object.freeze(['js', 'text/javascript', 'javascript']);

--- a/packages/instrumenter/src/parsers/index.ts
+++ b/packages/instrumenter/src/parsers/index.ts
@@ -1,11 +1,11 @@
 import path from 'path';
 
-import { AstFormat, AstByFormat } from '../syntax';
+import { AstByFormat, AstFormat } from '../syntax';
 
-import { createParser as createJSParser } from './js-parser';
-import { parse as tsParse } from './ts-parser';
 import { parse as htmlParse } from './html-parser';
+import { createParser as createJSParser } from './js-parser';
 import { ParserOptions } from './parser-options';
+import { parse as tsParse } from './ts-parser';
 
 export { ParserOptions };
 

--- a/packages/instrumenter/src/parsers/js-parser.ts
+++ b/packages/instrumenter/src/parsers/js-parser.ts
@@ -1,5 +1,5 @@
-import { ParserPlugin } from '@babel/parser';
 import { parseAsync, types } from '@babel/core';
+import { ParserPlugin } from '@babel/parser';
 
 import { AstFormat, JSAst } from '../syntax';
 

--- a/packages/instrumenter/src/parsers/parser-context.ts
+++ b/packages/instrumenter/src/parsers/parser-context.ts
@@ -1,4 +1,4 @@
-import { Ast, AstFormat, AstByFormat } from '../syntax';
+import { Ast, AstByFormat, AstFormat } from '../syntax';
 
 export interface ParserContext {
   parse<T extends AstFormat>(code: string, fileName: string, formatOverride?: T): Promise<AstByFormat[T]>;

--- a/packages/instrumenter/src/parsers/ts-parser.ts
+++ b/packages/instrumenter/src/parsers/ts-parser.ts
@@ -1,4 +1,4 @@
-import { types, parseAsync } from '@babel/core';
+import { parseAsync, types } from '@babel/core';
 
 import { AstFormat, TSAst } from '../syntax';
 

--- a/packages/instrumenter/src/transformers/babel-transformer.ts
+++ b/packages/instrumenter/src/transformers/babel-transformer.ts
@@ -7,8 +7,8 @@ import { File } from '@babel/core';
 
 import { placeMutants } from '../mutant-placers';
 import { mutate } from '../mutators';
-import { instrumentationBabelHeader, isTypeNode, isImportDeclaration } from '../util/syntax-helpers';
 import { AstFormat } from '../syntax';
+import { instrumentationBabelHeader, isImportDeclaration, isTypeNode } from '../util/syntax-helpers';
 
 import { AstTransformer } from '.';
 

--- a/packages/instrumenter/src/transformers/transformer.ts
+++ b/packages/instrumenter/src/transformers/transformer.ts
@@ -2,10 +2,10 @@ import { I } from '@stryker-mutator/util';
 
 import { Ast, AstByFormat, AstFormat } from '../syntax';
 
-import { TransformerOptions } from './transformer-options';
 import { transformBabel } from './babel-transformer';
 import { transformHtml } from './html-transformer';
 import { MutantCollector } from './mutant-collector';
+import { TransformerOptions } from './transformer-options';
 
 /**
  * Transform the AST by generating mutants and placing them in the AST.

--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -1,7 +1,7 @@
-import { INSTRUMENTER_CONSTANTS as ID } from '@stryker-mutator/api/core';
-import { types, NodePath } from '@babel/core';
-import traverse from '@babel/traverse';
+import { NodePath, types } from '@babel/core';
 import { parse } from '@babel/parser';
+import traverse from '@babel/traverse';
+import { INSTRUMENTER_CONSTANTS as ID } from '@stryker-mutator/api/core';
 
 import { Mutant } from '../mutant';
 

--- a/packages/instrumenter/test/helpers/expect-mutation.ts
+++ b/packages/instrumenter/test/helpers/expect-mutation.ts
@@ -1,10 +1,10 @@
 import { traverse } from '@babel/core';
-import { parse, ParserPlugin } from '@babel/parser';
 import generate from '@babel/generator';
+import { parse, ParserPlugin } from '@babel/parser';
 import { expect } from 'chai';
 
-import { NodeMutator } from '../../src/mutators/node-mutator';
 import { NodeMutation } from '../../src/mutant';
+import { NodeMutator } from '../../src/mutators/node-mutator';
 
 const plugins = [
   'doExpressions',

--- a/packages/instrumenter/test/helpers/factories.ts
+++ b/packages/instrumenter/test/helpers/factories.ts
@@ -1,12 +1,12 @@
 import { types } from '@babel/core';
 
-import { JSAst, AstFormat, HtmlAst, TSAst } from '../../src/syntax';
+import { InstrumenterOptions } from '../../src';
 import { Mutant, NamedNodeMutation } from '../../src/mutant';
 import { ParserOptions } from '../../src/parsers';
-import { InstrumenterOptions } from '../../src';
+import { AstFormat, HtmlAst, JSAst, TSAst } from '../../src/syntax';
 import { TransformerOptions } from '../../src/transformers';
 
-import { parseTS, parseJS, findNodePath } from './syntax-test-helpers';
+import { findNodePath, parseJS, parseTS } from './syntax-test-helpers';
 
 export function createParserOptions(overrides?: Partial<ParserOptions>): ParserOptions {
   return {

--- a/packages/instrumenter/test/helpers/syntax-test-helpers.ts
+++ b/packages/instrumenter/test/helpers/syntax-test-helpers.ts
@@ -1,11 +1,10 @@
-import { types, traverse, NodePath, parseSync } from '@babel/core';
-import { expect } from 'chai';
-import generate from '@babel/generator';
-
+import { NodePath, parseSync, traverse, types } from '@babel/core';
 /* eslint-disable @typescript-eslint/no-duplicate-imports */
 // @ts-expect-error The babel types don't define "File" yet
 import { File } from '@babel/core';
 /* eslint-enable @typescript-eslint/no-duplicate-imports */
+import generate from '@babel/generator';
+import { expect } from 'chai';
 
 export type AstExpectation = (nodePath: NodePath) => boolean;
 

--- a/packages/instrumenter/test/integration/disable-type-checks.it.spec.ts
+++ b/packages/instrumenter/test/integration/disable-type-checks.it.spec.ts
@@ -1,9 +1,8 @@
 import { promises as fsPromises } from 'fs';
 
+import { File } from '@stryker-mutator/api/core';
 import { expect } from 'chai';
 import chaiJestSnapshot from 'chai-jest-snapshot';
-
-import { File } from '@stryker-mutator/api/core';
 
 import { disableTypeChecks } from '../../src';
 import { createInstrumenterOptions } from '../helpers/factories';

--- a/packages/instrumenter/test/integration/instrumenter.it.spec.ts
+++ b/packages/instrumenter/test/integration/instrumenter.it.spec.ts
@@ -1,7 +1,7 @@
 import { promises as fsPromises } from 'fs';
 
-import { testInjector } from '@stryker-mutator/test-helpers';
 import { File } from '@stryker-mutator/api/core';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import chaiJestSnapshot from 'chai-jest-snapshot';
 

--- a/packages/instrumenter/test/integration/parsers.it.spec.ts
+++ b/packages/instrumenter/test/integration/parsers.it.spec.ts
@@ -3,7 +3,7 @@ import { promises as fsPromises } from 'fs';
 import { expect } from 'chai';
 
 import { createParser, ParserOptions } from '../../src/parsers';
-import { AstFormat, HtmlAst, TSAst, JSAst, Ast } from '../../src/syntax';
+import { Ast, AstFormat, HtmlAst, JSAst, TSAst } from '../../src/syntax';
 import { createParserOptions } from '../helpers/factories';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/instrumenter/test/integration/transformers.it.spec.ts
+++ b/packages/instrumenter/test/integration/transformers.it.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { createHtmlAst, createJSAst, createTransformerOptions, createTSAst } from '../helpers/factories';
 import { transform } from '../../src/transformers';
 import { MutantCollector } from '../../src/transformers/mutant-collector';
+import { createHtmlAst, createJSAst, createTransformerOptions, createTSAst } from '../helpers/factories';
 
 describe('transformers integration', () => {
   it('should transform an html file', () => {

--- a/packages/instrumenter/test/setup.ts
+++ b/packages/instrumenter/test/setup.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
-import sinon from 'sinon';
-import { testInjector } from '@stryker-mutator/test-helpers';
 import chaiJestSnapshot from 'chai-jest-snapshot';
 import type { Context } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { retrieveSourceMap } from 'source-map-support';
 
 chai.use(sinonChai);

--- a/packages/instrumenter/test/unit/disable-type-checks.spec.ts
+++ b/packages/instrumenter/test/unit/disable-type-checks.spec.ts
@@ -1,10 +1,10 @@
 import { File } from '@stryker-mutator/api/core';
 import { assertions } from '@stryker-mutator/test-helpers';
-import sinon from 'sinon';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import * as parsers from '../../src/parsers';
 import { disableTypeChecks } from '../../src';
+import * as parsers from '../../src/parsers';
 
 describe(disableTypeChecks.name, () => {
   describe('with TS or JS AST format', () => {

--- a/packages/instrumenter/test/unit/instrumenter.spec.ts
+++ b/packages/instrumenter/test/unit/instrumenter.spec.ts
@@ -1,14 +1,14 @@
+import { File } from '@stryker-mutator/api/core';
+import { testInjector } from '@stryker-mutator/test-helpers';
+import { I } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { testInjector } from '@stryker-mutator/test-helpers';
-import { File } from '@stryker-mutator/api/core';
-import { I } from '@stryker-mutator/util';
 
 import { Instrumenter } from '../../src';
 import * as parsers from '../../src/parsers';
-import * as transformers from '../../src/transformers';
 import * as printers from '../../src/printers';
-import { createJSAst, createTSAst, createNamedNodeMutation, createInstrumenterOptions } from '../helpers/factories';
+import * as transformers from '../../src/transformers';
+import { createInstrumenterOptions, createJSAst, createNamedNodeMutation, createTSAst } from '../helpers/factories';
 
 describe(Instrumenter.name, () => {
   let sut: Instrumenter;

--- a/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
@@ -1,12 +1,12 @@
-import { expect } from 'chai';
-import { types, NodePath } from '@babel/core';
-import { normalizeWhitespaces } from '@stryker-mutator/util';
+import { NodePath, types } from '@babel/core';
 import generate from '@babel/generator';
+import { normalizeWhitespaces } from '@stryker-mutator/util';
+import { expect } from 'chai';
 
-import { expressionMutantPlacer } from '../../../src/mutant-placers/expression-mutant-placer';
-import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 import { Mutant } from '../../../src/mutant';
+import { expressionMutantPlacer } from '../../../src/mutant-placers/expression-mutant-placer';
 import { createMutant } from '../../helpers/factories';
+import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 
 describe(expressionMutantPlacer.name, () => {
   it('should have the correct name', () => {

--- a/packages/instrumenter/test/unit/mutant-placers/index.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/index.spec.ts
@@ -1,10 +1,10 @@
-import sinon from 'sinon';
 import { NodePath, parseSync, types } from '@babel/core';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { placeMutants, MutantPlacer } from '../../../src/mutant-placers';
-import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
+import { MutantPlacer, placeMutants } from '../../../src/mutant-placers';
 import { createMutant } from '../../helpers/factories';
+import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 
 describe(placeMutants.name, () => {
   let mutantPlacers: Array<sinon.SinonStubbedMember<MutantPlacer>>;

--- a/packages/instrumenter/test/unit/mutant-placers/statement-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/statement-mutant-placer.spec.ts
@@ -1,12 +1,12 @@
-import { expect } from 'chai';
 import { types } from '@babel/core';
 import generate from '@babel/generator';
 import { normalizeWhitespaces } from '@stryker-mutator/util';
+import { expect } from 'chai';
 
-import { statementMutantPlacer } from '../../../src/mutant-placers/statement-mutant-placer';
-import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 import { Mutant } from '../../../src/mutant';
+import { statementMutantPlacer } from '../../../src/mutant-placers/statement-mutant-placer';
 import { createMutant } from '../../helpers/factories';
+import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 
 describe(statementMutantPlacer.name, () => {
   it('should have the correct name', () => {

--- a/packages/instrumenter/test/unit/mutant.spec.ts
+++ b/packages/instrumenter/test/unit/mutant.spec.ts
@@ -5,7 +5,7 @@ import { Mutant as MutantApi } from '@stryker-mutator/api/core';
 import { expect } from 'chai';
 
 import { Mutant } from '../../src/mutant';
-import { parseJS, findNodePath } from '../helpers/syntax-test-helpers';
+import { findNodePath, parseJS } from '../helpers/syntax-test-helpers';
 
 describe(Mutant.name, () => {
   describe('constructor', () => {

--- a/packages/instrumenter/test/unit/mutators/conditional-expression-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/conditional-expression-mutator.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { expectJSMutation } from '../../helpers/expect-mutation';
 import { ConditionalExpressionMutator } from '../../../src/mutators/conditional-expression-mutator';
+import { expectJSMutation } from '../../helpers/expect-mutation';
 
 describe(ConditionalExpressionMutator.name, () => {
   let sut: ConditionalExpressionMutator;

--- a/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { expectJSMutation } from '../../helpers/expect-mutation';
 import { StringLiteralMutator } from '../../../src/mutators/string-literal-mutator';
+import { expectJSMutation } from '../../helpers/expect-mutation';
 
 describe(StringLiteralMutator.name, () => {
   let sut: StringLiteralMutator;

--- a/packages/instrumenter/test/unit/parsers/html-parser.spec.ts
+++ b/packages/instrumenter/test/unit/parsers/html-parser.spec.ts
@@ -3,11 +3,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { parse } from '../../../src/parsers/html-parser';
-import { ParserContext } from '../../../src/parsers/parser-context';
-import { parserContextStub } from '../../helpers/stubs';
-import { createJSAst } from '../../helpers/factories';
-import { AstFormat } from '../../../src/syntax';
 import { ParseError } from '../../../src/parsers/parse-error';
+import { ParserContext } from '../../../src/parsers/parser-context';
+import { AstFormat } from '../../../src/syntax';
+import { createJSAst } from '../../helpers/factories';
+import { parserContextStub } from '../../helpers/stubs';
 
 describe('html-parser', () => {
   let contextStub: sinon.SinonStubbedInstance<ParserContext>;

--- a/packages/instrumenter/test/unit/parsers/js-parser.spec.ts
+++ b/packages/instrumenter/test/unit/parsers/js-parser.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
 import { createParser } from '../../../src/parsers/js-parser';
-import { JSAst, AstFormat } from '../../../src/syntax';
-import { expectAst, AstExpectation } from '../../helpers/syntax-test-helpers';
+import { AstFormat, JSAst } from '../../../src/syntax';
 import { createParserOptions } from '../../helpers/factories';
+import { AstExpectation, expectAst } from '../../helpers/syntax-test-helpers';
 
 describe('js-parser', () => {
   it('should be able to parse simple es5', async () => {

--- a/packages/instrumenter/test/unit/parsers/ts-parser.spec.ts
+++ b/packages/instrumenter/test/unit/parsers/ts-parser.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { TSAst, AstFormat } from '../../../src/syntax';
 import { parse } from '../../../src/parsers/ts-parser';
-import { expectAst, AstExpectation } from '../../helpers/syntax-test-helpers';
+import { AstFormat, TSAst } from '../../../src/syntax';
+import { AstExpectation, expectAst } from '../../helpers/syntax-test-helpers';
 
 describe('ts-parser', () => {
   it('should be able to parse simple typescript', async () => {

--- a/packages/instrumenter/test/unit/printers/html-printer.spec.ts
+++ b/packages/instrumenter/test/unit/printers/html-printer.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { createHtmlAst, createJSAst } from '../../helpers/factories';
-import { print } from '../../../src/printers/html-printer';
 import { PrinterContext } from '../../../src/printers';
-import { printerContextStub } from '../../helpers/stubs';
+import { print } from '../../../src/printers/html-printer';
 import { offsetLocations } from '../../../src/util/syntax-helpers';
+import { createHtmlAst, createJSAst } from '../../helpers/factories';
+import { printerContextStub } from '../../helpers/stubs';
 
 describe('html-printer', () => {
   let contextStub: sinon.SinonStubbedInstance<PrinterContext>;

--- a/packages/instrumenter/test/unit/printers/js-printer.spec.ts
+++ b/packages/instrumenter/test/unit/printers/js-printer.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { print } from '../../../src/printers/js-printer';
-import { printerContextStub } from '../../helpers/stubs';
-import { createJSAst } from '../../helpers/factories';
 import { PrinterContext } from '../../../src/printers';
+import { print } from '../../../src/printers/js-printer';
+import { createJSAst } from '../../helpers/factories';
+import { printerContextStub } from '../../helpers/stubs';
 
 describe('js-printer', () => {
   let contextStub: sinon.SinonStubbedInstance<PrinterContext>;

--- a/packages/instrumenter/test/unit/printers/ts-printer.spec.ts
+++ b/packages/instrumenter/test/unit/printers/ts-printer.spec.ts
@@ -1,10 +1,10 @@
-import { expect } from 'chai';
 import { types } from '@babel/core';
+import { expect } from 'chai';
 
+import { PrinterContext } from '../../../src/printers';
 import { print } from '../../../src/printers/ts-printer';
 import { createTSAst } from '../../helpers/factories';
 import { printerContextStub } from '../../helpers/stubs';
-import { PrinterContext } from '../../../src/printers';
 
 describe('ts-printer', () => {
   let contextStub: sinon.SinonStubbedInstance<PrinterContext>;

--- a/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/babel-transformer.spec.ts
@@ -1,16 +1,16 @@
-import sinon from 'sinon';
-import { expect } from 'chai';
-import { types, NodePath } from '@babel/core';
+import { NodePath, types } from '@babel/core';
 import generate from '@babel/generator';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { transformerContextStub } from '../../helpers/stubs';
-import { TransformerContext } from '../../../src/transformers';
-import * as mutators from '../../../src/mutators';
 import * as mutantPlacers from '../../../src/mutant-placers';
-import { MutantCollector } from '../../../src/transformers/mutant-collector';
+import * as mutators from '../../../src/mutators';
+import { TransformerContext } from '../../../src/transformers';
 import { transformBabel } from '../../../src/transformers/babel-transformer';
-import { createJSAst, createNamedNodeMutation, createMutant, createTSAst } from '../../helpers/factories';
+import { MutantCollector } from '../../../src/transformers/mutant-collector';
 import { instrumentationBabelHeader } from '../../../src/util/syntax-helpers';
+import { createJSAst, createMutant, createNamedNodeMutation, createTSAst } from '../../helpers/factories';
+import { transformerContextStub } from '../../helpers/stubs';
 
 describe('babel-transformer', () => {
   let context: sinon.SinonStubbedInstance<TransformerContext>;

--- a/packages/instrumenter/test/unit/transformers/mutant-collector.spec.ts
+++ b/packages/instrumenter/test/unit/transformers/mutant-collector.spec.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
 import { types } from '@babel/core';
+import { expect } from 'chai';
 
 import { MutantCollector } from '../../../src/transformers/mutant-collector';
 import { createMutant, createNamedNodeMutation } from '../../helpers/factories';

--- a/packages/jasmine-runner/src/index.ts
+++ b/packages/jasmine-runner/src/index.ts
@@ -2,7 +2,7 @@ import { declareFactoryPlugin, PluginKind } from '@stryker-mutator/api/plugin';
 
 import strykerValidationSchema from '../schema/jasmine-runner-options.json';
 
-import { JasmineTestRunner, createJasmineTestRunner, createJasmineTestRunnerFactory } from './jasmine-test-runner';
+import { createJasmineTestRunner, createJasmineTestRunnerFactory, JasmineTestRunner } from './jasmine-test-runner';
 
 export const strykerPlugins = [declareFactoryPlugin(PluginKind.TestRunner, 'jasmine', createJasmineTestRunner)];
 

--- a/packages/jasmine-runner/src/jasmine-test-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-test-runner.ts
@@ -1,19 +1,19 @@
 import { EOL } from 'os';
 
-import { StrykerOptions, CoverageAnalysis, InstrumenterContext, MutantCoverage, INSTRUMENTER_CONSTANTS } from '@stryker-mutator/api/core';
-import { commonTokens, tokens, Injector, PluginContext } from '@stryker-mutator/api/plugin';
+import { CoverageAnalysis, INSTRUMENTER_CONSTANTS, InstrumenterContext, MutantCoverage, StrykerOptions } from '@stryker-mutator/api/core';
+import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import {
+  DryRunOptions,
+  DryRunResult,
   DryRunStatus,
+  ErrorDryRunResult,
+  MutantRunOptions,
+  MutantRunResult,
   TestResult,
   TestRunner,
-  MutantRunOptions,
-  DryRunResult,
-  MutantRunResult,
   toMutantRunResult,
-  ErrorDryRunResult,
-  DryRunOptions,
 } from '@stryker-mutator/api/test-runner';
-import { errorToString, Task, DirectoryRequireCache, I } from '@stryker-mutator/util';
+import { DirectoryRequireCache, errorToString, I, Task } from '@stryker-mutator/util';
 
 import { JasmineRunnerOptions } from '../src-generated/jasmine-runner-options';
 

--- a/packages/jasmine-runner/test/helpers/assertions.ts
+++ b/packages/jasmine-runner/test/helpers/assertions.ts
@@ -1,4 +1,4 @@
-import { TestResult, SuccessTestResult, FailedTestResult, SkippedTestResult } from '@stryker-mutator/api/test-runner';
+import { FailedTestResult, SkippedTestResult, SuccessTestResult, TestResult } from '@stryker-mutator/api/test-runner';
 import { expect } from 'chai';
 
 type TimelessTestResult = Omit<FailedTestResult, 'timeSpentMs'> | Omit<SkippedTestResult, 'timeSpentMs'> | Omit<SuccessTestResult, 'timeSpentMs'>;

--- a/packages/jasmine-runner/test/integration/helpers.ts
+++ b/packages/jasmine-runner/test/integration/helpers.ts
@@ -1,4 +1,4 @@
-import { TestStatus, SuccessTestResult } from '@stryker-mutator/api/test-runner';
+import { SuccessTestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 
 export const jasmineInitResultTestNames = Object.freeze([
   'Player should be able to play a Song',

--- a/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/jasmine-init-instrumented.it.spec.ts
@@ -1,8 +1,8 @@
-import { factory, testInjector, assertions } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import { MutantRunStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
-import { JasmineTestRunner, createJasmineTestRunnerFactory } from '../../src';
+import { createJasmineTestRunnerFactory, JasmineTestRunner } from '../../src';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('JasmineRunner integration with code instrumentation', () => {

--- a/packages/jasmine-runner/test/integration/jasmine-runner.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/jasmine-runner.it.spec.ts
@@ -1,8 +1,8 @@
-import { factory, assertions, testInjector } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import { TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
-import { JasmineTestRunner, createJasmineTestRunnerFactory } from '../../src/jasmine-test-runner';
+import { createJasmineTestRunnerFactory, JasmineTestRunner } from '../../src/jasmine-test-runner';
 import { expectTestResultsToEqual } from '../helpers/assertions';
 import { resolveFromRoot, resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/jasmine-runner/test/integration/memory-leak.it.spec.ts
+++ b/packages/jasmine-runner/test/integration/memory-leak.it.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import execa from 'execa';
 import { expect } from 'chai';
+import execa from 'execa';
 
 import { JasmineTestRunner } from '../../src';
 

--- a/packages/jasmine-runner/test/integration/memory-leak.worker.ts
+++ b/packages/jasmine-runner/test/integration/memory-leak.worker.ts
@@ -1,6 +1,6 @@
+import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
-import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
 
 import { createJasmineTestRunnerFactory } from '../../src';
 import { resolveTestResource } from '../helpers/resolve-test-resource';

--- a/packages/jasmine-runner/test/setup.ts
+++ b/packages/jasmine-runner/test/setup.ts
@@ -1,9 +1,9 @@
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
-import { testInjector } from '@stryker-mutator/test-helpers';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
+++ b/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
@@ -1,15 +1,15 @@
-import sinon from 'sinon';
-import { expect } from 'chai';
-import { factory, assertions, testInjector } from '@stryker-mutator/test-helpers';
-import { TestStatus, CompleteDryRunResult, DryRunStatus } from '@stryker-mutator/api/test-runner';
-import Jasmine from 'jasmine';
+import { CompleteDryRunResult, DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { DirectoryRequireCache } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import Jasmine from 'jasmine';
+import sinon from 'sinon';
 
+import { JasmineTestRunner } from '../../src';
 import * as helpers from '../../src/helpers';
 import * as pluginTokens from '../../src/plugin-tokens';
-import { JasmineTestRunner } from '../../src';
 import { expectTestResultsToEqual } from '../helpers/assertions';
-import { createEnvStub, createRunDetails, createCustomReporterResult } from '../helpers/mock-factories';
+import { createCustomReporterResult, createEnvStub, createRunDetails } from '../helpers/mock-factories';
 
 describe(JasmineTestRunner.name, () => {
   let reporter: jasmine.CustomReporter;

--- a/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
+++ b/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Logger } from '@stryker-mutator/api/logging';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
-import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Config } from '@jest/types';
+import { StrykerOptions } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 
-import { loader, projectRoot } from '../plugin-tokens';
 import { JestRunnerOptionsWithStrykerOptions } from '../jest-runner-options-with-stryker-options';
+import { loader, projectRoot } from '../plugin-tokens';
 
 import { JestConfigLoader } from './jest-config-loader';
 import { NodeRequireFunction } from './node-require-function';

--- a/packages/jest-runner/src/config-loaders/index.ts
+++ b/packages/jest-runner/src/config-loaders/index.ts
@@ -1,6 +1,6 @@
-import { tokens, commonTokens, Injector, PluginContext } from '@stryker-mutator/api/plugin';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 
 import { requireResolve } from '@stryker-mutator/util';
 

--- a/packages/jest-runner/src/config-loaders/react-scripts-jest-config-loader.ts
+++ b/packages/jest-runner/src/config-loaders/react-scripts-jest-config-loader.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 
-import { tokens } from '@stryker-mutator/api/plugin';
 import { Config } from '@jest/types';
+import { tokens } from '@stryker-mutator/api/plugin';
 
-import { createReactJestConfig } from '../utils';
 import * as pluginTokens from '../plugin-tokens';
+import { createReactJestConfig } from '../utils';
 
 import { JestConfigLoader } from './jest-config-loader';
 

--- a/packages/jest-runner/src/config-loaders/react-scripts-ts-jest-config-loader.ts
+++ b/packages/jest-runner/src/config-loaders/react-scripts-ts-jest-config-loader.ts
@@ -1,12 +1,11 @@
 import path from 'path';
 
-import { Logger } from '@stryker-mutator/api/logging';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
-
 import { Config } from '@jest/types';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 
-import { createReactTsJestConfig } from '../utils';
 import * as pluginTokens from '../plugin-tokens';
+import { createReactTsJestConfig } from '../utils';
 
 import { JestConfigLoader } from './jest-config-loader';
 

--- a/packages/jest-runner/src/jest-plugins/jest-environment-jsdom-sixteen.ts
+++ b/packages/jest-runner/src/jest-plugins/jest-environment-jsdom-sixteen.ts
@@ -1,5 +1,5 @@
-import { requireResolve } from '@stryker-mutator/util';
 import { JestEnvironment } from '@jest/environment';
+import { requireResolve } from '@stryker-mutator/util';
 
 import { mixinJestEnvironment } from './mixin-jest-environment';
 

--- a/packages/jest-runner/src/jest-plugins/jest-environment-jsdom.ts
+++ b/packages/jest-runner/src/jest-plugins/jest-environment-jsdom.ts
@@ -1,5 +1,5 @@
-import { requireResolve } from '@stryker-mutator/util';
 import { JestEnvironment } from '@jest/environment';
+import { requireResolve } from '@stryker-mutator/util';
 
 import { mixinJestEnvironment } from './mixin-jest-environment';
 

--- a/packages/jest-runner/src/jest-plugins/jest-environment-node.ts
+++ b/packages/jest-runner/src/jest-plugins/jest-environment-node.ts
@@ -1,5 +1,5 @@
-import { requireResolve } from '@stryker-mutator/util';
 import { JestEnvironment } from '@jest/environment';
+import { requireResolve } from '@stryker-mutator/util';
 
 import { mixinJestEnvironment } from './mixin-jest-environment';
 

--- a/packages/jest-runner/src/jest-plugins/mixin-jest-environment.ts
+++ b/packages/jest-runner/src/jest-plugins/mixin-jest-environment.ts
@@ -1,5 +1,5 @@
-import type { JestEnvironment, EnvironmentContext } from '@jest/environment';
-import type { Config, Circus } from '@jest/types';
+import type { EnvironmentContext, JestEnvironment } from '@jest/environment';
+import type { Circus, Config } from '@jest/types';
 
 import { state } from '../messaging';
 

--- a/packages/jest-runner/src/jest-run-result.ts
+++ b/packages/jest-runner/src/jest-run-result.ts
@@ -1,5 +1,5 @@
-import type { Config } from '@jest/types';
 import type { AggregatedResult } from '@jest/test-result';
+import type { Config } from '@jest/types';
 
 export interface JestRunResult {
   results: AggregatedResult;

--- a/packages/jest-runner/src/jest-test-adapters/jest-greater-than-25-adapter.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-greater-than-25-adapter.ts
@@ -1,5 +1,5 @@
-import { jestWrapper } from '../utils';
 import { JestRunResult } from '../jest-run-result';
+import { jestWrapper } from '../utils';
 
 import { JestTestAdapter, RunSettings } from './jest-test-adapter';
 

--- a/packages/jest-runner/src/jest-test-adapters/jest-less-than-25-adapter.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-less-than-25-adapter.ts
@@ -2,7 +2,7 @@ import jest from 'jest';
 
 import { JestRunResult } from '../jest-run-result';
 
-import { RunSettings, JestTestAdapter } from './jest-test-adapter';
+import { JestTestAdapter, RunSettings } from './jest-test-adapter';
 
 /**
  * The adapter used for 22 < Jest < 25.

--- a/packages/jest-runner/src/jest-test-adapters/jest-test-adapter-factory.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-test-adapter-factory.ts
@@ -1,12 +1,12 @@
-import { Logger } from '@stryker-mutator/api/logging';
 import { StrykerOptions } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
 import { BaseContext, commonTokens, Injector, tokens } from '@stryker-mutator/api/plugin';
 import semver from 'semver';
 
 import { jestVersion } from '../plugin-tokens';
 
-import { JestLessThan25TestAdapter } from './jest-less-than-25-adapter';
 import { JestGreaterThan25TestAdapter } from './jest-greater-than-25-adapter';
+import { JestLessThan25TestAdapter } from './jest-less-than-25-adapter';
 
 export function jestTestAdapterFactory(
   log: Logger,

--- a/packages/jest-runner/src/jest-test-runner.ts
+++ b/packages/jest-runner/src/jest-test-runner.ts
@@ -1,37 +1,37 @@
 // monkey patch exit first!!
 import './utils/monkey-patch-exit';
 
-import { StrykerOptions, INSTRUMENTER_CONSTANTS, MutantCoverage } from '@stryker-mutator/api/core';
+import type * as jestTestResult from '@jest/test-result';
+import type * as jest from '@jest/types';
+import { SerializableError } from '@jest/types/build/TestResult';
+import { INSTRUMENTER_CONSTANTS, MutantCoverage, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import {
-  TestRunner,
-  MutantRunOptions,
-  DryRunResult,
-  MutantRunResult,
-  toMutantRunResult,
-  DryRunStatus,
-  TestResult,
-  TestStatus,
   DryRunOptions,
+  DryRunResult,
+  DryRunStatus,
+  MutantRunOptions,
+  MutantRunResult,
+  TestResult,
+  TestRunner,
+  TestStatus,
+  toMutantRunResult,
 } from '@stryker-mutator/api/test-runner';
 import { escapeRegExp, notEmpty } from '@stryker-mutator/util';
-import type * as jest from '@jest/types';
-import type * as jestTestResult from '@jest/test-result';
-import { SerializableError } from '@jest/types/build/TestResult';
 
 import { JestOptions } from '../src-generated/jest-runner-options';
 
+import { configLoaderFactory } from './config-loaders';
+import { JestConfigLoader } from './config-loaders/jest-config-loader';
+import { JEST_OVERRIDE_OPTIONS } from './jest-override-options';
+import { withCoverageAnalysis } from './jest-plugins';
+import { JestRunnerOptionsWithStrykerOptions } from './jest-runner-options-with-stryker-options';
 import { jestTestAdapterFactory } from './jest-test-adapters';
 import { JestTestAdapter, RunSettings } from './jest-test-adapters/jest-test-adapter';
-import { JestConfigLoader } from './config-loaders/jest-config-loader';
-import { withCoverageAnalysis } from './jest-plugins';
-import * as pluginTokens from './plugin-tokens';
-import { configLoaderFactory } from './config-loaders';
-import { JestRunnerOptionsWithStrykerOptions } from './jest-runner-options-with-stryker-options';
-import { JEST_OVERRIDE_OPTIONS } from './jest-override-options';
-import { mergeMutantCoverage, verifyAllTestFilesHaveCoverage } from './utils';
 import { state } from './messaging';
+import * as pluginTokens from './plugin-tokens';
+import { mergeMutantCoverage, verifyAllTestFilesHaveCoverage } from './utils';
 
 export function createJestTestRunnerFactory(
   namespace: typeof INSTRUMENTER_CONSTANTS.NAMESPACE | '__stryker2__' = INSTRUMENTER_CONSTANTS.NAMESPACE

--- a/packages/jest-runner/test/helpers/producers.ts
+++ b/packages/jest-runner/test/helpers/producers.ts
@@ -1,5 +1,5 @@
-import type { TestResult, AggregatedResult, AssertionResult, SerializableError } from '@jest/test-result';
 import type { EnvironmentContext } from '@jest/environment';
+import type { AggregatedResult, AssertionResult, SerializableError, TestResult } from '@jest/test-result';
 import { Circus, Config } from '@jest/types';
 
 import { JestOptions } from '../../src-generated/jest-runner-options';

--- a/packages/jest-runner/test/integration/coverage-analysis.it.spec.ts
+++ b/packages/jest-runner/test/integration/coverage-analysis.it.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import { JestOptions } from '../../src-generated/jest-runner-options';
 import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options';
-import { JestTestRunner, createJestTestRunnerFactory } from '../../src/jest-test-runner';
+import { createJestTestRunnerFactory, JestTestRunner } from '../../src/jest-test-runner';
 import { createJestOptions } from '../helpers/producers';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
+++ b/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
@@ -1,14 +1,14 @@
-import path from 'path';
 import { platform } from 'os';
+import path from 'path';
 
-import { expect } from 'chai';
 import { commonTokens } from '@stryker-mutator/api/plugin';
-import { factory, testInjector, assertions } from '@stryker-mutator/test-helpers';
 import { CompleteDryRunResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
-import { JestTestRunner, jestTestRunnerFactory } from '../../src/jest-test-runner';
-import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options';
 import { JestOptions } from '../../src-generated/jest-runner-options';
+import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options';
+import { JestTestRunner, jestTestRunnerFactory } from '../../src/jest-test-runner';
 import { createJestOptions } from '../helpers/producers';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/jest-runner/test/setup.ts
+++ b/packages/jest-runner/test/setup.ts
@@ -1,9 +1,9 @@
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
-import { testInjector } from '@stryker-mutator/test-helpers';
+import sinonChai from 'sinon-chai';
 
 import { state } from '../src/messaging';
 

--- a/packages/jest-runner/test/unit/config-loaders/config-loader-factory.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/config-loader-factory.spec.ts
@@ -1,14 +1,14 @@
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { Config } from '@jest/types';
+import { commonTokens } from '@stryker-mutator/api/plugin';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { commonTokens } from '@stryker-mutator/api/plugin';
-import { Config } from '@jest/types';
 
+import { configLoaderFactory } from '../../../src/config-loaders';
 import * as customJestConfigLoader from '../../../src/config-loaders/custom-jest-config-loader';
 import * as reactScriptsJestConfigLoader from '../../../src/config-loaders/react-scripts-jest-config-loader';
 import * as reactScriptsTSJestConfigLoader from '../../../src/config-loaders/react-scripts-ts-jest-config-loader';
 import { JestRunnerOptionsWithStrykerOptions } from '../../../src/jest-runner-options-with-stryker-options';
-import { configLoaderFactory } from '../../../src/config-loaders';
 
 describe(configLoaderFactory.name, () => {
   let customConfigLoaderStub: sinon.SinonStubbedInstance<customJestConfigLoader.CustomJestConfigLoader>;

--- a/packages/jest-runner/test/unit/config-loaders/custom-config-loader.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/custom-config-loader.spec.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
+import { factory } from '@stryker-mutator/test-helpers';
 import { assert, expect } from 'chai';
 import sinon from 'sinon';
-import { factory } from '@stryker-mutator/test-helpers';
 
 import { CustomJestConfigLoader } from '../../../src/config-loaders/custom-jest-config-loader';
 

--- a/packages/jest-runner/test/unit/config-loaders/default-config-loader.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/default-config-loader.spec.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
+import { factory } from '@stryker-mutator/test-helpers';
 import { assert, expect } from 'chai';
 import sinon from 'sinon';
-import { factory } from '@stryker-mutator/test-helpers';
 
 import { CustomJestConfigLoader } from '../../../src/config-loaders/custom-jest-config-loader';
 

--- a/packages/jest-runner/test/unit/jest-plugins/mixin-jest-environment.spec.ts
+++ b/packages/jest-runner/test/unit/jest-plugins/mixin-jest-environment.spec.ts
@@ -1,15 +1,14 @@
 import { EnvironmentContext } from '@jest/environment';
-import JestEnvironmentNode from 'jest-environment-node';
-import sinon from 'sinon';
 import { Circus, Config } from '@jest/types';
 import { MutantCoverage } from '@stryker-mutator/api/core';
 import { expect } from 'chai';
-
-import * as producers from '../../helpers/producers';
+import JestEnvironmentNode from 'jest-environment-node';
+import sinon from 'sinon';
 
 import { mixinJestEnvironment } from '../../../src/jest-plugins';
-import { state } from '../../../src/messaging';
 import * as constants from '../../../src/jest-plugins/constants';
+import { state } from '../../../src/messaging';
+import * as producers from '../../helpers/producers';
 
 describe(`jest plugins ${mixinJestEnvironment.name}`, () => {
   class TestJestEnvironment extends JestEnvironmentNode {

--- a/packages/jest-runner/test/unit/jest-test-adapters/jest-greater-than-25-adapter.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-adapters/jest-greater-than-25-adapter.spec.ts
@@ -1,8 +1,7 @@
+import { Config } from '@jest/types';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { Config } from '@jest/types';
 
 import { JestGreaterThan25TestAdapter } from '../../../src/jest-test-adapters/jest-greater-than-25-adapter';
 import { jestWrapper } from '../../../src/utils/jest-wrapper';

--- a/packages/jest-runner/test/unit/jest-test-runner.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-runner.spec.ts
@@ -1,22 +1,21 @@
 import path from 'path';
 
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
+import { Config } from '@jest/types';
+import { INSTRUMENTER_CONSTANTS, MutantCoverage } from '@stryker-mutator/api/core';
+import { CompleteDryRunResult, DryRunStatus, ErrorDryRunResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { Task } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DryRunStatus, TestStatus, CompleteDryRunResult, ErrorDryRunResult } from '@stryker-mutator/api/test-runner';
-import { INSTRUMENTER_CONSTANTS, MutantCoverage } from '@stryker-mutator/api/core';
-import { Config } from '@jest/types';
 
-import { Task } from '@stryker-mutator/util';
-
+import { JestConfigLoader } from '../../src/config-loaders/jest-config-loader';
+import { JestRunResult } from '../../src/jest-run-result';
+import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options';
 import { JestTestAdapter } from '../../src/jest-test-adapters';
 import { JestTestRunner } from '../../src/jest-test-runner';
-import * as producers from '../helpers/producers';
-import * as pluginTokens from '../../src/plugin-tokens';
-import { JestConfigLoader } from '../../src/config-loaders/jest-config-loader';
-import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options';
-import { JestRunResult } from '../../src/jest-run-result';
 import { state } from '../../src/messaging';
+import * as pluginTokens from '../../src/plugin-tokens';
+import * as producers from '../helpers/producers';
 
 describe(JestTestRunner.name, () => {
   const basePath = '/path/to/project/root';

--- a/packages/jest-runner/test/unit/utils/verify-all-test-files-have-coverage.spec.ts
+++ b/packages/jest-runner/test/unit/utils/verify-all-test-files-have-coverage.spec.ts
@@ -2,9 +2,8 @@ import path from 'path';
 
 import { expect } from 'chai';
 
-import * as producers from '../../helpers/producers';
-
 import { verifyAllTestFilesHaveCoverage } from '../../../src/utils';
+import * as producers from '../../helpers/producers';
 
 describe(verifyAllTestFilesHaveCoverage.name, () => {
   it('should not fail when all files have coverage', () => {

--- a/packages/karma-runner/src/karma-plugins/stryker-reporter.ts
+++ b/packages/karma-runner/src/karma-plugins/stryker-reporter.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
-import { DryRunStatus, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import { MutantCoverage } from '@stryker-mutator/api/core';
+import { DryRunStatus, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import karma from 'karma';
 
 export interface KarmaSpec {

--- a/packages/karma-runner/src/karma-plugins/test-hooks-middleware.ts
+++ b/packages/karma-runner/src/karma-plugins/test-hooks-middleware.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import url from 'url';
 
-import { RequestHandler } from 'express';
 import { CoverageAnalysis, INSTRUMENTER_CONSTANTS } from '@stryker-mutator/api/core';
 import { MutantRunOptions } from '@stryker-mutator/api/test-runner';
 import { escapeRegExpLiteral } from '@stryker-mutator/util';
+import { RequestHandler } from 'express';
 
 export const TEST_HOOKS_FILE_NAME = require.resolve('./test-hooks-middleware-21f23d35-a4c9-4b01-aeff-da9c99c3ffc0');
 const TEST_HOOKS_FILE_BASE_NAME = path.basename(TEST_HOOKS_FILE_NAME);

--- a/packages/karma-runner/src/karma-test-runner.ts
+++ b/packages/karma-runner/src/karma-test-runner.ts
@@ -1,26 +1,26 @@
-import karma from 'karma';
-import { StrykerOptions, MutantCoverage } from '@stryker-mutator/api/core';
+import { MutantCoverage, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import {
-  TestRunner,
-  TestResult,
-  DryRunStatus,
   DryRunOptions,
-  MutantRunOptions,
   DryRunResult,
+  DryRunStatus,
+  MutantRunOptions,
   MutantRunResult,
+  TestResult,
+  TestRunner,
   toMutantRunResult,
 } from '@stryker-mutator/api/test-runner';
+import karma from 'karma';
 
 import { StrykerKarmaSetup } from '../src-generated/karma-runner-options';
 
+import { StrykerReporter } from './karma-plugins/stryker-reporter';
+import { TestHooksMiddleware } from './karma-plugins/test-hooks-middleware';
+import { KarmaRunnerOptionsWithStrykerOptions } from './karma-runner-options-with-stryker-options';
+import { ProjectStarter } from './starters/project-starter';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import strykerKarmaConf = require('./starters/stryker-karma.conf');
-import { ProjectStarter } from './starters/project-starter';
-import { StrykerReporter } from './karma-plugins/stryker-reporter';
-import { KarmaRunnerOptionsWithStrykerOptions } from './karma-runner-options-with-stryker-options';
-import { TestHooksMiddleware } from './karma-plugins/test-hooks-middleware';
 
 export interface ConfigOptions extends karma.ConfigOptions {
   detached?: boolean;

--- a/packages/karma-runner/src/starters/angular-starter.ts
+++ b/packages/karma-runner/src/starters/angular-starter.ts
@@ -1,10 +1,9 @@
 import path from 'path';
 
-import decamelize from 'decamelize';
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
-import semver from 'semver';
-
 import { requireResolve } from '@stryker-mutator/util';
+import decamelize from 'decamelize';
+import semver from 'semver';
 
 import { NgConfigOptions, NgTestArguments } from '../../src-generated/karma-runner-options';
 

--- a/packages/karma-runner/src/starters/stryker-karma.conf.ts
+++ b/packages/karma-runner/src/starters/stryker-karma.conf.ts
@@ -1,11 +1,11 @@
 import path from 'path';
 
 import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
-import { Config, ConfigOptions, ClientOptions, InlinePluginType } from 'karma';
 import { noopLogger, requireResolve } from '@stryker-mutator/util';
+import { ClientOptions, Config, ConfigOptions, InlinePluginType } from 'karma';
 
 import { StrykerReporter } from '../karma-plugins/stryker-reporter';
-import { TestHooksMiddleware, TEST_HOOKS_FILE_NAME } from '../karma-plugins/test-hooks-middleware';
+import { TEST_HOOKS_FILE_NAME, TestHooksMiddleware } from '../karma-plugins/test-hooks-middleware';
 
 function setDefaultOptions(config: Config) {
   config.set({

--- a/packages/karma-runner/test/helpers/assertions.ts
+++ b/packages/karma-runner/test/helpers/assertions.ts
@@ -1,4 +1,4 @@
-import { CompleteDryRunResult, TestStatus, SkippedTestResult, FailedTestResult, SuccessTestResult } from '@stryker-mutator/api/test-runner';
+import { CompleteDryRunResult, FailedTestResult, SkippedTestResult, SuccessTestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import { expect } from 'chai';
 
 export type TimelessTestResult =

--- a/packages/karma-runner/test/integration/instrumented.it.spec.ts
+++ b/packages/karma-runner/test/integration/instrumented.it.spec.ts
@@ -1,10 +1,10 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import { KilledMutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
-import { KarmaTestRunner } from '../../src/karma-test-runner';
-import { KarmaRunnerOptionsWithStrykerOptions } from '../../src/karma-runner-options-with-stryker-options';
 import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
+import { KarmaRunnerOptionsWithStrykerOptions } from '../../src/karma-runner-options-with-stryker-options';
+import { KarmaTestRunner } from '../../src/karma-test-runner';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 function createSut() {

--- a/packages/karma-runner/test/integration/karma-test-runner.it.spec.ts
+++ b/packages/karma-runner/test/integration/karma-test-runner.it.spec.ts
@@ -1,13 +1,13 @@
-import { promisify } from 'util';
 import http from 'http';
+import { promisify } from 'util';
 
-import { DryRunStatus, TestStatus, CompleteDryRunResult, TestResult, FailedTestResult } from '@stryker-mutator/api/test-runner';
-import { testInjector, assertions, factory } from '@stryker-mutator/test-helpers';
+import { CompleteDryRunResult, DryRunStatus, FailedTestResult, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import { FilePattern } from 'karma';
 
-import { KarmaTestRunner } from '../../src/karma-test-runner';
 import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
+import { KarmaTestRunner } from '../../src/karma-test-runner';
 
 function setOptions(
   files: ReadonlyArray<FilePattern | string> = [

--- a/packages/karma-runner/test/integration/read-config.it.spec.ts
+++ b/packages/karma-runner/test/integration/read-config.it.spec.ts
@@ -1,9 +1,9 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
 import { TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
-import { KarmaTestRunner } from '../../src/karma-test-runner';
 import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
+import { KarmaTestRunner } from '../../src/karma-test-runner';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('read config integration', () => {

--- a/packages/karma-runner/test/integration/sample.it.spec.ts
+++ b/packages/karma-runner/test/integration/sample.it.spec.ts
@@ -1,10 +1,10 @@
 import { TestStatus } from '@stryker-mutator/api/test-runner';
-import { testInjector, assertions, factory } from '@stryker-mutator/test-helpers';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 
+import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
+import { KarmaRunnerOptionsWithStrykerOptions } from '../../src/karma-runner-options-with-stryker-options';
 import { KarmaTestRunner } from '../../src/karma-test-runner';
 import { expectTestResults, TimelessTestResult } from '../helpers/assertions';
-import { KarmaRunnerOptionsWithStrykerOptions } from '../../src/karma-runner-options-with-stryker-options';
-import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('Sample project', () => {

--- a/packages/karma-runner/test/setup.ts
+++ b/packages/karma-runner/test/setup.ts
@@ -2,9 +2,8 @@ import 'source-map-support/register';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
-
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/karma-runner/test/unit/karma-plugins/stryker-reporter.spec.ts
+++ b/packages/karma-runner/test/unit/karma-plugins/stryker-reporter.spec.ts
@@ -1,9 +1,9 @@
+import { MutantCoverage } from '@stryker-mutator/api/core';
 import { DryRunStatus, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import { expect } from 'chai';
 import { TestResults } from 'karma';
-import { MutantCoverage } from '@stryker-mutator/api/core';
 
-import { StrykerReporter, KarmaSpec } from '../../../src/karma-plugins/stryker-reporter';
+import { KarmaSpec, StrykerReporter } from '../../../src/karma-plugins/stryker-reporter';
 
 describe('StrykerReporter', () => {
   let sut: StrykerReporter;

--- a/packages/karma-runner/test/unit/karma-plugins/test-hooks-middleware.spec.ts
+++ b/packages/karma-runner/test/unit/karma-plugins/test-hooks-middleware.spec.ts
@@ -1,11 +1,11 @@
 import path from 'path';
 
-import { expect } from 'chai';
 import { factory } from '@stryker-mutator/test-helpers';
-import { Request, NextFunction, Response } from 'express';
+import { expect } from 'chai';
+import { NextFunction, Request, Response } from 'express';
 import sinon from 'sinon';
 
-import { TestHooksMiddleware, TEST_HOOKS_FILE_NAME } from '../../../src/karma-plugins/test-hooks-middleware';
+import { TEST_HOOKS_FILE_NAME, TestHooksMiddleware } from '../../../src/karma-plugins/test-hooks-middleware';
 
 describe(TestHooksMiddleware.name, () => {
   let sut: TestHooksMiddleware;

--- a/packages/karma-runner/test/unit/karma-test-runner.spec.ts
+++ b/packages/karma-runner/test/unit/karma-test-runner.spec.ts
@@ -3,18 +3,18 @@ import { EventEmitter } from 'events';
 import { LoggerFactoryMethod } from '@stryker-mutator/api/logging';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { DryRunStatus } from '@stryker-mutator/api/test-runner';
-import { testInjector, assertions, factory } from '@stryker-mutator/test-helpers';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import karma from 'karma';
 import sinon from 'sinon';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import strykerKarmaConf = require('../../src/starters/stryker-karma.conf');
-import { KarmaTestRunner } from '../../src/karma-test-runner';
-import * as projectStarter from '../../src/starters/project-starter';
-import { StrykerKarmaSetup, NgConfigOptions } from '../../src-generated/karma-runner-options';
+import { NgConfigOptions, StrykerKarmaSetup } from '../../src-generated/karma-runner-options';
 import { StrykerReporter } from '../../src/karma-plugins/stryker-reporter';
 import { TestHooksMiddleware } from '../../src/karma-plugins/test-hooks-middleware';
+import { KarmaTestRunner } from '../../src/karma-test-runner';
+import * as projectStarter from '../../src/starters/project-starter';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import strykerKarmaConf = require('../../src/starters/stryker-karma.conf');
 
 describe(KarmaTestRunner.name, () => {
   let projectStarterMock: sinon.SinonStubbedInstance<projectStarter.ProjectStarter>;

--- a/packages/karma-runner/test/unit/starters/stryker-karma.conf.spec.ts
+++ b/packages/karma-runner/test/unit/starters/stryker-karma.conf.spec.ts
@@ -1,15 +1,15 @@
 import path from 'path';
 
 import { testInjector } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
-import { Config, ConfigOptions, ClientOptions } from 'karma';
-import sinon from 'sinon';
 import * as utils from '@stryker-mutator/util';
+import { expect } from 'chai';
+import { ClientOptions, Config, ConfigOptions } from 'karma';
+import sinon from 'sinon';
 
+import { StrykerReporter } from '../../../src/karma-plugins/stryker-reporter';
+import { TEST_HOOKS_FILE_NAME, TestHooksMiddleware } from '../../../src/karma-plugins/test-hooks-middleware';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import sut = require('../../../src/starters/stryker-karma.conf');
-import { StrykerReporter } from '../../../src/karma-plugins/stryker-reporter';
-import { TestHooksMiddleware, TEST_HOOKS_FILE_NAME } from '../../../src/karma-plugins/test-hooks-middleware';
 
 describe('stryker-karma.conf.js', () => {
   let getLogger: sinon.SinonStub;

--- a/packages/mocha-runner/src/lib-wrapper.ts
+++ b/packages/mocha-runner/src/lib-wrapper.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import Mocha from 'mocha';
 import glob from 'glob';
+import Mocha from 'mocha';
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
 

--- a/packages/mocha-runner/src/mocha-adapter.ts
+++ b/packages/mocha-runner/src/mocha-adapter.ts
@@ -1,8 +1,8 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { PropertyPathBuilder } from '@stryker-mutator/util';
 
 import { MochaOptions, MochaRunnerOptions } from '../src-generated/mocha-runner-options';

--- a/packages/mocha-runner/src/mocha-options-loader.ts
+++ b/packages/mocha-runner/src/mocha-options-loader.ts
@@ -8,8 +8,8 @@ import { PropertyPathBuilder } from '@stryker-mutator/util';
 import { MochaOptions, MochaRunnerOptions } from '../src-generated/mocha-runner-options';
 
 import { LibWrapper } from './lib-wrapper';
-import { filterConfig, serializeMochaLoadOptionsArguments } from './utils';
 import { MochaRunnerWithStrykerOptions } from './mocha-runner-with-stryker-options';
+import { filterConfig, serializeMochaLoadOptionsArguments } from './utils';
 
 /**
  * Subset of defaults for mocha options

--- a/packages/mocha-runner/src/mocha-test-runner.ts
+++ b/packages/mocha-runner/src/mocha-test-runner.ts
@@ -1,26 +1,25 @@
-import { InstrumenterContext, INSTRUMENTER_CONSTANTS, StrykerOptions } from '@stryker-mutator/api/core';
+import { INSTRUMENTER_CONSTANTS, InstrumenterContext, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
-import { I, escapeRegExp, DirectoryRequireCache } from '@stryker-mutator/util';
-
 import {
-  TestRunner,
-  DryRunResult,
+  CompleteDryRunResult,
   DryRunOptions,
+  DryRunResult,
+  DryRunStatus,
   MutantRunOptions,
   MutantRunResult,
-  DryRunStatus,
+  TestRunner,
   toMutantRunResult,
-  CompleteDryRunResult,
 } from '@stryker-mutator/api/test-runner';
+import { DirectoryRequireCache, escapeRegExp, I } from '@stryker-mutator/util';
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
 
-import { StrykerMochaReporter } from './stryker-mocha-reporter';
+import { MochaAdapter } from './mocha-adapter';
+import { MochaOptionsLoader } from './mocha-options-loader';
 import { MochaRunnerWithStrykerOptions } from './mocha-runner-with-stryker-options';
 import * as pluginTokens from './plugin-tokens';
-import { MochaOptionsLoader } from './mocha-options-loader';
-import { MochaAdapter } from './mocha-adapter';
+import { StrykerMochaReporter } from './stryker-mocha-reporter';
 
 export class MochaTestRunner implements TestRunner {
   public testFileNames?: string[];

--- a/packages/mocha-runner/src/stryker-mocha-reporter.ts
+++ b/packages/mocha-runner/src/stryker-mocha-reporter.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@stryker-mutator/api/logging';
-import { FailedTestResult, TestResult, SuccessTestResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { FailedTestResult, SuccessTestResult, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import { I } from '@stryker-mutator/util';
 
 import { Timer } from './timer';

--- a/packages/mocha-runner/src/utils.ts
+++ b/packages/mocha-runner/src/utils.ts
@@ -1,7 +1,6 @@
-import { MochaOptions } from '../src-generated/mocha-runner-options';
-
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import mochaSchema = require('../schema/mocha-runner-options.json');
+import { MochaOptions } from '../src-generated/mocha-runner-options';
 
 export function serializeMochaLoadOptionsArguments(mochaOptions: MochaOptions): string[] {
   const args: string[] = [];

--- a/packages/mocha-runner/test/integration/memory-leak.it.spec.ts
+++ b/packages/mocha-runner/test/integration/memory-leak.it.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import execa from 'execa';
 import { expect } from 'chai';
+import execa from 'execa';
 
 import { MochaTestRunner } from '../../src';
 

--- a/packages/mocha-runner/test/integration/memory-leak.worker.ts
+++ b/packages/mocha-runner/test/integration/memory-leak.worker.ts
@@ -1,7 +1,7 @@
+import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
 import { testInjector } from '@stryker-mutator/test-helpers';
 
 import { expect } from 'chai';
-import { DryRunStatus, TestStatus } from '@stryker-mutator/api/test-runner';
 
 import { createMochaTestRunnerFactory } from '../../src';
 import { resolveTestResource } from '../helpers/resolve-test-resource';

--- a/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
+++ b/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
+import { createMochaTestRunnerFactory } from '../../src';
 import { MochaOptionsLoader } from '../../src/mocha-options-loader';
 import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryker-options';
-import { createMochaTestRunnerFactory } from '../../src';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('Mocha 6 file resolving integration', () => {

--- a/packages/mocha-runner/test/integration/mocha-options-loader.it.spec.ts
+++ b/packages/mocha-runner/test/integration/mocha-options-loader.it.spec.ts
@@ -2,7 +2,7 @@ import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
 import { MochaOptions } from '../../src-generated/mocha-runner-options';
-import { MochaOptionsLoader, DEFAULT_MOCHA_OPTIONS } from '../../src/mocha-options-loader';
+import { DEFAULT_MOCHA_OPTIONS, MochaOptionsLoader } from '../../src/mocha-options-loader';
 import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryker-options';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
+++ b/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
@@ -1,4 +1,4 @@
-import { assertions, testInjector, factory } from '@stryker-mutator/test-helpers';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
 import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';

--- a/packages/mocha-runner/test/integration/qunit-sample.it.spec.ts
+++ b/packages/mocha-runner/test/integration/qunit-sample.it.spec.ts
@@ -1,8 +1,8 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
-import { createMochaOptions } from '../helpers/factories';
 import { createMochaTestRunnerFactory } from '../../src';
+import { createMochaOptions } from '../helpers/factories';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('QUnit sample', () => {

--- a/packages/mocha-runner/test/integration/sample-project-instrumented.it.spec.ts
+++ b/packages/mocha-runner/test/integration/sample-project-instrumented.it.spec.ts
@@ -1,8 +1,8 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import { MutantCoverage } from '@stryker-mutator/api/core';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
-import { MochaTestRunner, createMochaTestRunnerFactory } from '../../src';
+import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';
 import { createMochaOptions } from '../helpers/factories';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 

--- a/packages/mocha-runner/test/integration/sample-project.it.spec.ts
+++ b/packages/mocha-runner/test/integration/sample-project.it.spec.ts
@@ -1,9 +1,9 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { TestResult, CompleteDryRunResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { CompleteDryRunResult, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
-import { createMochaOptions } from '../helpers/factories';
 import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';
+import { createMochaOptions } from '../helpers/factories';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
 
 const countTests = (runResult: CompleteDryRunResult, predicate: (result: TestResult) => boolean) => runResult.tests.filter(predicate).length;

--- a/packages/mocha-runner/test/setup.ts
+++ b/packages/mocha-runner/test/setup.ts
@@ -1,9 +1,9 @@
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { testInjector } from '@stryker-mutator/test-helpers';
 
 import { StrykerMochaReporter } from '../src/stryker-mocha-reporter';
 

--- a/packages/mocha-runner/test/unit/mocha-adapter.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-adapter.spec.ts
@@ -1,12 +1,12 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
-import sinon from 'sinon';
-import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { MochaAdapter } from '../../src/mocha-adapter';
 import { LibWrapper } from '../../src/lib-wrapper';
+import { MochaAdapter } from '../../src/mocha-adapter';
 
 describe(MochaAdapter.name, () => {
   let requireStub: sinon.SinonStub;

--- a/packages/mocha-runner/test/unit/mocha-options-loader.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-options-loader.spec.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import sinon from 'sinon';
-import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { LibWrapper } from '../../src/lib-wrapper';
 import { MochaOptions } from '../../src-generated/mocha-runner-options';
+import { LibWrapper } from '../../src/lib-wrapper';
 import { MochaOptionsLoader } from '../../src/mocha-options-loader';
 import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryker-options';
 

--- a/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
@@ -1,15 +1,15 @@
+import { KilledMutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { DirectoryRequireCache } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import Mocha from 'mocha';
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
 import sinon from 'sinon';
-import { KilledMutantRunResult, MutantRunStatus } from '@stryker-mutator/api/test-runner';
-import { DirectoryRequireCache } from '@stryker-mutator/util';
 
-import { MochaTestRunner } from '../../src/mocha-test-runner';
-import { StrykerMochaReporter } from '../../src/stryker-mocha-reporter';
 import { MochaAdapter } from '../../src/mocha-adapter';
-import * as pluginTokens from '../../src/plugin-tokens';
 import { MochaOptionsLoader } from '../../src/mocha-options-loader';
+import { MochaTestRunner } from '../../src/mocha-test-runner';
+import * as pluginTokens from '../../src/plugin-tokens';
+import { StrykerMochaReporter } from '../../src/stryker-mocha-reporter';
 import { createMochaOptions } from '../helpers/factories';
 
 describe(MochaTestRunner.name, () => {

--- a/packages/test-helpers/src/assertions.ts
+++ b/packages/test-helpers/src/assertions.ts
@@ -1,23 +1,22 @@
 import assert from 'assert';
 
-import { expect } from 'chai';
-
+import { CheckResult, CheckStatus, FailedCheckResult } from '@stryker-mutator/api/check';
+import { File } from '@stryker-mutator/api/core';
 import {
-  MutantRunResult,
-  SurvivedMutantRunResult,
-  ErrorDryRunResult,
-  KilledMutantRunResult,
-  MutantRunStatus,
-  DryRunResult,
   CompleteDryRunResult,
+  DryRunResult,
   DryRunStatus,
+  ErrorDryRunResult,
   ErrorMutantRunResult,
-  TestResult,
   FailedTestResult,
+  KilledMutantRunResult,
+  MutantRunResult,
+  MutantRunStatus,
+  SurvivedMutantRunResult,
+  TestResult,
   TestStatus,
 } from '@stryker-mutator/api/test-runner';
-import { File } from '@stryker-mutator/api/core';
-import { CheckResult, FailedCheckResult, CheckStatus } from '@stryker-mutator/api/check';
+import { expect } from 'chai';
 
 export function expectKilled(result: MutantRunResult): asserts result is KilledMutantRunResult {
   assert.equal(result.status, MutantRunStatus.Killed);

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -1,50 +1,50 @@
-import Ajv from 'ajv';
+import { Checker, CheckResult, CheckStatus, FailedCheckResult } from '@stryker-mutator/api/check';
 import {
   File,
   Location,
-  MutationScoreThresholds,
-  StrykerOptions,
-  strykerCoreSchema,
-  WarningOptions,
   Mutant,
   MutantCoverage,
+  MutationScoreThresholds,
+  strykerCoreSchema,
+  StrykerOptions,
+  WarningOptions,
 } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
+import { PluginResolver } from '@stryker-mutator/api/plugin';
 import {
+  IgnoredMutantResult,
+  InvalidMutantResult,
+  KilledMutantResult,
   MatchedMutant,
   MutantStatus,
   mutationTestReportSchema,
   Reporter,
-  KilledMutantResult,
-  InvalidMutantResult,
-  UndetectedMutantResult,
   TimeoutMutantResult,
-  IgnoredMutantResult,
+  UndetectedMutantResult,
 } from '@stryker-mutator/api/report';
+import {
+  CompleteDryRunResult,
+  DryRunOptions,
+  DryRunStatus,
+  ErrorDryRunResult,
+  ErrorMutantRunResult,
+  FailedTestResult,
+  KilledMutantRunResult,
+  MutantRunOptions,
+  MutantRunStatus,
+  SkippedTestResult,
+  SuccessTestResult,
+  SurvivedMutantRunResult,
+  TestResult,
+  TestRunner,
+  TestStatus,
+  TimeoutDryRunResult,
+  TimeoutMutantRunResult,
+} from '@stryker-mutator/api/test-runner';
+import Ajv from 'ajv';
 import { Metrics, MetricsResult } from 'mutation-testing-metrics';
 import sinon from 'sinon';
 import { Injector } from 'typed-inject';
-import { PluginResolver } from '@stryker-mutator/api/plugin';
-import {
-  MutantRunOptions,
-  DryRunOptions,
-  DryRunStatus,
-  TestRunner,
-  SuccessTestResult,
-  FailedTestResult,
-  SkippedTestResult,
-  CompleteDryRunResult,
-  ErrorDryRunResult,
-  TimeoutDryRunResult,
-  KilledMutantRunResult,
-  SurvivedMutantRunResult,
-  MutantRunStatus,
-  TimeoutMutantRunResult,
-  ErrorMutantRunResult,
-  TestStatus,
-  TestResult,
-} from '@stryker-mutator/api/test-runner';
-import { Checker, CheckResult, CheckStatus, FailedCheckResult } from '@stryker-mutator/api/check';
 
 const ajv = new Ajv({ useDefaults: true, strict: false });
 

--- a/packages/test-helpers/src/test-injector.ts
+++ b/packages/test-helpers/src/test-injector.ts
@@ -2,7 +2,7 @@ import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, PluginContext, PluginResolver } from '@stryker-mutator/api/plugin';
 import sinon from 'sinon';
-import { Injector, createInjector } from 'typed-inject';
+import { createInjector, Injector } from 'typed-inject';
 
 import * as factory from './factory';
 

--- a/packages/typescript-checker/src/fs/hybrid-file-system.ts
+++ b/packages/typescript-checker/src/fs/hybrid-file-system.ts
@@ -1,7 +1,7 @@
-import ts from 'typescript';
 import { Mutant } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
-import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+import ts from 'typescript';
 
 import { ScriptFile } from './script-file';
 

--- a/packages/typescript-checker/src/fs/script-file.ts
+++ b/packages/typescript-checker/src/fs/script-file.ts
@@ -1,5 +1,5 @@
-import ts from 'typescript';
 import { Mutant } from '@stryker-mutator/api/core';
+import ts from 'typescript';
 
 export class ScriptFile {
   private readonly originalContent: string;

--- a/packages/typescript-checker/src/index.ts
+++ b/packages/typescript-checker/src/index.ts
@@ -1,4 +1,4 @@
-import { PluginKind, declareFactoryPlugin } from '@stryker-mutator/api/plugin';
+import { declareFactoryPlugin, PluginKind } from '@stryker-mutator/api/plugin';
 
 import { create } from './typescript-checker';
 

--- a/packages/typescript-checker/src/tsconfig-helpers.ts
+++ b/packages/typescript-checker/src/tsconfig-helpers.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 
-import ts from 'typescript';
 import semver from 'semver';
+import ts from 'typescript';
 
 // Override some compiler options that have to do with code quality. When mutating, we're not interested in the resulting code quality
 // See https://github.com/stryker-mutator/stryker/issues/391 for more info

--- a/packages/typescript-checker/src/typescript-checker.ts
+++ b/packages/typescript-checker/src/typescript-checker.ts
@@ -1,16 +1,16 @@
 import { EOL } from 'os';
 import path from 'path';
 
-import ts from 'typescript';
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { tokens, commonTokens, PluginContext, Injector, Scope } from '@stryker-mutator/api/plugin';
-import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
-import { Task, propertyPath } from '@stryker-mutator/util';
 import { Mutant, StrykerOptions } from '@stryker-mutator/api/core';
+import { Logger, LoggerFactoryMethod } from '@stryker-mutator/api/logging';
+import { commonTokens, Injector, PluginContext, Scope, tokens } from '@stryker-mutator/api/plugin';
+import { propertyPath, Task } from '@stryker-mutator/util';
+import ts from 'typescript';
 
 import { HybridFileSystem } from './fs';
-import { determineBuildModeEnabled, overrideOptions, retrieveReferencedProjects, guardTSVersion } from './tsconfig-helpers';
 import * as pluginTokens from './plugin-tokens';
+import { determineBuildModeEnabled, guardTSVersion, overrideOptions, retrieveReferencedProjects } from './tsconfig-helpers';
 
 const diagnosticsHost: ts.FormatDiagnosticsHost = {
   getCanonicalFileName: (fileName) => fileName,

--- a/packages/typescript-checker/test/integration/project-references.it.spec.ts
+++ b/packages/typescript-checker/test/integration/project-references.it.spec.ts
@@ -1,10 +1,10 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
-import { expect } from 'chai';
-import { Mutant, Range } from '@stryker-mutator/api/core';
 import { CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import { Mutant, Range } from '@stryker-mutator/api/core';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
 import { createTypescriptChecker } from '../../src';
 import { TypescriptChecker } from '../../src/typescript-checker';

--- a/packages/typescript-checker/test/integration/single-project.it.spec.ts
+++ b/packages/typescript-checker/test/integration/single-project.it.spec.ts
@@ -1,10 +1,10 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
-import { Mutant, Range } from '@stryker-mutator/api/core';
 import { CheckResult, CheckStatus } from '@stryker-mutator/api/check';
+import { Mutant, Range } from '@stryker-mutator/api/core';
+import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 
 import { createTypescriptChecker } from '../../src';
 import { TypescriptChecker } from '../../src/typescript-checker';

--- a/packages/typescript-checker/test/setup.ts
+++ b/packages/typescript-checker/test/setup.ts
@@ -1,9 +1,9 @@
 import 'source-map-support/register';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
-import { testInjector } from '@stryker-mutator/test-helpers';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/typescript-checker/test/unit/fs/hybrid-file-system.spec.ts
+++ b/packages/typescript-checker/test/unit/fs/hybrid-file-system.spec.ts
@@ -1,7 +1,7 @@
+import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
 import sinon from 'sinon';
 import ts from 'typescript';
-import { expect } from 'chai';
-import { testInjector } from '@stryker-mutator/test-helpers';
 
 import { HybridFileSystem } from '../../../src/fs';
 

--- a/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
+++ b/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 
+import { expect } from 'chai';
 import sinon from 'sinon';
 import ts from 'typescript';
-import { expect } from 'chai';
 
-import { determineBuildModeEnabled, overrideOptions, retrieveReferencedProjects, guardTSVersion } from '../../src/tsconfig-helpers';
+import { determineBuildModeEnabled, guardTSVersion, overrideOptions, retrieveReferencedProjects } from '../../src/tsconfig-helpers';
 
 describe('typescript-helpers', () => {
   describe(determineBuildModeEnabled.name, () => {

--- a/packages/util/test/integration/require-resolve.it.spec.ts
+++ b/packages/util/test/integration/require-resolve.it.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import sinon from 'sinon';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { requireResolve } from '../../src';
 

--- a/packages/util/test/setup.ts
+++ b/packages/util/test/setup.ts
@@ -1,8 +1,8 @@
 import 'source-map-support/register';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/packages/util/test/unit/directory-require-cache.spec.ts
+++ b/packages/util/test/unit/directory-require-cache.spec.ts
@@ -1,8 +1,7 @@
 import path from 'path';
 
-import sinon from 'sinon';
-
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { DirectoryRequireCache } from '../../src';
 

--- a/packages/util/test/unit/string-utils.spec.ts
+++ b/packages/util/test/unit/string-utils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral, escapeRegExp, PropertyPathBuilder } from '../../src';
+import { escapeRegExp, escapeRegExpLiteral, normalizeWhitespaces, propertyPath, PropertyPathBuilder } from '../../src';
 
 describe('stringUtils', () => {
   describe(normalizeWhitespaces.name, () => {

--- a/packages/util/test/unit/task.spec.ts
+++ b/packages/util/test/unit/task.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import sinon from 'sinon';
 
-import { Task, ExpirableTask } from '../../src';
+import { ExpirableTask, Task } from '../../src';
 
 describe(Task.name, () => {
   it('should give access to underlying promise', () => {


### PR DESCRIPTION
enables ordering in
`imports`:
```diff
- import path from 'path';
- import fs from 'fs';
+ import fs from 'fs;
+ import path from 'path;
```
and `members of imports`:
```diff
- import { StrykerOptions, PartialStrykerOptions } from '@stryker-mutator/api';
+ import { PartialStrykerOptions, StrykerOptions } from '@stryker-mutator/api';
```