### PR TITLE
fix(sandbox): make directory if not exists before symlinking

### DIFF
--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -69,7 +69,8 @@ export function moveDirectoryRecursiveSync(from: string, to: string): void {
  * @param to The thing you want to point to
  * @param from The thing you want to point from
  */
-export function symlinkJunction(to: string, from: string): Promise<void> {
+export async function symlinkJunction(to: string, from: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(from), { recursive: true });
   return fs.promises.symlink(to, from, 'junction');
 }
 

--- a/packages/core/test/unit/utils/file-utils.spec.ts
+++ b/packages/core/test/unit/utils/file-utils.spec.ts
@@ -21,6 +21,7 @@ describe('fileUtils', () => {
   beforeEach(() => {
     sinon.stub(fs.promises, 'writeFile');
     sinon.stub(fs.promises, 'symlink');
+    sinon.stub(fs.promises, 'mkdir');
     readdirStub = sinon.stub(fs.promises, 'readdir');
   });
 
@@ -28,6 +29,10 @@ describe('fileUtils', () => {
     it('should call fs.symlink', async () => {
       await fileUtils.symlinkJunction('a', 'b');
       expect(fs.promises.symlink).calledWith('a', 'b', 'junction');
+    });
+    it("should create the dir if it doesn't exist", async () => {
+      await fileUtils.symlinkJunction('a', path.resolve('b', 'c'));
+      expect(fs.promises.mkdir).calledWith(path.resolve('b'), { recursive: true });
     });
   });
 


### PR DESCRIPTION
First create directory if it not already existing _before_ creating the symlink to `node_modules` inside the sandbox directory.