### PR TITLE
feat(mutator): mutate nullish coalescing operator

### DIFF
--- a/packages/instrumenter/src/mutators/logical-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/logical-operator-mutator.ts
@@ -8,6 +8,7 @@ import { NodeMutator } from '.';
 enum LogicalOperators {
   '&&' = '||',
   '||' = '&&',
+  '??' = '&&',
 }
 
 export class LogicalOperatorMutator implements NodeMutator {

--- a/packages/instrumenter/test/unit/mutators/logical-operator-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/logical-operator-mutator.spec.ts
@@ -13,8 +13,20 @@ describe(LogicalOperatorMutator.name, () => {
     expect(sut.name).eq('LogicalOperator');
   });
 
-  it('should mutate && and ||', () => {
+  it('should mutate &&', () => {
     expectJSMutation(sut, 'a && b', 'a || b');
+  });
+
+  it('should mutate ||', () => {
     expectJSMutation(sut, 'a || b', 'a && b');
+  });
+
+  it('should not mutate & and |', () => {
+    expectJSMutation(sut, 'a & b');
+    expectJSMutation(sut, 'a | b');
+  });
+
+  it('should mutate ?? to &&', () => {
+    expectJSMutation(sut, 'a ?? b', 'a && b');
   });
 });


### PR DESCRIPTION
Allow the logical operator mutator to mutate [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) to a logical [AND (&&) operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND):

```diff
-foo ?? bar
+foo && bar
```