### PR TITLE
fix invalid json format of stryker.conf.json

### DIFF
--- a/docs/guides/vuejs.md
+++ b/docs/guides/vuejs.md
@@ -27,7 +27,7 @@ Follow this guide if you're using the if you're using the [unit-jest](https://cl
      "tempDirName_comment": "Jest doesn't play nice with the default (.stryker-tmp).",
      "tempDirName": "stryker-tmp",
      "testRunner": "jest",
-     "coverageAnalysis": "off",
+     "coverageAnalysis": "off"
    }
    ```
 1. Add `stryker-tmp` to your `.gitignore` file.


### PR DESCRIPTION
Hi !
I have fixed the stryker.conf.json of `docs/guides/vuejs.md`.

why?: that's invalid json format.

thx.