### PR TITLE
fix(node 12): clear error message for node <12.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.19, 16.x]
+        node-version: ['12.17', 16.x]
         os: ['ubuntu-latest', 'windows-latest']
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 16.x]
+        node-version: [12.19, 16.x]
         os: ['ubuntu-latest', 'windows-latest']
     steps:
     - uses: actions/checkout@v2.3.4

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/core"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12.17"
   },
   "keywords": [
     "mutation testing",
@@ -78,6 +78,7 @@
     "progress": "~2.0.0",
     "rimraf": "~3.0.0",
     "rxjs": "~7.3.0",
+    "semver": "^7.3.5",
     "source-map": "~0.7.3",
     "tree-kill": "~1.2.2",
     "tslib": "~2.3.0",
@@ -93,6 +94,7 @@
     "@types/minimatch": "~3.0.3",
     "@types/node": "^15.0.0",
     "@types/progress": "~2.0.1",
+    "@types/semver": "^7.3.8",
     "flatted": "~3.2.0"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
-import { Stryker } from './stryker';
 import { StrykerCli } from './stryker-cli';
+import { Stryker } from './stryker';
 
 export { Stryker, StrykerCli };
 

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -1,3 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports, import/order
+const strykerPackage: { version: string; engines: { node: string } } = require('../../package.json');
+
+import semver from 'semver';
+
+guardMinimalNodeVersion();
+
 import commander from 'commander';
 import { MutantResult, DashboardOptions, ALL_REPORT_TYPES, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
@@ -44,7 +51,7 @@ export class StrykerCli {
     const defaultValues = defaultOptions();
     this.program
       // eslint-disable-next-line @typescript-eslint/no-require-imports
-      .version(require('../../package.json').version as string)
+      .version(strykerPackage.version)
       .usage('<command> [options] [configFile]')
       .description(
         `Possible commands:
@@ -187,5 +194,14 @@ export class StrykerCli {
     } else {
       console.error('Unknown command: "%s", supported commands: [%s], or use `stryker --help`.', this.command, Object.keys(commands));
     }
+  }
+}
+
+export function guardMinimalNodeVersion(processVersion = process.version): void {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  if (!semver.satisfies(processVersion, strykerPackage.engines.node)) {
+    throw new Error(
+      `Node.js version ${processVersion} detected. StrykerJS requires version to match ${strykerPackage.engines.node}. Please update your Node.js version or visit https://nodejs.org/ for additional instructions`
+    );
   }
 }

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { DashboardOptions, StrykerOptions, ReportType, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
 import { LogConfigurator } from '../../src/logging';
-import { StrykerCli } from '../../src/stryker-cli';
+import { guardMinimalNodeVersion, StrykerCli } from '../../src/stryker-cli';
 
 describe(StrykerCli.name, () => {
   let runMutationTestingStub: sinon.SinonStub;
@@ -91,6 +91,17 @@ describe(StrykerCli.name, () => {
       const actualOptions: StrykerOptions = call.args[0];
       const dashboardKeys = Object.keys(actualOptions).filter((key) => key.startsWith('dashboard.'));
       expect(dashboardKeys, JSON.stringify(dashboardKeys)).lengthOf(0);
+    });
+  });
+
+  describe(guardMinimalNodeVersion.name, () => {
+    it('should fail for < v12.17', () => {
+      expect(() => guardMinimalNodeVersion('v12.16.0')).throws(
+        'Node.js version v12.16.0 detected. StrykerJS requires version to match >=12.17. Please update your Node.js version or visit https://nodejs.org/ for additional instructions'
+      );
+    });
+    it('should not fail for >= v12.17', () => {
+      expect(() => guardMinimalNodeVersion('v12.17.0')).not.throws();
     });
   });
 


### PR DESCRIPTION
StrykerJS supports Node 12.17 and higher. This change adds a clear error message when you run it with a lower node version

Fixes #3007 