### PR TITLE
WIP - Create the disableBail option.

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -456,6 +456,11 @@
         }
       ],
       "description": "Enable or disable certain warnings"
+    },
+    "disableBail": {
+      "description": "Disables the default of bailing after first failing test. When true runs all tests covering a mutant. Useful when the subject under test is not completely isolated by mocks and you want to know which tests are killing the mutants. This will impact performance.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/packages/api/src/test-runner/mutant-run-result.ts
+++ b/packages/api/src/test-runner/mutant-run-result.ts
@@ -18,13 +18,13 @@ export interface TimeoutMutantRunResult {
 export interface KilledMutantRunResult {
   status: MutantRunStatus.Killed;
   /**
-   * The id of the test that killed this mutant
+   * An array with the ids of the tests that killed this mutant
    */
   killedBy: string[];
   /**
-   * The failure message that was reported by the test
+   * The failure message that was reported by first the test
    */
-  failureMessages: string[];
+  failureMessage: string;
   /**
    * The number of total tests ran in this test run.
    */

--- a/packages/api/src/test-runner/mutant-run-result.ts
+++ b/packages/api/src/test-runner/mutant-run-result.ts
@@ -20,7 +20,7 @@ export interface KilledMutantRunResult {
   /**
    * An array with the ids of the tests that killed this mutant
    */
-  killedBy: string[];
+  killedBy: string[] | string;
   /**
    * The failure message that was reported by first the test
    */

--- a/packages/api/src/test-runner/mutant-run-result.ts
+++ b/packages/api/src/test-runner/mutant-run-result.ts
@@ -20,11 +20,11 @@ export interface KilledMutantRunResult {
   /**
    * The id of the test that killed this mutant
    */
-  killedBy: string;
+  killedBy: string[];
   /**
    * The failure message that was reported by the test
    */
-  failureMessage: string;
+  failureMessages: string[];
   /**
    * The number of total tests ran in this test run.
    */

--- a/packages/api/src/test-runner/run-result-helpers.ts
+++ b/packages/api/src/test-runner/run-result-helpers.ts
@@ -11,7 +11,7 @@ export function determineHitLimitReached(hitCount: number | undefined, hitLimit:
   return;
 }
 
-export function toMutantRunResult(dryRunResult: DryRunResult): MutantRunResult {
+export function toMutantRunResult(dryRunResult: DryRunResult, reportAllKillers = false): MutantRunResult {
   switch (dryRunResult.status) {
     case DryRunStatus.Complete: {
       const failedTests = dryRunResult.tests.filter<FailedTestResult>((test): test is FailedTestResult => test.status === TestStatus.Failed);
@@ -21,7 +21,7 @@ export function toMutantRunResult(dryRunResult: DryRunResult): MutantRunResult {
         return {
           status: MutantRunStatus.Killed,
           failureMessage: failedTests[0].failureMessage,
-          killedBy: failedTests.map<string>((test) => test.id),
+          killedBy: reportAllKillers ? failedTests.map<string>((test) => test.id) : failedTests[0].id,
           nrOfTests,
         };
       } else {

--- a/packages/api/src/test-runner/run-result-helpers.ts
+++ b/packages/api/src/test-runner/run-result-helpers.ts
@@ -14,13 +14,14 @@ export function determineHitLimitReached(hitCount: number | undefined, hitLimit:
 export function toMutantRunResult(dryRunResult: DryRunResult): MutantRunResult {
   switch (dryRunResult.status) {
     case DryRunStatus.Complete: {
-      const killedBy = dryRunResult.tests.find<FailedTestResult>((test): test is FailedTestResult => test.status === TestStatus.Failed);
+      const failedTests = dryRunResult.tests.filter<FailedTestResult>((test): test is FailedTestResult => test.status === TestStatus.Failed);
       const nrOfTests = dryRunResult.tests.filter((test) => test.status !== TestStatus.Skipped).length;
-      if (killedBy) {
+
+      if (failedTests.length > 0) {
         return {
           status: MutantRunStatus.Killed,
-          failureMessage: killedBy.failureMessage,
-          killedBy: killedBy.id,
+          failureMessages: failedTests.map<string>((test) => test.failureMessage),
+          killedBy: failedTests.map<string>((test) => test.id),
           nrOfTests,
         };
       } else {

--- a/packages/api/src/test-runner/run-result-helpers.ts
+++ b/packages/api/src/test-runner/run-result-helpers.ts
@@ -20,7 +20,7 @@ export function toMutantRunResult(dryRunResult: DryRunResult): MutantRunResult {
       if (failedTests.length > 0) {
         return {
           status: MutantRunStatus.Killed,
-          failureMessages: failedTests.map<string>((test) => test.failureMessage),
+          failureMessage: failedTests[0].failureMessage,
           killedBy: failedTests.map<string>((test) => test.id),
           nrOfTests,
         };

--- a/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
+++ b/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
@@ -36,17 +36,24 @@ describe('runResultHelpers', () => {
       expect(actual).deep.eq(expected);
     });
 
-    it('should report a failed test as "killed"', () => {
-      const expected: MutantRunResult = { status: MutantRunStatus.Killed, failureMessage: 'expected foo to be bar', killedBy: '42', nrOfTests: 3 };
-      const actual = toMutantRunResult({
-        status: DryRunStatus.Complete,
-        tests: [
-          { status: TestStatus.Success, id: 'success1', name: 'success1', timeSpentMs: 42 },
-          { status: TestStatus.Failed, id: '42', name: 'error', timeSpentMs: 42, failureMessage: 'expected foo to be bar' },
-          { status: TestStatus.Success, id: 'success2', name: 'success2', timeSpentMs: 42 },
-        ],
-      });
-      expect(actual).deep.eq(expected);
+    it('should report all failed tests as "killed"', () => {
+      const expected: MutantRunResult = {
+        status: MutantRunStatus.Killed,
+        failureMessage: 'expected foo to be bar',
+        killedBy: ['42', '43'],
+        nrOfTests: 4,
+      };
+      expect(
+        toMutantRunResult({
+          status: DryRunStatus.Complete,
+          tests: [
+            { status: TestStatus.Success, id: 'success1', name: 'success1', timeSpentMs: 42 },
+            { status: TestStatus.Failed, id: '42', name: 'error', timeSpentMs: 42, failureMessage: 'expected foo to be bar' },
+            { status: TestStatus.Failed, id: '43', name: 'error', timeSpentMs: 43, failureMessage: 'expected this to be that' },
+            { status: TestStatus.Success, id: 'success2', name: 'success2', timeSpentMs: 42 },
+          ],
+        })
+      ).deep.eq(expected);
     });
 
     it('should report only succeeded tests as "survived"', () => {
@@ -72,7 +79,7 @@ describe('runResultHelpers', () => {
     });
 
     it("should set nrOfTests with the amount of tests that weren't `skipped`", () => {
-      const expected: MutantRunResult = { nrOfTests: 2, failureMessage: '', killedBy: '1', status: MutantRunStatus.Killed };
+      const expected: MutantRunResult = { nrOfTests: 2, failureMessages: [''], killedBy: ['1'], status: MutantRunStatus.Killed };
       const actual = toMutantRunResult({
         status: DryRunStatus.Complete,
         tests: [

--- a/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
+++ b/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
@@ -79,7 +79,7 @@ describe('runResultHelpers', () => {
     });
 
     it("should set nrOfTests with the amount of tests that weren't `skipped`", () => {
-      const expected: MutantRunResult = { nrOfTests: 2, failureMessages: [''], killedBy: ['1'], status: MutantRunStatus.Killed };
+      const expected: MutantRunResult = { nrOfTests: 2, failureMessage: '', killedBy: ['1'], status: MutantRunStatus.Killed };
       const actual = toMutantRunResult({
         status: DryRunStatus.Complete,
         tests: [

--- a/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
+++ b/packages/api/test/unit/test_runner/run-result-helpers.spec.ts
@@ -36,24 +36,45 @@ describe('runResultHelpers', () => {
       expect(actual).deep.eq(expected);
     });
 
-    it('should report all failed tests as "killed"', () => {
+    it('should report all failed tests as "killed" when given the option', () => {
       const expected: MutantRunResult = {
         status: MutantRunStatus.Killed,
         failureMessage: 'expected foo to be bar',
         killedBy: ['42', '43'],
         nrOfTests: 4,
       };
-      expect(
-        toMutantRunResult({
+      const actual = toMutantRunResult(
+        {
           status: DryRunStatus.Complete,
           tests: [
             { status: TestStatus.Success, id: 'success1', name: 'success1', timeSpentMs: 42 },
             { status: TestStatus.Failed, id: '42', name: 'error', timeSpentMs: 42, failureMessage: 'expected foo to be bar' },
-            { status: TestStatus.Failed, id: '43', name: 'error', timeSpentMs: 43, failureMessage: 'expected this to be that' },
+            { status: TestStatus.Failed, id: '43', name: 'error', timeSpentMs: 42, failureMessage: 'expected this to be that' },
             { status: TestStatus.Success, id: 'success2', name: 'success2', timeSpentMs: 42 },
           ],
-        })
-      ).deep.eq(expected);
+        },
+        true
+      );
+      expect(actual).deep.eq(expected);
+    });
+
+    it('should report a single tests as "killed" by default', () => {
+      const expected: MutantRunResult = {
+        status: MutantRunStatus.Killed,
+        failureMessage: 'expected foo to be bar',
+        killedBy: '42',
+        nrOfTests: 4,
+      };
+      const actual = toMutantRunResult({
+        status: DryRunStatus.Complete,
+        tests: [
+          { status: TestStatus.Success, id: 'success1', name: 'success1', timeSpentMs: 42 },
+          { status: TestStatus.Failed, id: '42', name: 'error', timeSpentMs: 42, failureMessage: 'expected foo to be bar' },
+          { status: TestStatus.Failed, id: '43', name: 'error', timeSpentMs: 42, failureMessage: 'expected this to be that' },
+          { status: TestStatus.Success, id: 'success2', name: 'success2', timeSpentMs: 42 },
+        ],
+      });
+      expect(actual).deep.eq(expected);
     });
 
     it('should report only succeeded tests as "survived"', () => {
@@ -79,7 +100,7 @@ describe('runResultHelpers', () => {
     });
 
     it("should set nrOfTests with the amount of tests that weren't `skipped`", () => {
-      const expected: MutantRunResult = { nrOfTests: 2, failureMessage: '', killedBy: ['1'], status: MutantRunStatus.Killed };
+      const expected: MutantRunResult = { nrOfTests: 2, failureMessage: '', killedBy: '1', status: MutantRunStatus.Killed };
       const actual = toMutantRunResult({
         status: DryRunStatus.Complete,
         tests: [

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -66,7 +66,7 @@ export class MutationTestReportHelper {
           ...mutant,
           status: MutantStatus.Killed,
           testsCompleted: result.nrOfTests,
-          killedBy: result.killedBy,
+          killedBy: typeof result.killedBy === 'string' ? [result.killedBy] : result.killedBy,
           statusReason: result.failureMessage,
         });
       case MutantRunStatus.Timeout:

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -66,8 +66,8 @@ export class MutationTestReportHelper {
           ...mutant,
           status: MutantStatus.Killed,
           testsCompleted: result.nrOfTests,
-          killedBy: [result.killedBy],
-          statusReason: result.failureMessage,
+          killedBy: result.killedBy,
+          statusReason: result.failureMessages.join('\n'),
         });
       case MutantRunStatus.Timeout:
         return this.reportOne({

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -67,7 +67,7 @@ export class MutationTestReportHelper {
           status: MutantStatus.Killed,
           testsCompleted: result.nrOfTests,
           killedBy: result.killedBy,
-          statusReason: result.failureMessages.join('\n'),
+          statusReason: result.failureMessage,
         });
       case MutantRunStatus.Timeout:
         return this.reportOne({

--- a/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
+++ b/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
@@ -61,7 +61,7 @@ describe(`${CommandTestRunner.name} integration`, () => {
       const sut = createSut({ command: 'npm run mutant' });
       const result = await sut.mutantRun({ activeMutant: factory.mutant({ id: '42' /* 42 should fail */ }) });
       assertions.expectKilled(result);
-      expect(result.killedBy).deep.eq(['all']);
+      expect(result.killedBy).eq('all');
     });
   });
 

--- a/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
+++ b/packages/core/test/integration/command-test-runner/command-test-runner.it.spec.ts
@@ -61,7 +61,7 @@ describe(`${CommandTestRunner.name} integration`, () => {
       const sut = createSut({ command: 'npm run mutant' });
       const result = await sut.mutantRun({ activeMutant: factory.mutant({ id: '42' /* 42 should fail */ }) });
       assertions.expectKilled(result);
-      expect(result.killedBy).eq('all');
+      expect(result.killedBy).deep.eq(['all']);
     });
   });
 

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -83,6 +83,7 @@ describe(OptionsValidator.name, () => {
         timeoutMS: 5000,
         tsconfigFile: 'tsconfig.json',
         warnings: true,
+        disableBail: false,
       };
       expect(options).deep.eq(expectedOptions);
     });

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -514,7 +514,7 @@ describe(MutationTestReportHelper.name, () => {
         // Act
         const actual = sut.reportMutantRunResult(
           factory.mutantTestCoverage({ fileName: 'add.js' }),
-          factory.killedMutantRunResult({ killedBy: ['1'], nrOfTests: 42, failureMessages: ['foo should have been bar at line 1'] })
+          factory.killedMutantRunResult({ killedBy: ['1'], nrOfTests: 42, failureMessage: 'foo should have been bar at line 1' })
         );
 
         // Assert

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -514,7 +514,7 @@ describe(MutationTestReportHelper.name, () => {
         // Act
         const actual = sut.reportMutantRunResult(
           factory.mutantTestCoverage({ fileName: 'add.js' }),
-          factory.killedMutantRunResult({ killedBy: '1', nrOfTests: 42, failureMessage: 'foo should have been bar at line 1' })
+          factory.killedMutantRunResult({ killedBy: ['1'], nrOfTests: 42, failureMessages: ['foo should have been bar at line 1'] })
         );
 
         // Assert

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -514,13 +514,34 @@ describe(MutationTestReportHelper.name, () => {
         // Act
         const actual = sut.reportMutantRunResult(
           factory.mutantTestCoverage({ fileName: 'add.js' }),
-          factory.killedMutantRunResult({ killedBy: ['1'], nrOfTests: 42, failureMessage: 'foo should have been bar at line 1' })
+          factory.killedMutantRunResult({ killedBy: '1', nrOfTests: 42, failureMessage: 'foo should have been bar at line 1' })
         );
 
         // Assert
         const expected: Partial<MutantResult> = {
           status: MutantStatus.Killed,
           killedBy: ['1'],
+          testsCompleted: 42,
+          statusReason: 'foo should have been bar at line 1',
+        };
+        expect(actual).deep.include(expected);
+      });
+
+      it('should report a killed mutant when called with a KilledMutantRunResult with KilledBy as array', () => {
+        // Arrange
+        dryRunResult.tests.push(factory.failedTestResult({ id: '1', name: 'foo should be bar' }));
+        const sut = createSut();
+
+        // Act
+        const actual = sut.reportMutantRunResult(
+          factory.mutantTestCoverage({ fileName: 'add.js' }),
+          factory.killedMutantRunResult({ killedBy: ['1', '2'], nrOfTests: 42, failureMessage: 'foo should have been bar at line 1' })
+        );
+
+        // Assert
+        const expected: Partial<MutantResult> = {
+          status: MutantStatus.Killed,
+          killedBy: ['1', '2'],
           testsCompleted: 42,
           statusReason: 'foo should have been bar at line 1',
         };

--- a/packages/core/test/unit/test-runner/command-test-runner.spec.ts
+++ b/packages/core/test/unit/test-runner/command-test-runner.spec.ts
@@ -103,7 +103,7 @@ describe(CommandTestRunner.name, () => {
     it('should convert exit code 1 to a killed mutant', async () => {
       const result = await actMutantRun(createSut(), { exitCode: 1 });
       assertions.expectKilled(result);
-      expect(result.killedBy).eq('all');
+      expect(result.killedBy).deep.eq(['all']);
     });
   });
 

--- a/packages/core/test/unit/test-runner/command-test-runner.spec.ts
+++ b/packages/core/test/unit/test-runner/command-test-runner.spec.ts
@@ -103,7 +103,7 @@ describe(CommandTestRunner.name, () => {
     it('should convert exit code 1 to a killed mutant', async () => {
       const result = await actMutantRun(createSut(), { exitCode: 1 });
       assertions.expectKilled(result);
-      expect(result.killedBy).deep.eq(['all']);
+      expect(result.killedBy).eq('all');
     });
   });
 

--- a/packages/jest-runner/schema/jest-runner-options.json
+++ b/packages/jest-runner/schema/jest-runner-options.json
@@ -26,11 +26,6 @@
           "description": "Whether to run jest with the `--findRelatedTests` flag. When `true`, Jest will only run tests related to the mutated file per test. (See [_--findRelatedTests_](https://jestjs.io/docs/en/cli.html#findrelatedtests-spaceseparatedlistofsourcefiles)",
           "type": "boolean",
           "default": true
-        },
-        "enableBail": {
-          "description": "Whether to run jest with the `--bail` flag. When `true`, Jest stop testing after the first failing test, which boosts performance. (See [_--bail_](https://jestjs.io/docs/en/cli#--bail)",
-          "type": "boolean",
-          "default": true
         }
       },
       "additionalProperties": false

--- a/packages/jest-runner/src/jest-test-runner.ts
+++ b/packages/jest-runner/src/jest-test-runner.ts
@@ -140,7 +140,7 @@ export class JestTestRunner implements TestRunner {
         jestConfig: this.configForMutantRun(fileNameUnderTest),
         testNamePattern,
       });
-      return toMutantRunResult(dryRunResult);
+      return toMutantRunResult(dryRunResult, true);
     } finally {
       delete process.env[INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE];
     }

--- a/packages/jest-runner/src/jest-test-runner.ts
+++ b/packages/jest-runner/src/jest-test-runner.ts
@@ -80,7 +80,7 @@ export class JestTestRunner implements TestRunner {
     this.jestOptions = (options as JestRunnerOptionsWithStrykerOptions).jest;
     // Get jest configuration from stryker options and assign it to jestConfig
     const configFromFile = configLoader.loadConfig();
-    this.jestConfig = this.mergeConfigSettings(configFromFile, this.jestOptions || {});
+    this.jestConfig = this.mergeConfigSettings(configFromFile, (options as JestRunnerOptionsWithStrykerOptions) || {});
 
     // Get enableFindRelatedTests from stryker jest options or default to true
     this.enableFindRelatedTests = this.jestOptions.enableFindRelatedTests;
@@ -256,12 +256,13 @@ export class JestTestRunner implements TestRunner {
     return testResults;
   }
 
-  private mergeConfigSettings(configFromFile: jest.Config.InitialOptions, options: JestOptions): jest.Config.InitialOptions {
-    const config = (options.config ?? {}) as jest.Config.InitialOptions;
-    config.bail = options.enableBail;
+  private mergeConfigSettings(configFromFile: jest.Config.InitialOptions, options: JestRunnerOptionsWithStrykerOptions): jest.Config.InitialOptions {
+    const config = (options.jest.config ?? {}) as jest.Config.InitialOptions;
+    // when disableBail is false (by default) we tell jest to bail
+    config.bail = !options.disableBail;
     const stringify = (obj: unknown) => JSON.stringify(obj, null, 2);
     this.log.debug(
-      `Merging file-based config ${stringify(configFromFile)} 
+      `Merging file-based config ${stringify(configFromFile)}
       with custom config ${stringify(config)}
       and default (internal) stryker config ${stringify(JEST_OVERRIDE_OPTIONS)}`
     );

--- a/packages/jest-runner/test/helpers/producers.ts
+++ b/packages/jest-runner/test/helpers/producers.ts
@@ -13,7 +13,6 @@ export const createJestRunnerOptionsWithStrykerOptions = (overrides?: Partial<Je
 
 export const createJestOptions = (overrides?: Partial<JestOptions>): JestOptions => {
   return {
-    enableBail: true,
     enableFindRelatedTests: true,
     projectType: 'custom',
     ...overrides,

--- a/packages/jest-runner/test/integration/coverage-analysis.it.spec.ts
+++ b/packages/jest-runner/test/integration/coverage-analysis.it.spec.ts
@@ -103,7 +103,7 @@ describe('JestTestRunner coverage analysis integration', () => {
             })
           );
           assertions.expectKilled(result);
-          expect(result.killedBy).eq('Add should be able to recognize a negative number');
+          expect(result.killedBy).deep.eq(['Add should be able to recognize a negative number']);
           expect(result.nrOfTests).eq(1);
         });
 
@@ -242,7 +242,7 @@ describe('JestTestRunner coverage analysis integration', () => {
             })
           );
           assertions.expectKilled(result);
-          expect(result.killedBy).eq('Add should be able to recognize a negative number');
+          expect(result.killedBy).deep.eq(['Add should be able to recognize a negative number']);
           expect(result.nrOfTests).eq(1);
         });
 

--- a/packages/jest-runner/test/integration/file-under-test-outside-roots.it.spec.ts
+++ b/packages/jest-runner/test/integration/file-under-test-outside-roots.it.spec.ts
@@ -22,6 +22,6 @@ describe('jest with fileUnderTest outside of roots', () => {
     const sut = createSut({ enableFindRelatedTests: true });
     const actual = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '1' }), sandboxFileName: 'src/foo.js' }));
     assertions.expectKilled(actual);
-    expect(actual.killedBy).eq('foo should be 42');
+    expect(actual.killedBy).deep.eq(['foo should be 42']);
   });
 });

--- a/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
+++ b/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
@@ -121,7 +121,7 @@ describe(`${JestTestRunner.name} integration test`, () => {
 
       assertions.expectKilled(runResult);
       expect(runResult.killedBy).deep.eq(['Add should be able to add two numbers']);
-      expect(runResult.failureMessages[0]).contains('Expected: 7').contains('Received: -3');
+      expect(runResult.failureMessage).contains('Expected: 7').contains('Received: -3');
     });
 
     it('should let mutant 11 survive', async () => {

--- a/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
+++ b/packages/jest-runner/test/integration/jest-test-runner.it.spec.ts
@@ -120,8 +120,8 @@ describe(`${JestTestRunner.name} integration test`, () => {
       const runResult = await jestTestRunner.mutantRun(mutantRunOptions);
 
       assertions.expectKilled(runResult);
-      expect(runResult.killedBy).eq('Add should be able to add two numbers');
-      expect(runResult.failureMessage).contains('Expected: 7').contains('Received: -3');
+      expect(runResult.killedBy).deep.eq(['Add should be able to add two numbers']);
+      expect(runResult.failureMessages[0]).contains('Expected: 7').contains('Received: -3');
     });
 
     it('should let mutant 11 survive', async () => {

--- a/packages/jest-runner/test/unit/jest-test-runner.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-runner.spec.ts
@@ -38,7 +38,6 @@ describe(JestTestRunner.name, () => {
     options.jest = {
       enableFindRelatedTests: true,
       projectType: 'custom',
-      enableBail: true,
     };
     options.basePath = basePath;
 
@@ -96,8 +95,8 @@ describe(JestTestRunner.name, () => {
       );
     });
 
-    it('should set bail = false when enableBail is false', async () => {
-      options.jest.enableBail = false;
+    it('should set bail = false when disableBail is true', async () => {
+      options.disableBail = true;
       const sut = createSut();
       await sut.dryRun({ coverageAnalysis: 'off' });
       expect(jestTestAdapterMock.run).calledWithMatch(

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/.gitignore
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/package.json
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "name": "example-project",
+  "version": "0.0.0",
+  "description": "An instrumented test project with jest-jasmine2 as a test runner and node as test environment",
+  "jest": {
+    "moduleFileExtensions": ["js", "json", "jsx", "node"],
+    "testEnvironment": "node",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$",
+    "testRunner": "jest-jasmine2",
+    "testURL": "http://localhost",
+    "collectCoverage": true,
+    "verbose": true,
+    "bail": false,
+    "notify": true
+  }
+}

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Add.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Add.js
@@ -46,7 +46,15 @@ function stryMutAct_9fa48(id) {
   var ns = stryNS_9fa48();
 
   function isActive(id) {
-    return ns.activeMutant === id;
+    if (ns.activeMutant === id) {
+      if (ns.hitCount !== void 0 && ++ns.hitCount > ns.hitLimit) {
+        throw new Error('Stryker: Hit count limit reached (' + ns.hitCount + ')');
+      }
+
+      return true;
+    }
+
+    return false;
   }
 
   stryMutAct_9fa48 = isActive;

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Add.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Add.js
@@ -1,0 +1,63 @@
+// This file is generated with tasks/instrument-test-resources.js
+ function stryNS_9fa48() {
+  var g = new Function("return this")();
+  var ns = g.__stryker2__ || (g.__stryker2__ = {});
+
+  if (ns.activeMutant === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    ns.activeMutant = g.process.env.__STRYKER_ACTIVE_MUTANT__;
+  }
+
+  function retrieveNS() {
+    return ns;
+  }
+
+  stryNS_9fa48 = retrieveNS;
+  return retrieveNS();
+}
+
+stryNS_9fa48();
+
+function stryCov_9fa48() {
+  var ns = stryNS_9fa48();
+  var cov = ns.mutantCoverage || (ns.mutantCoverage = {
+    static: {},
+    perTest: {}
+  });
+
+  function cover() {
+    var c = cov.static;
+
+    if (ns.currentTestId) {
+      c = cov.perTest[ns.currentTestId] = cov.perTest[ns.currentTestId] || {};
+    }
+
+    var a = arguments;
+
+    for (var i = 0; i < a.length; i++) {
+      c[a[i]] = (c[a[i]] || 0) + 1;
+    }
+  }
+
+  stryCov_9fa48 = cover;
+  cover.apply(null, arguments);
+}
+
+function stryMutAct_9fa48(id) {
+  var ns = stryNS_9fa48();
+
+  function isActive(id) {
+    return ns.activeMutant === id;
+  }
+
+  stryMutAct_9fa48 = isActive;
+  return isActive(id);
+}
+
+exports.add = function (num1, num2) {
+  if (stryMutAct_9fa48("0")) {
+    {}
+  } else {
+    stryCov_9fa48("0");
+    return stryMutAct_9fa48("1") ? num1 - num2 : (stryCov_9fa48("1"), num1 + num2);
+  }
+};

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Multiply.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Multiply.js
@@ -46,7 +46,15 @@ function stryMutAct_9fa48(id) {
   var ns = stryNS_9fa48();
 
   function isActive(id) {
-    return ns.activeMutant === id;
+    if (ns.activeMutant === id) {
+      if (ns.hitCount !== void 0 && ++ns.hitCount > ns.hitLimit) {
+        throw new Error('Stryker: Hit count limit reached (' + ns.hitCount + ')');
+      }
+
+      return true;
+    }
+
+    return false;
   }
 
   stryMutAct_9fa48 = isActive;

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Multiply.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Multiply.js
@@ -1,0 +1,77 @@
+// This file is generated with tasks/instrument-test-resources.js
+ function stryNS_9fa48() {
+  var g = new Function("return this")();
+  var ns = g.__stryker2__ || (g.__stryker2__ = {});
+
+  if (ns.activeMutant === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    ns.activeMutant = g.process.env.__STRYKER_ACTIVE_MUTANT__;
+  }
+
+  function retrieveNS() {
+    return ns;
+  }
+
+  stryNS_9fa48 = retrieveNS;
+  return retrieveNS();
+}
+
+stryNS_9fa48();
+
+function stryCov_9fa48() {
+  var ns = stryNS_9fa48();
+  var cov = ns.mutantCoverage || (ns.mutantCoverage = {
+    static: {},
+    perTest: {}
+  });
+
+  function cover() {
+    var c = cov.static;
+
+    if (ns.currentTestId) {
+      c = cov.perTest[ns.currentTestId] = cov.perTest[ns.currentTestId] || {};
+    }
+
+    var a = arguments;
+
+    for (var i = 0; i < a.length; i++) {
+      c[a[i]] = (c[a[i]] || 0) + 1;
+    }
+  }
+
+  stryCov_9fa48 = cover;
+  cover.apply(null, arguments);
+}
+
+function stryMutAct_9fa48(id) {
+  var ns = stryNS_9fa48();
+
+  function isActive(id) {
+    return ns.activeMutant === id;
+  }
+
+  stryMutAct_9fa48 = isActive;
+  return isActive(id);
+}
+
+exports.multiply = function (num1, num2) {
+  if (stryMutAct_9fa48("2")) {
+    {}
+  } else {
+    stryCov_9fa48("2");
+
+    const add = require('./Add');
+
+    let result = 0;
+
+    for (let index = 0; stryMutAct_9fa48("5") ? index >= num1 : stryMutAct_9fa48("4") ? index <= num1 : stryMutAct_9fa48("3") ? false : (stryCov_9fa48("3", "4", "5"), index < num1); stryMutAct_9fa48("6") ? index-- : (stryCov_9fa48("6"), index++)) {
+      if (stryMutAct_9fa48("7")) {
+        {}
+      } else {
+        stryCov_9fa48("7");
+        result += add(result, num2);
+      }
+    }
+
+    return result;
+  }
+};

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/__tests__/AddSpec.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/__tests__/AddSpec.js
@@ -1,0 +1,16 @@
+var add = require('../Add').add;
+var addOne = require('../Add').addOne;
+var isNegativeNumber = require('../Add').isNegativeNumber;
+var negate = require('../Add').negate;
+
+describe('Add', function() {
+  it('should be able to add two numbers', function() {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = num1 + num2;
+
+    var actual = add(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/__tests__/MultiplySpec.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/__tests__/MultiplySpec.js
@@ -1,0 +1,13 @@
+var multiply = require('../Multiply').multiply;
+
+describe('Multiply', function () {
+  it('should be able to multiply two numbers', function () {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = 10;
+
+    var actual = multiply(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks/package.json
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "example-project",
+  "version": "0.0.0",
+  "description": "A test project with jest-jasmine2 as a test runner and node as test environment",
+  "jest": {
+    "moduleFileExtensions": ["js", "json", "jsx", "node"],
+    "testEnvironment": "node",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$",
+    "testURL": "http://localhost"
+  }
+}

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Add.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Add.js
@@ -1,0 +1,3 @@
+exports.add = function (num1, num2) {
+  return num1 + num2;
+};

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Multiply.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Multiply.js
@@ -1,0 +1,8 @@
+exports.multiply = function (num1, num2) {
+  const add = require('./Add');
+  let result = 0;
+  for (let index = 0; index < num1; index++) {
+    result += add(result, num2);
+  }
+  return result;
+};

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/__tests__/AddSpec.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/__tests__/AddSpec.js
@@ -1,0 +1,16 @@
+var add = require('../Add').add;
+var addOne = require('../Add').addOne;
+var isNegativeNumber = require('../Add').isNegativeNumber;
+var negate = require('../Add').negate;
+
+describe('Add', function () {
+  it('should be able to add two numbers', function () {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = num1 + num2;
+
+    var actual = add(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/__tests__/MultiplySpec.js
+++ b/packages/jest-runner/testResources/jasmine2-node-no-mocks/src/__tests__/MultiplySpec.js
@@ -1,0 +1,13 @@
+var multiply = require('../Multiply').multiply;
+
+describe('Multiply', function () {
+  it('should be able to multiply two numbers', function () {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = 10;
+
+    var actual = multiply(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -283,7 +283,7 @@ export const timeoutDryRunResult = factoryMethod<TimeoutDryRunResult>(() => ({
 export const killedMutantRunResult = factoryMethod<KilledMutantRunResult>(() => ({
   status: MutantRunStatus.Killed,
   killedBy: ['spec1'],
-  failureMessages: ['foo should be bar'],
+  failureMessage: 'foo should be bar',
   nrOfTests: 1,
 }));
 

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -282,8 +282,8 @@ export const timeoutDryRunResult = factoryMethod<TimeoutDryRunResult>(() => ({
 
 export const killedMutantRunResult = factoryMethod<KilledMutantRunResult>(() => ({
   status: MutantRunStatus.Killed,
-  killedBy: 'spec1',
-  failureMessage: 'foo should be bar',
+  killedBy: ['spec1'],
+  failureMessages: ['foo should be bar'],
   nrOfTests: 1,
 }));
 

--- a/tasks/instrument-test-resources.js
+++ b/tasks/instrument-test-resources.js
@@ -27,6 +27,10 @@ async function main() {
     './packages/jest-runner/testResources/jasmine2-node/src/Add.js': './packages/jest-runner/testResources/jasmine2-node-instrumented/src/Add.js',
     './packages/jest-runner/testResources/jasmine2-node/src/Circle.js': './packages/jest-runner/testResources/jasmine2-node-instrumented/src/Circle.js',
   },  '__stryker2__')
+  await instrument([
+    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Add.js',
+    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Multiply.js',
+  ], './packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src',  '__stryker2__')
   await instrument({
     './packages/cucumber-runner/testResources/example/src/calculator.js': './packages/cucumber-runner/testResources/example-instrumented/src/calculator.js',
     './packages/cucumber-runner/testResources/example/src/calculator-static.js': './packages/cucumber-runner/testResources/example-instrumented/src/calculator-static.js',
@@ -34,9 +38,9 @@ async function main() {
 }
 
 /**
- * 
- * @param {object} fromTo 
- * @param {'__stryker__' | '__stryker2__'} globalNamespace 
+ *
+ * @param {object} fromTo
+ * @param {'__stryker__' | '__stryker2__'} globalNamespace
  */
 async function instrument(fromTo, globalNamespace = INSTRUMENTER_CONSTANTS.NAMESPACE) {
   const files = Object.keys(fromTo).map(fileName => new File(fileName, fs.readFileSync(fileName)));
@@ -44,7 +48,7 @@ async function instrument(fromTo, globalNamespace = INSTRUMENTER_CONSTANTS.NAMES
   out.files.forEach(file => {
     const toFileName = fromTo[file.name];
     fs.writeFileSync(toFileName, `// This file is generated with ${path.relative(process.cwd(), __filename)}\n ${file.textContent.replace(new RegExp(INSTRUMENTER_CONSTANTS.NAMESPACE, 'g'), globalNamespace)}`);
-    
+
     console.log(`✅ ${toFileName}`);
   });
 }

--- a/tasks/instrument-test-resources.js
+++ b/tasks/instrument-test-resources.js
@@ -27,10 +27,10 @@ async function main() {
     './packages/jest-runner/testResources/jasmine2-node/src/Add.js': './packages/jest-runner/testResources/jasmine2-node-instrumented/src/Add.js',
     './packages/jest-runner/testResources/jasmine2-node/src/Circle.js': './packages/jest-runner/testResources/jasmine2-node-instrumented/src/Circle.js',
   },  '__stryker2__')
-  await instrument([
-    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Add.js',
-    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Multiply.js',
-  ], './packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src',  '__stryker2__')
+  await instrument({
+    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Add.js': './packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Add.js',
+    './packages/jest-runner/testResources/jasmine2-node-no-mocks/src/Multiply.js': './packages/jest-runner/testResources/jasmine2-node-no-mocks-instrumented/src/Multiply.js',
+  }, '__stryker2__')
   await instrument({
     './packages/cucumber-runner/testResources/example/src/calculator.js': './packages/cucumber-runner/testResources/example-instrumented/src/calculator.js',
     './packages/cucumber-runner/testResources/example/src/calculator-static.js': './packages/cucumber-runner/testResources/example-instrumented/src/calculator-static.js',


### PR DESCRIPTION
As discussed in #2996 and #3012 this PR enables the user to set a `disableBail` option to collect all tests killing a mutant.

Notes on the implementation:
1. Initially only implemented for jest. The rest of the test runners should continue to work without changes
1. I deleted the `enableBail` option from `jest-runner-options.json`. I figured since this new `disableBail` option at the striker level it made no sense to keep it. It might be necessary to do the same for all test helpers
1. We only track the first error message of the first failing test. 

To be done:
- [ ] In the integration tests, jest doesn't bail and always report two tests killing a mutant, although I am sure ([and the tests confirm](https://github.com/stryker-mutator/stryker-js/pull/3061/files#diff-45feb2b206aba6659dc47f3a6f20a3449a6f5720f231929f464bf63d33cd5cefR97)) I'm telling Jest to run with `bail = true`. I am not sure what to do about this or if this is a problem with my implementation.
- [ ] enableBail should be deprecated, not removed.
- [ ] merge jasmine2-node-no-mocks into jasmine2-node
- [ ] add disableBail to the RunOptions (for both DryRunOptions and MutantRunOptions)