### PR TITLE
fix(ProgressReporter): don't render when there are no valid mutants to render

### DIFF
--- a/packages/core/src/reporters/progress-reporter.ts
+++ b/packages/core/src/reporters/progress-reporter.ts
@@ -38,6 +38,8 @@ export class ProgressBarReporter extends ProgressKeeper {
   }
 
   private render(renderObj: Record<string, unknown>): void {
-    this.progressBar?.render(renderObj);
+    if (this.progressBar?.total) {
+      this.progressBar.render(renderObj);
+    }
   }
 }

--- a/packages/core/test/unit/reporters/progress-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/progress-reporter.spec.ts
@@ -94,6 +94,16 @@ describe(ProgressBarReporter.name, () => {
       progressBarTickTokens = { total: 3, tested: 1, survived: 1 };
       expect(progressBar.tick).calledWithMatch(progressBarTickTokens);
     });
+
+    it('should not render the ProgressBar if all mutants have status "NoCoverage" or are static', () => {
+      const noCoverageResult = { coveredBy: undefined, static: false };
+      mutants = [factory.mutantTestCoverage(noCoverageResult), factory.mutantTestCoverage({ static: true })];
+      sut.onAllMutantsMatchedWithTests(mutants);
+
+      sut.onMutantTested(factory.mutantResult(noCoverageResult));
+
+      expect(progressBar.render).to.not.have.been.called;
+    });
   });
 
   describe('ProgressBar estimated time for 3 mutants', () => {


### PR DESCRIPTION
Fixes #3154 