### PR TITLE
Fix typo in disable-mutants docs

### DIFF
--- a/docs/disable-mutants.md
+++ b/docs/disable-mutants.md
@@ -166,7 +166,7 @@ Disable all mutators for an entire file, but restore the EqualityOperator for 1 
 ```js
 // Stryker disable all
 function max(a, b) {
-  // Stryker restore EqualityOperator
+  // Stryker restore next-line EqualityOperator
   return a < b ? b : a;
 }
 ```


### PR DESCRIPTION
The line above says "restore the EqualityOperator for 1 line:", so I guess the "next-line" keyword should be used.