### PR TITLE
test(placers): hard code placer names in test descriptions

### DIFF
--- a/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
@@ -8,7 +8,7 @@ import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 import { Mutant } from '../../../src/mutant';
 import { createMutant } from '../../helpers/factories';
 
-describe(expressionMutantPlacer.name, () => {
+describe('expressionMutantPlacer', () => {
   it('should have the correct name', () => {
     expect(expressionMutantPlacer.name).eq('expressionMutantPlacer');
   });

--- a/packages/instrumenter/test/unit/mutant-placers/statement-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/statement-mutant-placer.spec.ts
@@ -8,7 +8,7 @@ import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 import { Mutant } from '../../../src/mutant';
 import { createMutant } from '../../helpers/factories';
 
-describe(statementMutantPlacer.name, () => {
+describe('statementMutantPlacer', () => {
   it('should have the correct name', () => {
     expect(statementMutantPlacer.name).eq('statementMutantPlacer');
   });

--- a/packages/instrumenter/test/unit/mutant-placers/switch-case-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/switch-case-mutant-placer.spec.ts
@@ -7,7 +7,7 @@ import { switchCaseMutantPlacer as sut } from '../../../src/mutant-placers/switc
 import { createMutant } from '../../helpers/factories';
 import { findNodePath, parseJS } from '../../helpers/syntax-test-helpers';
 
-describe(sut.name, () => {
+describe('switchCaseMutantPlacer', () => {
   it('should have the correct name', () => {
     expect(sut.name).eq('switchCaseMutantPlacer');
   });


### PR DESCRIPTION
Hard-code the placer names in test `describe` functions, so the string mutator cannot impact the test names.

Fixes #3168