### PR TITLE
feat(checkers): allow custom checker node args

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,24 @@ Config file: `"buildCommand": 'npm run build'`
 Configure a build command to run after mutating the code, but before mutants are tested. This is generally used to transpile your code before testing.
 Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like `babel/register` or `ts-node`.
 
+### `checkers` [`string[]`]
+
+Default: `[]`<br />
+Command line: `--checkers typescript`<br />
+Config file: `"checkers": ["typescript"]`
+
+Enable checker plugins here. A checker plugin will be invoked for each mutant before it is run in a test runner. It can check to see of a given mutant is valid, by for example validate that it won't result in a type error.
+
+See [typescript-checker](./typescript-checker.md) for an example of a checker plugin.
+
+### `checkerNodeArgs` [`string[]`]
+
+Default: `[]`<br />
+Command line: `--checkerNodeArgs "--inspect-brk --cpu-prof"`<br />
+Config file: `"checkerNodeArgs": ["--inspect-brk", "--cpu-prof"]`
+
+Configure arguments to be passed as exec arguments to the checker child process. For example, running Stryker with `--concurrency 1 --checkerNodeArgs "--inspect-brk"` will allow you to debug the checker child process. See `execArgv` of [`child_process.fork`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options).
+
 ### `cleanTempDir` [`boolean`]
 
 Default: `true`<br />

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -253,6 +253,14 @@
       },
       "default": []
     },
+    "checkerNodeArgs": {
+      "description": "Configure arguments to be passed as exec arguments to the checker child process(es). For example, running Stryker with `--concurrency 1 --checkerNodeArgs --inspect-brk` will allow you to debug the checker child process. See `execArgv` of [`child_process.fork`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "concurrency": {
       "description": "Set the concurrency of workers. Stryker will always run checkers and test runners in parallel by creating worker processes (note, not `worker_threads`). This defaults to `n-1` where `n` is the number of logical CPU cores available on your machine, unless `n <= 4`, in that case it uses `n`. This is a sane default for most use cases.",
       "type": "number"

--- a/packages/core/src/checker/checker-child-process-proxy.ts
+++ b/packages/core/src/checker/checker-child-process-proxy.ts
@@ -12,7 +12,15 @@ export class CheckerChildProcessProxy implements Checker, Disposable, Resource {
   private readonly childProcess: ChildProcessProxy<CheckerWorker>;
 
   constructor(options: StrykerOptions, loggingContext: LoggingClientContext) {
-    this.childProcess = ChildProcessProxy.create(require.resolve('./checker-worker'), loggingContext, options, {}, process.cwd(), CheckerWorker, []);
+    this.childProcess = ChildProcessProxy.create(
+      require.resolve('./checker-worker'),
+      loggingContext,
+      options,
+      {},
+      process.cwd(),
+      CheckerWorker,
+      options.checkerNodeArgs
+    );
   }
 
   public async dispose(): Promise<void> {

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -28,7 +28,7 @@ function deepOption<T extends string, R>(object: { [K in T]?: R }, key: T) {
 const list = createSplitter(',');
 
 function createSplitter(sep: string) {
-  return (val: string) => val.split(sep);
+  return (val: string) => val.split(sep).filter(Boolean);
 }
 
 function parseBoolean(val: string) {
@@ -85,6 +85,12 @@ export class StrykerCli {
         'Configure a build command to run after mutating the code, but before mutants are tested. This is generally used to transpile your code before testing.' +
           " Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like `babel/register` or `ts-node`."
       )
+      .option(
+        '--checkers <listOfCheckersOrEmptyString>',
+        'A comma separated list of checkers to use, for example --checkers typescript',
+        createSplitter(',')
+      )
+      .option('--checkerNodeArgs <listOfNodeArgs>', 'A list of node args to be passed to checker child processes.', createSplitter(' '))
       .option(
         `--coverageAnalysis <perTest|all|off>', 'The coverage analysis strategy you want to use. Default value: "${defaultValues.coverageAnalysis}"`
       )

--- a/packages/core/test/integration/checker/additional-checkers.ts
+++ b/packages/core/test/integration/checker/additional-checkers.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { Checker, CheckResult, CheckStatus } from '@stryker-mutator/api/check';
 import { Mutant } from '@stryker-mutator/api/core';
 import { declareClassPlugin, PluginKind } from '@stryker-mutator/api/plugin';
+import { factory } from '@stryker-mutator/test-helpers';
 
 class HealthyChecker implements Checker {
   public async init(): Promise<void> {
@@ -44,8 +45,23 @@ export class TwoTimesTheCharm implements Checker {
   }
 }
 
+export class VerifyTitle implements Checker {
+  public async init(): Promise<void> {
+    // Init
+  }
+
+  public async check(mutant: Mutant): Promise<CheckResult> {
+    if (mutant.fileName === process.title) {
+      return factory.checkResult({ status: CheckStatus.Passed });
+    } else {
+      return factory.checkResult({ status: CheckStatus.CompileError });
+    }
+  }
+}
+
 export const strykerPlugins = [
   declareClassPlugin(PluginKind.Checker, 'healthy', HealthyChecker),
   declareClassPlugin(PluginKind.Checker, 'crashing', CrashingChecker),
   declareClassPlugin(PluginKind.Checker, 'two-times-the-charm', TwoTimesTheCharm),
+  declareClassPlugin(PluginKind.Checker, 'verify-title', VerifyTitle),
 ];

--- a/packages/core/test/integration/checker/create-checker-factory.it.spec.ts
+++ b/packages/core/test/integration/checker/create-checker-factory.it.spec.ts
@@ -63,4 +63,13 @@ describe(`${createCheckerFactory.name} integration`, () => {
     const expected: CheckResult = { status: CheckStatus.Passed };
     expect(actual).deep.eq(expected);
   });
+
+  it('should provide the nodeArgs', async () => {
+    testInjector.options.checkerNodeArgs = ['--title=shouldProvideNodeArgs'];
+    await arrangeSut('verify-title');
+    const passed = await sut.check(factory.mutant({ fileName: 'shouldProvideNodeArgs' }));
+    const failed = await sut.check(factory.mutant({ fileName: 'somethingElse' }));
+    expect(passed).deep.eq(factory.checkResult({ status: CheckStatus.Passed }));
+    expect(failed).deep.eq(factory.checkResult({ status: CheckStatus.CompileError }));
+  });
 });

--- a/packages/core/test/unit/checker/checker-child-process-proxy.spec.ts
+++ b/packages/core/test/unit/checker/checker-child-process-proxy.spec.ts
@@ -1,0 +1,51 @@
+import { LogLevel } from '@stryker-mutator/api/core';
+import { testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CheckerChildProcessProxy } from '../../../src/checker/checker-child-process-proxy';
+import { CheckerWorker } from '../../../src/checker/checker-worker';
+import { ChildProcessProxy } from '../../../src/child-proxy/child-process-proxy';
+import { LoggingClientContext } from '../../../src/logging';
+
+describe(CheckerChildProcessProxy.name, () => {
+  let childProcessProxyCreateStub: sinon.SinonStub;
+  let loggingContext: LoggingClientContext;
+
+  beforeEach(() => {
+    childProcessProxyCreateStub = sinon.stub(ChildProcessProxy, 'create');
+    loggingContext = { port: 4200, level: LogLevel.Fatal };
+  });
+
+  function createSut(): CheckerChildProcessProxy {
+    return new CheckerChildProcessProxy(testInjector.options, loggingContext);
+  }
+
+  describe('constructor', () => {
+    it('should create the child process', () => {
+      createSut();
+      expect(childProcessProxyCreateStub).calledWith(
+        require.resolve('../../../src/checker/checker-worker'),
+        loggingContext,
+        testInjector.options,
+        {},
+        process.cwd(),
+        CheckerWorker,
+        []
+      );
+    });
+    it('should provide arguments', () => {
+      testInjector.options.checkerNodeArgs = ['foo', 'bar'];
+      createSut();
+      expect(childProcessProxyCreateStub).calledWith(
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        ['foo', 'bar']
+      );
+    });
+  });
+});

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -35,6 +35,7 @@ describe(OptionsValidator.name, () => {
         cleanTempDir: true,
         inPlace: false,
         ignorePatterns: [],
+        checkerNodeArgs: [],
         clearTextReporter: {
           allowColor: true,
           logTests: true,

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -31,6 +31,10 @@ describe(StrykerCli.name, () => {
       [['--ignorePatterns', 'foo.js,bar.js'], { ignorePatterns: ['foo.js', 'bar.js'] }],
       [['--buildCommand', 'npm run build'], { buildCommand: 'npm run build' }],
       [['-b', 'npm run build'], { buildCommand: 'npm run build' }],
+      [['--checkers', 'foo,bar'], { checkers: ['foo', 'bar'] }],
+      [['--checkers', 'foo'], { checkers: ['foo'] }],
+      [['--checkers', ''], { checkers: [] }],
+      [['--checkerNodeArgs', '--inspect=1337 --gc'], { checkerNodeArgs: ['--inspect=1337', '--gc'] }],
       [['--disableBail'], { disableBail: true }],
       [['--mutate', 'foo.js,bar.js'], { mutate: ['foo.js', 'bar.js'] }],
       [['--reporters', 'foo,bar'], { reporters: ['foo', 'bar'] }],
@@ -51,7 +55,7 @@ describe(StrykerCli.name, () => {
       [['--maxTestRunnerReuse', '3'], { maxTestRunnerReuse: 3 }],
     ];
     testCases.forEach(([args, expected]) => {
-      it(`should parse option "${args.join(' ')}" as ${JSON.stringify(expected)}"`, () => {
+      it(`should parse option "${args.map((arg) => (arg === '' ? "''" : arg)).join(' ')}" as ${JSON.stringify(expected)}"`, () => {
         arrangeActAssertConfigOption(args, expected);
       });
     });


### PR DESCRIPTION
Allow specifing of custom checker node arguments.

For example: `--checkerNodeArgs "--inspect-brk" --concurrency 1` will allow a developer to debug their checker plugin.
