### PR TITLE
docs: --mutate as an alternative to --files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,7 @@ Default: `undefined`<br />
 Command line: `[--files|-f] src/**/*.js,a.js,test/**/*.js`<br />
 Config file: `"files": ["src/**/*.js", "!src/**/index.js", "test/**/*.js"]`
 
-**DEPRECATED**. Please use [`ignorePatterns`](#ignorepatterns-string) instead.
+**DEPRECATED**. Please use [`ignorePatterns`](#ignorepatterns-string) and/or [mutate](#mutate-string) instead. 
 
 ### `ignorePatterns` [`string[]`]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,8 +167,8 @@ Default: `undefined`<br />
 Command line: `[--files|-f] src/**/*.js,a.js,test/**/*.js`<br />
 Config file: `"files": ["src/**/*.js", "!src/**/index.js", "test/**/*.js"]`
 
-**DEPRECATED**. Please use [`ignorePatterns`](#ignorepatterns-string) and/or [mutate](#mutate-string) instead. 
-
+**DEPRECATED**. Please use [`ignorePatterns`](#ignorepatterns-string) instead, or use [mutate](#mutate-string) to select which files to mutate. 
+ 
 ### `ignorePatterns` [`string[]`]
 
 Default: `[]`<br />


### PR DESCRIPTION
If you want to target a specific file (or files) for mutation, such as those that are staged in Git, the `--mutate` option works better than `--ignorePatterns`.