### PR TITLE
fix(instrumenter): don't mutate TS generics

### DIFF
--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -149,10 +149,10 @@ const tsTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.free
   'TSInterfaceDeclaration',
   'TSTypeAnnotation',
   'TSTypeAliasDeclaration',
-  'TSModuleDeclaration',
   'TSEnumDeclaration',
   'TSDeclareFunction',
   'TSTypeParameterInstantiation',
+  'TSTypeParameterDeclaration',
 ]);
 
 const flowTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.freeze([

--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -131,7 +131,8 @@ export function isTypeNode(path: NodePath): boolean {
     path.isTypeAnnotation() ||
     flowTypeAnnotationNodeTypes.includes(path.node.type) ||
     tsTypeAnnotationNodeTypes.includes(path.node.type) ||
-    isDeclareVariableStatement(path)
+    isDeclareVariableStatement(path) ||
+    isModuleNameAsStringLiteral(path)
   );
 }
 
@@ -142,6 +143,15 @@ export function isTypeNode(path: NodePath): boolean {
  */
 function isDeclareVariableStatement(path: NodePath): boolean {
   return path.isVariableDeclaration() && path.node.declare === true;
+}
+
+/**
+ * Determines whether or not a node is a string literal that is the name of a module.
+ * @example
+ * declare module "express" {};
+ */
+function isModuleNameAsStringLiteral(path: NodePath): boolean {
+  return path.isStringLiteral() && path.parentPath.isTSModuleDeclaration();
 }
 
 const tsTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.freeze([

--- a/packages/instrumenter/src/util/syntax-helpers.ts
+++ b/packages/instrumenter/src/util/syntax-helpers.ts
@@ -132,7 +132,7 @@ export function isTypeNode(path: NodePath): boolean {
     flowTypeAnnotationNodeTypes.includes(path.node.type) ||
     tsTypeAnnotationNodeTypes.includes(path.node.type) ||
     isDeclareVariableStatement(path) ||
-    isModuleNameAsStringLiteral(path)
+    isDeclareModule(path)
   );
 }
 
@@ -150,8 +150,8 @@ function isDeclareVariableStatement(path: NodePath): boolean {
  * @example
  * declare module "express" {};
  */
-function isModuleNameAsStringLiteral(path: NodePath): boolean {
-  return path.isStringLiteral() && path.parentPath.isTSModuleDeclaration();
+function isDeclareModule(path: NodePath): boolean {
+  return path.isTSModuleDeclaration() && (path.node.declare ?? false);
 }
 
 const tsTypeAnnotationNodeTypes: ReadonlyArray<types.Node['type']> = Object.freeze([

--- a/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
+++ b/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
@@ -32,7 +32,12 @@ describe('syntax-helpers', () => {
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should be false for module declarations', () => {
+    it('should identify TS module declarations', () => {
+      const input = findNodePath(parseTS('declare module "express" {}'), (p) => p.isTSModuleDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should be false for module (without `declare`)', () => {
       const input = findNodePath(parseTS('namespace A { }'), (p) => p.isTSModuleDeclaration());
       expect(syntaxHelpers.isTypeNode(input)).false;
     });
@@ -54,11 +59,6 @@ describe('syntax-helpers', () => {
 
     it('should identify TS generic type parameters declarations', () => {
       const input = findNodePath(parseTS('function foo<bar extends `${position} ${color}`>() { }'), (p) => p.isTSTypeParameterDeclaration());
-      expect(syntaxHelpers.isTypeNode(input)).true;
-    });
-
-    it('should identify TS module name string literals', () => {
-      const input = findNodePath(parseTS('declare module "express" {}'), (p) => p.isStringLiteral());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
   });

--- a/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
+++ b/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
@@ -12,48 +12,53 @@ describe('syntax-helpers', () => {
   });
 
   describe('isTypeNode', () => {
-    it('should identify type assertions ("as")', async () => {
+    it('should identify type assertions ("as")', () => {
       const input = findNodePath(parseTS('const foo = { bar: "baz" } as const'), (p) => p.isTSAsExpression());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify interface declarations', async () => {
+    it('should identify interface declarations', () => {
       const input = findNodePath(parseTS('interface Foo {}'), (p) => p.isTSInterfaceDeclaration());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify type annotations', async () => {
+    it('should identify type annotations', () => {
       const input = findNodePath(parseTS('const foo: bar = baz;'), (p) => p.isTSTypeAnnotation());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify type alias declarations', async () => {
+    it('should identify type alias declarations', () => {
       const input = findNodePath(parseTS('type Foo = "bar"'), (p) => p.isTSTypeAliasDeclaration());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should be false for module declarations', async () => {
+    it('should be false for module declarations', () => {
       const input = findNodePath(parseTS('namespace A { }'), (p) => p.isTSModuleDeclaration());
       expect(syntaxHelpers.isTypeNode(input)).false;
     });
 
-    it('should identify TS enum declarations', async () => {
+    it('should identify TS enum declarations', () => {
       const input = findNodePath(parseTS('enum A { B }'), (p) => p.isTSEnumDeclaration());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify TS declare function syntax', async () => {
+    it('should identify TS declare function syntax', () => {
       const input = findNodePath(parseTS('declare function foo(): void;'), (p) => p.isTSDeclareFunction());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify TS generic type parameter instantiations', async () => {
+    it('should identify TS generic type parameter instantiations', () => {
       const input = findNodePath(parseTS('foo<"test">()'), (p) => p.isTSTypeParameterInstantiation());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
 
-    it('should identify TS generic type parameters declarations', async () => {
+    it('should identify TS generic type parameters declarations', () => {
       const input = findNodePath(parseTS('function foo<bar extends `${position} ${color}`>() { }'), (p) => p.isTSTypeParameterDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify TS module name string literals', () => {
+      const input = findNodePath(parseTS('declare module "express" {}'), (p) => p.isStringLiteral());
       expect(syntaxHelpers.isTypeNode(input)).true;
     });
   });

--- a/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
+++ b/packages/instrumenter/test/unit/util/syntax-helpers.spec.ts
@@ -1,12 +1,60 @@
 import { expect } from 'chai';
 
 import * as syntaxHelpers from '../../../src/util/syntax-helpers';
+import { findNodePath, parseTS } from '../../helpers/syntax-test-helpers';
 
 describe('syntax-helpers', () => {
   describe('instrumentationBabelHeader', () => {
     it('should be immutable', () => {
       expect(syntaxHelpers.instrumentationBabelHeader).frozen;
       expect(syntaxHelpers.instrumentationBabelHeader[0].leadingComments).frozen;
+    });
+  });
+
+  describe('isTypeNode', () => {
+    it('should identify type assertions ("as")', async () => {
+      const input = findNodePath(parseTS('const foo = { bar: "baz" } as const'), (p) => p.isTSAsExpression());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify interface declarations', async () => {
+      const input = findNodePath(parseTS('interface Foo {}'), (p) => p.isTSInterfaceDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify type annotations', async () => {
+      const input = findNodePath(parseTS('const foo: bar = baz;'), (p) => p.isTSTypeAnnotation());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify type alias declarations', async () => {
+      const input = findNodePath(parseTS('type Foo = "bar"'), (p) => p.isTSTypeAliasDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should be false for module declarations', async () => {
+      const input = findNodePath(parseTS('namespace A { }'), (p) => p.isTSModuleDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).false;
+    });
+
+    it('should identify TS enum declarations', async () => {
+      const input = findNodePath(parseTS('enum A { B }'), (p) => p.isTSEnumDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify TS declare function syntax', async () => {
+      const input = findNodePath(parseTS('declare function foo(): void;'), (p) => p.isTSDeclareFunction());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify TS generic type parameter instantiations', async () => {
+      const input = findNodePath(parseTS('foo<"test">()'), (p) => p.isTSTypeParameterInstantiation());
+      expect(syntaxHelpers.isTypeNode(input)).true;
+    });
+
+    it('should identify TS generic type parameters declarations', async () => {
+      const input = findNodePath(parseTS('function foo<bar extends `${position} ${color}`>() { }'), (p) => p.isTSTypeParameterDeclaration());
+      expect(syntaxHelpers.isTypeNode(input)).true;
     });
   });
 });


### PR DESCRIPTION
Don't mutate generic declarations, like `{color} {position}` in

 ```ts
 function foo<T extends `{color} {position}`>() {
 }
 ```

Fixes #3253 