### PR TITLE
fix(config): `declarationMap` should disabled as well

### DIFF
--- a/packages/typescript-checker/src/tsconfig-helpers.ts
+++ b/packages/typescript-checker/src/tsconfig-helpers.ts
@@ -17,6 +17,7 @@ const NO_EMIT_OPTIONS_FOR_SINGLE_PROJECT: Readonly<Partial<ts.CompilerOptions>> 
   incremental: false, // incremental and composite off: https://github.com/microsoft/TypeScript/issues/36917
   composite: false,
   declaration: false,
+  declarationMap: false,
 });
 
 // When we're running in 'project references' mode, we need to enable declaration output

--- a/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
+++ b/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
@@ -54,6 +54,7 @@ describe('typescript-helpers', () => {
         incremental: false,
         composite: false,
         declaration: false,
+        declarationMap: false,
       });
       expect(
         JSON.parse(
@@ -65,6 +66,7 @@ describe('typescript-helpers', () => {
                   incremental: true,
                   composite: true,
                   declaration: true,
+                  declarationMap: false,
                 },
               },
             },
@@ -76,6 +78,7 @@ describe('typescript-helpers', () => {
         incremental: false,
         composite: false,
         declaration: false,
+        declarationMap: false,
       });
     });
 


### PR DESCRIPTION
Even user enabled is config in their `tsconfig.json` file, typescript compiler will throw exception below anyway. So it better to just disabled in adjustment config.

```
TS5069: Option 'declarationMap' cannot be specified without specifying option 'declaration' or option 'composite'.
```