### PR TITLE
Update guide

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -23,7 +23,7 @@ You may have to change some paths like the [mutate](../configuration.md#mutate-s
 {
   "testRunner": "jest",
   "jest": {
-    "projectType": "create-react-app",
+    "projectType": "create-react-app"
   }
 }
 ```
@@ -40,7 +40,7 @@ Configuration:
 {
   "testRunner": "jest",
   "jest": {
-    "projectType": "create-react-app",
+    "projectType": "create-react-app"
   },
   "checkers": ["typescript"],
   "tsconfigFile": "tsconfig.json"

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -7,7 +7,7 @@ Stryker supports React projects using Jest with both JSX and TSX code.
 
 ## JSX project
 
-Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/javascript-mutator @stryker-mutator/html-reporter`
+Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner`
 
 Recommended other packages:
 

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -15,38 +15,36 @@ Recommended other packages:
 
 ### Configuration
 
-After installing the recommended packages, create the `stryker.conf.js` file in your repository.
+After installing the recommended packages, create the `stryker.conf.json` file in your repository.
 The configuration below contains a good starting point for React projects.
-You may have to change some paths like the mutate array.
+You may have to change some paths like the [mutate](../configuration.md#mutate-string) array.
 
-Coverage analysis is unfortunately not supported as of right now.
-
-```js
-module.exports = function (config) {
-  config.set({
-    mutate: ['src/**/*.js?(x)', '!src/**/*@(.test|.spec|Spec).js?(x)'],
-    mutator: 'javascript',
-    testRunner: 'jest',
-    reporter: ['progress', 'clear-text', 'html'],
-    coverageAnalysis: 'off',
-    jest: {
-      project: 'react',
-    },
-  });
-};
+```json
+{
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "create-react-app",
+  }
+}
 ```
 
 ## TSX projects
 
 For projects using TypeScript and TSX, you can follow the JSX guide but with a few differences:
 
-Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/typescript @stryker-mutator/html-reporter`
+Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/typescript-checker`
 
 Configuration:
 
-```js
-mutate: ['src/**/*.ts?(x)', '!src/**/*@(.test|.spec|Spec).ts?(x)'],
-mutator: 'typescript',
+```json
+{
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "create-react-app",
+  },
+  "checkers": ["typescript"],
+  "tsconfigFile": "tsconfig.json"
+}
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
The @stryker-mutator/html-reporter package is a stub package. The html reporter is now included with @stryker-mutator/core. There is no need to install the @stryker-mutator/html-reporter package. Mutator plugins are no longer needed in Stryker@^4.0, so remove "@stryker-mutator/javascript-mutator" from devDependencies.