### PR TITLE
feat(instrumenter/mutators): Implement missing MethodExpression

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -7,7 +7,7 @@ Stryker supports React projects using Jest with both JSX and TSX code.
 
 ## JSX project
 
-Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/javascript-mutator @stryker-mutator/html-reporter`
+Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner`
 
 Recommended other packages:
 
@@ -15,38 +15,36 @@ Recommended other packages:
 
 ### Configuration
 
-After installing the recommended packages, create the `stryker.conf.js` file in your repository.
+After installing the recommended packages, create the `stryker.conf.json` file in your repository.
 The configuration below contains a good starting point for React projects.
-You may have to change some paths like the mutate array.
+You may have to change some paths like the [mutate](../configuration.md#mutate-string) array.
 
-Coverage analysis is unfortunately not supported as of right now.
-
-```js
-module.exports = function (config) {
-  config.set({
-    mutate: ['src/**/*.js?(x)', '!src/**/*@(.test|.spec|Spec).js?(x)'],
-    mutator: 'javascript',
-    testRunner: 'jest',
-    reporter: ['progress', 'clear-text', 'html'],
-    coverageAnalysis: 'off',
-    jest: {
-      project: 'react',
-    },
-  });
-};
+```json
+{
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "create-react-app"
+  }
+}
 ```
 
 ## TSX projects
 
 For projects using TypeScript and TSX, you can follow the JSX guide but with a few differences:
 
-Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/typescript @stryker-mutator/html-reporter`
+Recommended stryker packages: `npm i -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutator/typescript-checker`
 
 Configuration:
 
-```js
-mutate: ['src/**/*.ts?(x)', '!src/**/*@(.test|.spec|Spec).ts?(x)'],
-mutator: 'typescript',
+```json
+{
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "create-react-app"
+  },
+  "checkers": ["typescript"],
+  "tsconfigFile": "tsconfig.json"
+}
 ```
 
 ## Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -10633,9 +10633,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19500,9 +19500,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uglify-js": {

--- a/packages/typescript-checker/src/tsconfig-helpers.ts
+++ b/packages/typescript-checker/src/tsconfig-helpers.ts
@@ -60,6 +60,13 @@ export function overrideOptions(parsedConfig: { config?: any }, useBuildMode: bo
       ...(useBuildMode ? LOW_EMIT_OPTIONS_FOR_PROJECT_REFERENCES : NO_EMIT_OPTIONS_FOR_SINGLE_PROJECT),
     },
   };
+
+  if (!useBuildMode && config.declarationDir !== undefined && config.declarationDir !== null) {
+    // because composite and/or declaration was disabled in non-build mode, we have to disable declarationDir as well
+    // otherwise, error TS5069: Option 'declarationDir' cannot be specified without specifying option 'declaration' or option 'composite'.
+    delete config.declarationDir;
+  }
+
   return JSON.stringify(config);
 }
 

--- a/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
+++ b/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
@@ -82,6 +82,59 @@ describe('typescript-helpers', () => {
       });
     });
 
+    it('should remove --declarationDir options when `--build` mode is off', () => {
+      expect(
+        JSON.parse(
+          overrideOptions(
+            {
+              config: {
+                compilerOptions: {
+                  noEmit: false,
+                  incremental: true,
+                  composite: true,
+                  declaration: true,
+                  declarationMap: false,
+                  declarationDir: '.',
+                },
+              },
+            },
+            false
+          )
+        ).compilerOptions
+      ).deep.include({
+        noEmit: true,
+        incremental: false,
+        composite: false,
+        declaration: false,
+        declarationMap: false,
+      });
+      expect(
+        JSON.parse(
+          overrideOptions(
+            {
+              config: {
+                compilerOptions: {
+                  noEmit: false,
+                  incremental: true,
+                  composite: true,
+                  declaration: true,
+                  declarationMap: false,
+                  declarationDir: '',
+                },
+              },
+            },
+            false
+          )
+        ).compilerOptions
+      ).deep.include({
+        noEmit: true,
+        incremental: false,
+        composite: false,
+        declaration: false,
+        declarationMap: false,
+      });
+    });
+
     it('should set --emitDeclarationOnly options when `--build` mode is on', () => {
       expect(JSON.parse(overrideOptions({ config: {} }, true)).compilerOptions).deep.include({
         emitDeclarationOnly: true,


### PR DESCRIPTION
This pull request contains the missing MethodExpressions implemented for:

enum MethodExpressions {
  'forEach' = 'map',
  'map' = 'forEach',
  'filter' = 'reduce',
  'reduce' = 'filter',
  'some' = 'every',
  'every' = 'some',
  'from' = 'assign',
  'assign' = 'from',
  'slice' = 'split',
  'split' = 'slice',
}