### PR TITLE
feat(esm): support esm in the mocha runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ stryker-tmp
 src-generated
 dist
 dist-test
+packages/*/testResources/tmp
 packages/report.*.json # Ignore heap dumps
 e2e/module/*.js
 e2e/module/*.map

--- a/e2e/test/esm/.mocharc.json
+++ b/e2e/test/esm/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "require": ["test/chai-setup.js"]
+}

--- a/e2e/test/esm/karma.conf.cjs
+++ b/e2e/test/esm/karma.conf.cjs
@@ -1,0 +1,15 @@
+module.exports = function(config) {
+  config.set({
+    frameworks: ['jasmine'],
+    files: [
+      { pattern: 'src/*.js', type: 'module' },
+      { pattern: 'test/math.spec.js', type: 'module' },
+    ],
+    reporters: ['progress'],
+    colors: true,
+    autoWatch: false,
+    browsers: ['ChromeHeadless'],
+    singleRun: true,
+    concurrency: Infinity
+  });
+}

--- a/e2e/test/esm/package.json
+++ b/e2e/test/esm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "esm",
+  "version": "1.0.0",
+  "description": "A e2e test for native ESM (ecma script modules)",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test:cucumber": "cucumber-js",
+    "test:mocha": "mocha",
+    "test:jasmine": "jasmine",
+    "test:karma": "karma start karma.conf.cjs",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "mocha --no-config --no-timeout --require ../../tasks/ts-node-register.js verify/*.cjs"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/e2e/test/esm/spec/support/jasmine.json
+++ b/e2e/test/esm/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "../test/*.spec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true,
+  "jsLoader": "import"
+}

--- a/e2e/test/esm/src/lib.js
+++ b/e2e/test/esm/src/lib.js
@@ -1,0 +1,16 @@
+export function add(a, b) {
+  return a + b;
+}
+
+const wave = '👋'; // static mutant
+export function greet(name) {
+  return `${wave} ${name}`;
+}
+
+export function inc(a) {
+  return ++a;
+}
+
+export function notCoveredSubtract(a, b) {
+  return a - b;
+}

--- a/e2e/test/esm/stryker.conf.json
+++ b/e2e/test/esm/stryker.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "concurrency": 1,
+  "reporters": ["json", "html"],
+  "disableBail": true,
+  "karma": {
+    "configFile": "karma.conf.js"
+  }
+}

--- a/e2e/test/esm/test/chai-setup.js
+++ b/e2e/test/esm/test/chai-setup.js
@@ -1,0 +1,8 @@
+import chai from 'chai';
+
+chai.util.addMethod(chai.Assertion.prototype, 'toEqual', function (expected) {
+  var obj = chai.util.flag(this, 'object');
+  new chai.Assertion(obj).to.deep.equal(expected);
+});
+
+global.expect = chai.expect;

--- a/e2e/test/esm/test/math.spec.js
+++ b/e2e/test/esm/test/math.spec.js
@@ -1,0 +1,15 @@
+import { add, greet, inc } from '../src/lib.js';
+
+describe('lib', () => {
+  it('should result in 42 for add 40 and 2', () => {
+    expect(add(40, 2)).toEqual(42);
+  });
+  it('should greet world', () => {
+    expect(greet('world')).toEqual('👋 world');
+  });
+
+  it('should result in 1 when inc 0', () => {
+    inc(0);
+    // Forget the expect 🙄 should survive
+  })
+});

--- a/e2e/test/esm/verify/verify.cjs
+++ b/e2e/test/esm/verify/verify.cjs
@@ -1,0 +1,18 @@
+// @ts-check
+const fs = require('fs');
+const { expectMetricsJsonToMatchSnapshot, execStryker } = require('../../../helpers');
+
+describe('esm', () => {
+  beforeEach(async () => {
+    await fs.promises.rm('reports', { recursive: true, force: true });
+  });
+
+  it('should be supported in the mocha runner', async () => {
+    execStryker('stryker run --testRunner mocha');
+    await assertStrykerRanCorrectly();
+  });
+});
+
+async function assertStrykerRanCorrectly() {
+  await expectMetricsJsonToMatchSnapshot();
+}

--- a/e2e/test/esm/verify/verify.cjs.snap
+++ b/e2e/test/esm/verify/verify.cjs.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`esm should be supported in the mocha runner 1`] = `
+Object {
+  "compileErrors": 0,
+  "ignored": 0,
+  "killed": 5,
+  "mutationScore": 55.55555555555556,
+  "mutationScoreBasedOnCoveredCode": 71.42857142857143,
+  "noCoverage": 2,
+  "runtimeErrors": 0,
+  "survived": 2,
+  "timeout": 0,
+  "totalCovered": 7,
+  "totalDetected": 5,
+  "totalInvalid": 0,
+  "totalMutants": 9,
+  "totalUndetected": 4,
+  "totalValid": 9,
+}
+`;

--- a/e2e/test/logging-e2e/custom-test-runner.js
+++ b/e2e/test/logging-e2e/custom-test-runner.js
@@ -1,0 +1,49 @@
+// @ts-check
+const { declareClassPlugin, PluginKind, tokens, commonTokens } = require('@stryker-mutator/api/plugin');
+const { DryRunStatus } = require('@stryker-mutator/api/test-runner');
+
+module.exports.strykerPlugins = [
+  declareClassPlugin(
+    PluginKind.TestRunner,
+    'custom',
+    class CustomTestRunner {
+      static inject = tokens(commonTokens.logger);
+
+      /**
+       *
+       * @param {import('@stryker-mutator/api/logging').Logger} logger
+       */
+      constructor(logger) {
+        this.logger = logger;
+      }
+
+      /**
+       * @returns {import('@stryker-mutator/api/test-runner').TestRunnerCapabilities}
+       */
+      capabilities() {
+        return { reloadEnvironment: true };
+      }
+      /**
+       * @param {import('@stryker-mutator/api/test-runner').DryRunOptions} options
+       * @returns {Promise<import('@stryker-mutator/api/test-runner').DryRunResult>}
+       */
+      async dryRun(options) {
+        if (this.logger.isTraceEnabled()) {
+          this.logger.trace('trace %s', JSON.stringify(options));
+        }
+        this.logger.debug('test debug');
+        this.logger.info('test info');
+        this.logger.warn('test warn');
+        this.logger.error('test error');
+        return { status: DryRunStatus.Complete, tests: [] };
+      }
+
+      /**
+       * @returns {Promise<import('@stryker-mutator/api/test-runner').MutantRunResult>}
+       */
+      mutantRun() {
+        throw new Error('Not implemented');
+      }
+    }
+  ),
+];

--- a/e2e/test/logging-e2e/package.json
+++ b/e2e/test/logging-e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "logging-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A module to perform an integration test",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "rimraf \"reports\" \"stryker.log\"",
+    "test": "stryker run || exit 0",
+    "posttest": "mocha --no-config --require ../../tasks/ts-node-register.js verify/*.ts"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/e2e/test/logging-e2e/src/add.js
+++ b/e2e/test/logging-e2e/src/add.js
@@ -1,3 +1,3 @@
-function(num1, num2) {
+function add(num1, num2) {
   return num1 + num2;
-};
+}

--- a/e2e/test/logging-e2e/src/add.js
+++ b/e2e/test/logging-e2e/src/add.js
@@ -1,0 +1,3 @@
+function(num1, num2) {
+  return num1 + num2;
+};

--- a/e2e/test/logging-e2e/stryker.conf.js
+++ b/e2e/test/logging-e2e/stryker.conf.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testRunner: 'custom',
+  concurrency: 1,
+  coverageAnalysis: 'perTest',
+  fileLogLevel: 'trace',
+  reporters: ['json', 'clear-text', 'html', 'event-recorder'],
+  plugins: [require.resolve('./custom-test-runner.js')]
+};

--- a/e2e/test/logging-e2e/verify/verify.ts
+++ b/e2e/test/logging-e2e/verify/verify.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import { expect } from 'chai';
+
+describe('Verify stryker passed logging correctly', () => {
+
+  const strykerLog = fs.readFileSync('./stryker.log', 'utf-8');
+  it('should have logged worker messages on trace level', () => {
+    expect(strykerLog).matches(/TRACE CustomTestRunner trace \{.*"disableBail":false.*\}/);
+    expect(strykerLog).contains('DEBUG CustomTestRunner test debug');
+    expect(strykerLog).contains('INFO CustomTestRunner test info');
+    expect(strykerLog).contains('WARN CustomTestRunner test warn');
+    expect(strykerLog).contains('ERROR CustomTestRunner test error');
+  });
+
+  it('should have logged the PID if the worker process and main process', () => {
+    const [,workerPid] = /\((\d+)\) ERROR CustomTestRunner test error/.exec(strykerLog);
+    const [,mainPid] = /\((\d+)\) INFO Instrumenter/.exec(strykerLog);
+    expect(parseInt(mainPid, 10)).gt(0);
+    expect(parseInt(workerPid, 10)).gt(0);
+    expect(workerPid).not.eq(mainPid);
+  });
+});

--- a/e2e/test/mocha-old-version/package-lock.json
+++ b/e2e/test/mocha-old-version/package-lock.json
@@ -1,432 +1,2542 @@
 {
-	"name": "mocha-old-version",
-	"version": "0.0.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "mocha-old-version",
-			"version": "0.0.0",
-			"license": "ISC",
-			"devDependencies": {
-				"mocha": "~5.2.0"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
-		"node_modules/commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"node_modules/glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.x"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true,
-			"bin": {
-				"he": "bin/he"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-			"dev": true,
-			"dependencies": {
-				"minimist": "0.0.8"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/mocha": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-stdout": "1.3.1",
-				"commander": "2.15.1",
-				"debug": "3.1.0",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.2",
-				"growl": "1.10.5",
-				"he": "1.1.1",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"supports-color": "5.4.0"
-			},
-			"bin": {
-				"_mocha": "bin/_mocha",
-				"mocha": "bin/mocha"
-			},
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		}
-	},
-	"dependencies": {
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
-		"mocha": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-			"dev": true,
-			"requires": {
-				"browser-stdout": "1.3.1",
-				"commander": "2.15.1",
-				"debug": "3.1.0",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.2",
-				"growl": "1.10.5",
-				"he": "1.1.1",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"supports-color": "5.4.0"
-			}
-		},
-		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		}
-	}
+  "name": "mocha-old-version",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mocha-old-version",
+      "version": "0.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "mocha": "7.2"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract/node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
+      "integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mocha": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
+      "integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
+    }
+  }
 }

--- a/e2e/test/mocha-old-version/package.json
+++ b/e2e/test/mocha-old-version/package.json
@@ -19,6 +19,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "mocha": "~5.2.0"
+    "mocha": "7.2"
   }
 }

--- a/e2e/test/mocha-old-version/verify/verify.ts
+++ b/e2e/test/mocha-old-version/verify/verify.ts
@@ -1,16 +1,7 @@
-import { promises as fsPromises } from 'fs';
-import { expect } from 'chai';
+import { expectMetricsJsonToMatchSnapshot } from '../../../helpers';
 
-describe('Verify stryker runs with mocha < 6', () => {
-
-  let strykerLog: string;
-
-  before(async () => {
-    strykerLog = await fsPromises.readFile('./stryker.log', 'utf8');
+describe('Verify stryker runs on the lowest supported mocha version', () => {
+  it('should have run correctly', () => {
+    expectMetricsJsonToMatchSnapshot();
   });
-
-  it('should warn about old mocha version', async () => {
-    expect(strykerLog).contains('DEPRECATED: Mocha < 6 detected. Please upgrade to at least Mocha version 6. Stryker will drop support for Mocha < 6 in V5');
-  });
-
 });

--- a/e2e/test/mocha-old-version/verify/verify.ts.snap
+++ b/e2e/test/mocha-old-version/verify/verify.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Verify stryker runs on the lowest supported mocha version should have run correctly 1`] = `
+Object {
+  "compileErrors": 0,
+  "ignored": 0,
+  "killed": 2,
+  "mutationScore": 100,
+  "mutationScoreBasedOnCoveredCode": 100,
+  "noCoverage": 0,
+  "runtimeErrors": 0,
+  "survived": 0,
+  "timeout": 0,
+  "totalCovered": 2,
+  "totalDetected": 2,
+  "totalInvalid": 0,
+  "totalMutants": 2,
+  "totalUndetected": 0,
+  "totalValid": 2,
+}
+`;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint . --resolve-plugins-relative-to . --ext .ts,.tsx",
     "lint:log": "eslint . --resolve-plugins-relative-to . --ext .ts,.tsx -f compact -o lint.log",
     "lint:fix": "eslint . --resolve-plugins-relative-to . --ext .ts,.tsx --fix",
-    "clean": "rimraf \"packages/*/{package-lock.json,.nyc_output,reports,coverage,src-generated,*.tsbuildinfo,.stryker-tmp,dist}\" \"packages/core/schema/stryker-schema.json\"",
+    "clean": "rimraf \"packages/*/{package-lock.json,.nyc_output,reports,coverage,src-generated,*.tsbuildinfo,.stryker-tmp,dist,testResources/tmp}\" \"packages/core/schema/stryker-schema.json\"",
     "generate": "node tasks/generate-json-schema-to-ts.js && node tasks/generate-mono-schema.js",
     "prebuild": "npm run generate",
     "build": "tsc -b && lerna run build",

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@stryker-mutator/api": "5.6.1",
     "@stryker-mutator/util": "5.6.1",
-    "glob": "~7.2.0",
     "tslib": "~2.3.0"
   },
   "devDependencies": {
@@ -49,6 +48,6 @@
   },
   "peerDependencies": {
     "@stryker-mutator/core": "~5.6.0",
-    "mocha": ">= 2.3.3 < 10"
+    "mocha": ">= 7.2 < 10"
   }
 }

--- a/packages/mocha-runner/src/lib-wrapper.ts
+++ b/packages/mocha-runner/src/lib-wrapper.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import Mocha from 'mocha';
+import Mocha, { type RootHookObject } from 'mocha';
 import glob from 'glob';
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
@@ -9,7 +9,7 @@ const mochaRoot = path.dirname(require.resolve('mocha/package.json'));
 
 let loadOptions: ((argv?: string[] | string) => Record<string, any> | undefined) | undefined;
 let collectFiles: ((options: MochaOptions) => string[]) | undefined;
-let handleRequires: ((requires?: string[]) => Promise<any>) | undefined;
+let handleRequires: ((requires?: string[]) => Promise<RootHookObject>) | undefined;
 let loadRootHooks: ((rootHooks: any) => Promise<any>) | undefined;
 
 try {

--- a/packages/mocha-runner/src/lib-wrapper.ts
+++ b/packages/mocha-runner/src/lib-wrapper.ts
@@ -1,44 +1,33 @@
 import path from 'path';
 
 import Mocha, { type RootHookObject } from 'mocha';
-import glob from 'glob';
 
 import { MochaOptions } from '../src-generated/mocha-runner-options';
 
 const mochaRoot = path.dirname(require.resolve('mocha/package.json'));
+// https://github.com/mochajs/mocha/blob/master/lib/cli/run-helpers.js#L132
 
-let loadOptions: ((argv?: string[] | string) => Record<string, any> | undefined) | undefined;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const runHelpers = require(`${mochaRoot}/lib/cli/run-helpers`);
+
 let collectFiles: ((options: MochaOptions) => string[]) | undefined;
-let handleRequires: ((requires?: string[]) => Promise<RootHookObject>) | undefined;
-let loadRootHooks: ((rootHooks: any) => Promise<any>) | undefined;
 
-try {
-  /*
-   * If read, object containing parsed arguments
-   * @since 6.0.0'
-   * @see https://mochajs.org/api/module-lib_cli_options.html#.loadOptions
-   */
+/*
+ * If read, object containing parsed arguments
+ * @since 6.0.0'
+ * @see https://mochajs.org/api/module-lib_cli_options.html#.loadOptions
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const loadOptions: (argv?: string[] | string) => Record<string, any> | undefined = require(`${mochaRoot}/lib/cli/options`).loadOptions;
+
+const handleRequires: (requires?: string[]) => Promise<RootHookObject> = runHelpers.handleRequires;
+const loadRootHooks: ((rootHooks: any) => Promise<any>) | undefined = runHelpers.loadRootHooks; // loadRootHooks is available since mocha v7.2 and removed again in 8.0
+
+collectFiles = runHelpers.handleFiles;
+if (!collectFiles) {
+  // Might be moved: https://github.com/mochajs/mocha/commit/15b96afccaf508312445770e3af1c145d90b28c6#diff-39b692a81eb0c9f3614247af744ab4a8
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  loadOptions = require(`${mochaRoot}/lib/cli/options`).loadOptions;
-} catch {
-  // Mocha < 6 doesn't support `loadOptions`
-}
-
-try {
-  // https://github.com/mochajs/mocha/blob/master/lib/cli/run-helpers.js#L132
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const runHelpers = require(`${mochaRoot}/lib/cli/run-helpers`);
-  collectFiles = runHelpers.handleFiles;
-  handleRequires = runHelpers.handleRequires; // handleRequires is available since mocha v7.2
-  loadRootHooks = runHelpers.loadRootHooks; // loadRootHooks is available since mocha v7.2
-
-  if (!collectFiles) {
-    // Might be moved: https://github.com/mochajs/mocha/commit/15b96afccaf508312445770e3af1c145d90b28c6#diff-39b692a81eb0c9f3614247af744ab4a8
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    collectFiles = require(`${mochaRoot}/lib/cli/collect-files`);
-  }
-} catch {
-  // Mocha < 6 doesn't support `handleFiles`
+  collectFiles = require(`${mochaRoot}/lib/cli/collect-files`);
 }
 
 /**
@@ -47,7 +36,6 @@ try {
 export class LibWrapper {
   public static Mocha = Mocha;
   public static require = require;
-  public static glob = glob.sync;
   public static loadOptions = loadOptions;
   public static collectFiles = collectFiles;
   public static handleRequires = handleRequires;

--- a/packages/mocha-runner/src/mocha-adapter.ts
+++ b/packages/mocha-runner/src/mocha-adapter.ts
@@ -5,6 +5,8 @@ import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
 import { PropertyPathBuilder } from '@stryker-mutator/util';
 
+import { RootHookObject } from 'mocha';
+
 import { MochaOptions, MochaRunnerOptions } from '../src-generated/mocha-runner-options';
 
 import { LibWrapper } from './lib-wrapper';
@@ -37,7 +39,7 @@ export class MochaAdapter {
     }
   }
 
-  public async handleRequires(requires: string[]): Promise<unknown> {
+  public async handleRequires(requires: string[]): Promise<RootHookObject | undefined> {
     this.log.trace('Resolving requires %s', requires);
     if (LibWrapper.handleRequires) {
       this.log.trace('Using `handleRequires`');
@@ -47,7 +49,7 @@ export class MochaAdapter {
           // `loadRootHooks` made a brief appearance in mocha 8, removed in mocha 8.2
           return await LibWrapper.loadRootHooks(rawRootHooks);
         } else {
-          return rawRootHooks.rootHooks;
+          return (rawRootHooks as { rootHooks: RootHookObject }).rootHooks;
         }
       }
     } else {

--- a/packages/mocha-runner/src/mocha-adapter.ts
+++ b/packages/mocha-runner/src/mocha-adapter.ts
@@ -3,16 +3,11 @@ import fs from 'fs';
 
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
-import { PropertyPathBuilder } from '@stryker-mutator/util';
-
 import { RootHookObject } from 'mocha';
 
-import { MochaOptions, MochaRunnerOptions } from '../src-generated/mocha-runner-options';
+import { MochaOptions } from '../src-generated/mocha-runner-options';
 
 import { LibWrapper } from './lib-wrapper';
-import { MochaTestRunner } from './mocha-test-runner';
-
-const DEFAULT_TEST_PATTERN = 'test/**/*.js';
 
 /**
  * A class that contains polyfills for different versions of mocha.
@@ -30,12 +25,15 @@ export class MochaAdapter {
   }
 
   public collectFiles(options: MochaOptions): string[] {
-    if (LibWrapper.collectFiles) {
-      this.log.debug("Mocha >= 6 detected. Using mocha's `collectFiles` to load files");
-      return this.mocha6DiscoverFiles(options);
-    } else {
-      this.log.debug('Mocha < 6 detected. Using custom logic to discover files');
-      return this.legacyDiscoverFiles(options);
+    const originalProcessExit = process.exit;
+    try {
+      // process.exit unfortunate side effect: https://github.com/mochajs/mocha/blob/07ea8763c663bdd3fe1f8446cdb62dae233f4916/lib/cli/run-helpers.js#L174
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      (process as any).exit = () => {};
+      const files = LibWrapper.collectFiles!(options);
+      return files;
+    } finally {
+      process.exit = originalProcessExit;
     }
   }
 
@@ -65,58 +63,5 @@ export class MochaAdapter {
       modulesToRequire.forEach(LibWrapper.require);
     }
     return undefined;
-  }
-
-  private mocha6DiscoverFiles(options: MochaOptions): string[] {
-    const originalProcessExit = process.exit;
-    try {
-      // process.exit unfortunate side effect: https://github.com/mochajs/mocha/blob/07ea8763c663bdd3fe1f8446cdb62dae233f4916/lib/cli/run-helpers.js#L174
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      (process as any).exit = () => {};
-      const files = LibWrapper.collectFiles!(options);
-      return files;
-    } finally {
-      process.exit = originalProcessExit;
-    }
-  }
-
-  private legacyDiscoverFiles(options: MochaOptions): string[] {
-    const globPatterns = this.mochaFileGlobPatterns(options);
-    const fileNames = new Set<string>();
-    globPatterns.forEach((patten) => LibWrapper.glob(patten).forEach((fileName) => fileNames.add(fileName)));
-    if (fileNames.size) {
-      this.log.debug(`Using files: ${JSON.stringify(fileNames, null, 2)}`);
-    } else {
-      this.log.debug(`Tried ${JSON.stringify(globPatterns, null, 2)} but did not result in any files.`);
-      throw new Error(
-        `[${MochaTestRunner.name}] No files discovered (tried pattern(s) ${JSON.stringify(
-          globPatterns,
-          null,
-          2
-        )}). Please specify the files (glob patterns) containing your tests in ${PropertyPathBuilder.create<MochaRunnerOptions>()
-          .prop('mochaOptions')
-          .prop('spec')} in your config file.`
-      );
-    }
-    return [...fileNames];
-  }
-
-  private mochaFileGlobPatterns(mochaOptions: MochaOptions): string[] {
-    // Use both `spec` as `files`
-    const globPatterns: string[] = [];
-    if (mochaOptions.spec) {
-      globPatterns.push(...mochaOptions.spec);
-    }
-
-    if (typeof mochaOptions.files === 'string') {
-      // `files` if for backward compat
-      globPatterns.push(mochaOptions.files);
-    } else if (mochaOptions.files) {
-      globPatterns.push(...mochaOptions.files);
-    }
-    if (!globPatterns.length) {
-      globPatterns.push(DEFAULT_TEST_PATTERN);
-    }
-    return globPatterns;
   }
 }

--- a/packages/mocha-runner/src/mocha-options-loader.ts
+++ b/packages/mocha-runner/src/mocha-options-loader.ts
@@ -55,9 +55,9 @@ export class MochaOptionsLoader {
 
   private loadMocha6Options(overrides: MochaOptions) {
     const args = serializeMochaLoadOptionsArguments(overrides);
-    const rawConfig = LibWrapper.loadOptions!(args) ?? {};
+    const rawConfig = LibWrapper.loadOptions(args) ?? {};
     if (this.log.isTraceEnabled()) {
-      this.log.trace(`Mocha: ${LibWrapper.loadOptions!.name}([${args.map((arg) => `'${arg}'`).join(',')}]) => ${JSON.stringify(rawConfig)}`);
+      this.log.trace(`Mocha: ${LibWrapper.loadOptions.name}([${args.map((arg) => `'${arg}'`).join(',')}]) => ${JSON.stringify(rawConfig)}`);
     }
     const options = filterConfig(rawConfig);
     return options;

--- a/packages/mocha-runner/src/mocha-test-runner.ts
+++ b/packages/mocha-runner/src/mocha-test-runner.ts
@@ -1,7 +1,7 @@
 import { InstrumenterContext, INSTRUMENTER_CONSTANTS, StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
-import { I, escapeRegExp, DirectoryRequireCache } from '@stryker-mutator/util';
+import { I, escapeRegExp } from '@stryker-mutator/util';
 
 import {
   TestRunner,
@@ -16,7 +16,7 @@ import {
   TestRunnerCapabilities,
 } from '@stryker-mutator/api/test-runner';
 
-import { MochaOptions } from '../src-generated/mocha-runner-options';
+import { Context, RootHookObject, Suite } from 'mocha';
 
 import { StrykerMochaReporter } from './stryker-mocha-reporter';
 import { MochaRunnerWithStrykerOptions } from './mocha-runner-with-stryker-options';
@@ -25,63 +25,86 @@ import { MochaOptionsLoader } from './mocha-options-loader';
 import { MochaAdapter } from './mocha-adapter';
 
 export class MochaTestRunner implements TestRunner {
-  public testFileNames?: string[];
-  public rootHooks: any;
-  public mochaOptions!: MochaOptions;
+  private mocha!: Mocha;
   private readonly instrumenterContext: InstrumenterContext;
+  private originalGrep?: string;
+  public beforeEach?: (context: Context) => void;
 
   public static inject = tokens(
     commonTokens.logger,
     commonTokens.options,
     pluginTokens.loader,
     pluginTokens.mochaAdapter,
-    pluginTokens.directoryRequireCache,
     pluginTokens.globalNamespace
   );
+  private loadedEnv = false;
   constructor(
     private readonly log: Logger,
     private readonly options: StrykerOptions,
     private readonly loader: I<MochaOptionsLoader>,
     private readonly mochaAdapter: I<MochaAdapter>,
-    private readonly requireCache: I<DirectoryRequireCache>,
     globalNamespace: typeof INSTRUMENTER_CONSTANTS.NAMESPACE | '__stryker2__'
   ) {
     StrykerMochaReporter.log = log;
     this.instrumenterContext = global[globalNamespace] ?? (global[globalNamespace] = {});
   }
 
-  public capabilities(): TestRunnerCapabilities {
-    return { reloadEnvironment: true };
+  public async capabilities(): Promise<TestRunnerCapabilities> {
+    return {
+      // Mocha directly uses `import`, so reloading files once they are loaded is impossible
+      reloadEnvironment: false,
+    };
   }
 
   public async init(): Promise<void> {
-    this.mochaOptions = this.loader.load(this.options as MochaRunnerWithStrykerOptions);
-    this.testFileNames = this.mochaAdapter.collectFiles(this.mochaOptions);
-    if (this.mochaOptions.require) {
-      if (this.mochaOptions.require.includes('esm')) {
+    const mochaOptions = this.loader.load(this.options as MochaRunnerWithStrykerOptions);
+    const testFileNames = this.mochaAdapter.collectFiles(mochaOptions);
+    let rootHooks: RootHookObject | undefined;
+    if (mochaOptions.require) {
+      if (mochaOptions.require.includes('esm')) {
         throw new Error(
           'Config option "mochaOptions.require" does not support "esm", please use `"testRunnerNodeArgs": ["--require", "esm"]` instead. See https://github.com/stryker-mutator/stryker-js/issues/3014 for more information.'
         );
       }
-      this.rootHooks = await this.mochaAdapter.handleRequires(this.mochaOptions.require);
+      rootHooks = await this.mochaAdapter.handleRequires(mochaOptions.require);
+    }
+    this.mocha = this.mochaAdapter.create({
+      reporter: StrykerMochaReporter as any,
+      timeout: false as any, // Mocha 5 doesn't support `0`
+      rootHooks,
+    });
+    this.mocha.cleanReferencesAfterRun(false);
+    testFileNames.forEach((fileName) => this.mocha.addFile(fileName));
+
+    this.setIfDefined(mochaOptions['async-only'], (asyncOnly) => asyncOnly && this.mocha.asyncOnly());
+    this.setIfDefined(mochaOptions.ui, this.mocha.ui);
+    this.setIfDefined(mochaOptions.grep, this.mocha.grep);
+    this.originalGrep = mochaOptions.grep;
+
+    // Bind beforeEach, so we can use that for per code coverage in dry run
+    const self = this;
+    this.mocha.suite.beforeEach(function (this: Context) {
+      self.beforeEach?.(this);
+    });
+  }
+
+  private setIfDefined<T>(value: T | undefined, operation: (input: T) => void) {
+    if (typeof value !== 'undefined') {
+      operation.apply(this.mocha, [value]);
     }
   }
 
   public async dryRun({ coverageAnalysis, disableBail }: DryRunOptions): Promise<DryRunResult> {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    let interceptor: (mocha: Mocha) => void = () => {};
     if (coverageAnalysis === 'perTest') {
-      interceptor = (mocha) => {
-        const self = this;
-        mocha.suite.beforeEach('StrykerIntercept', function () {
-          self.instrumenterContext.currentTestId = this.currentTest?.fullTitle();
-        });
+      this.beforeEach = (context) => {
+        this.instrumenterContext.currentTestId = context.currentTest?.fullTitle();
       };
     }
-    const runResult = await this.run(interceptor, disableBail);
+    const runResult = await this.run(disableBail);
     if (runResult.status === DryRunStatus.Complete && coverageAnalysis !== 'off') {
       runResult.mutantCoverage = this.instrumenterContext.mutantCoverage;
     }
+    delete this.beforeEach;
     return runResult;
   }
 
@@ -89,39 +112,21 @@ export class MochaTestRunner implements TestRunner {
     this.instrumenterContext.activeMutant = activeMutant.id;
     this.instrumenterContext.hitLimit = hitLimit;
     this.instrumenterContext.hitCount = hitLimit ? 0 : undefined;
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    let intercept: (mocha: Mocha) => void = () => {};
     if (testFilter) {
       const metaRegExp = testFilter.map((testId) => `(${escapeRegExp(testId)})`).join('|');
       const regex = new RegExp(metaRegExp);
-      intercept = (mocha) => {
-        mocha.grep(regex);
-      };
+      this.mocha.grep(regex);
+    } else {
+      this.setIfDefined(this.originalGrep, this.mocha.grep);
     }
-    const dryRunResult = await this.run(intercept, disableBail);
+    const dryRunResult = await this.run(disableBail);
     return toMutantRunResult(dryRunResult, true);
   }
 
-  public async run(intercept: (mocha: Mocha) => void, disableBail: boolean): Promise<DryRunResult> {
-    this.requireCache.clear();
-    const mocha = this.mochaAdapter.create({
-      reporter: StrykerMochaReporter as any,
-      bail: !disableBail,
-      timeout: false as any, // Mocha 5 doesn't support `0`
-      rootHooks: this.rootHooks,
-    } as Mocha.MochaOptions);
-    this.configure(mocha);
-    intercept(mocha);
-    this.addFiles(mocha);
+  public async run(disableBail: boolean): Promise<DryRunResult> {
+    setBail(!disableBail, this.mocha.suite);
     try {
-      await this.runMocha(mocha);
-      // Call `requireCache.record` before `mocha.dispose`.
-      // `Mocha.dispose` already deletes test files from require cache, but its important that they are recorded before that.
-      this.requireCache.record();
-      if ((mocha as any).dispose) {
-        // Since mocha 7.2
-        (mocha as any).dispose();
-      }
+      await this.runMocha();
       const reporter = StrykerMochaReporter.currentInstance;
       if (reporter) {
         const timeoutResult = determineHitLimitReached(this.instrumenterContext.hitCount, this.instrumenterContext.hitLimit);
@@ -147,31 +152,33 @@ export class MochaTestRunner implements TestRunner {
         status: DryRunStatus.Error,
       };
     }
+
+    function setBail(bail: boolean, suite: Suite) {
+      suite.bail(bail);
+      suite.suites.forEach((childSuite) => setBail(bail, childSuite));
+    }
   }
 
-  private runMocha(mocha: Mocha): Promise<void> {
-    return new Promise<void>((res) => {
-      mocha.run(() => res());
-    });
-  }
-
-  private addFiles(mocha: Mocha) {
-    this.testFileNames?.forEach((fileName) => {
-      mocha.addFile(fileName);
-    });
-  }
-
-  private configure(mocha: Mocha) {
-    const options = this.mochaOptions;
-
-    function setIfDefined<T>(value: T | undefined, operation: (input: T) => void) {
-      if (typeof value !== 'undefined') {
-        operation.apply(mocha, [value]);
+  public async dispose(): Promise<void> {
+    try {
+      this.mocha?.dispose();
+    } catch (err: any) {
+      if (err?.code !== 'ERR_MOCHA_INSTANCE_ALREADY_RUNNING') {
+        // Oops, didn't mean to catch this one
+        throw err;
       }
     }
+  }
 
-    setIfDefined(options['async-only'], (asyncOnly) => asyncOnly && mocha.asyncOnly());
-    setIfDefined(options.ui, mocha.ui);
-    setIfDefined(options.grep, mocha.grep);
+  private async runMocha(): Promise<void> {
+    if (!this.loadedEnv) {
+      // Loading files Async is needed to support native esm modules
+      // See https://mochajs.org/api/mocha#loadFilesAsync
+      await this.mocha.loadFilesAsync();
+      this.loadedEnv = true;
+    }
+    return new Promise<void>((res) => {
+      this.mocha.run(() => res());
+    });
   }
 }

--- a/packages/mocha-runner/src/mocha-test-runner.ts
+++ b/packages/mocha-runner/src/mocha-test-runner.ts
@@ -70,7 +70,7 @@ export class MochaTestRunner implements TestRunner {
     }
     this.mocha = this.mochaAdapter.create({
       reporter: StrykerMochaReporter as any,
-      timeout: false as any, // Mocha 5 doesn't support `0`
+      timeout: 0,
       rootHooks,
     });
     this.mocha.cleanReferencesAfterRun(false);

--- a/packages/mocha-runner/test/helpers/resolve-test-resource.ts
+++ b/packages/mocha-runner/test/helpers/resolve-test-resource.ts
@@ -8,3 +8,11 @@ export const resolveTestResource: typeof path.resolve = path.resolve.bind(
   '..' /* dist */,
   'testResources'
 );
+
+export const resolveTempTestResourceDirectory: typeof path.resolve = () => {
+  return path.resolve(__dirname, '..' /* helpers */, '..' /* test */, '..' /* dist */, 'testResources', 'tmp', `workDir${random()}`);
+};
+
+function random(): number {
+  return Math.ceil(Math.random() * 10000000);
+}

--- a/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
+++ b/packages/mocha-runner/test/integration/mocha-file-resolving.it.spec.ts
@@ -3,24 +3,18 @@ import { testInjector } from '@stryker-mutator/test-helpers';
 
 import { MochaOptionsLoader } from '../../src/mocha-options-loader';
 import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryker-options';
-import { createMochaTestRunnerFactory } from '../../src';
 import { resolveTestResource } from '../helpers/resolve-test-resource';
+import { MochaAdapter } from '../../src/mocha-adapter';
 
-describe('Mocha 6 file resolving integration', () => {
-  let options: MochaRunnerWithStrykerOptions;
-
-  beforeEach(() => {
-    options = testInjector.options as MochaRunnerWithStrykerOptions;
-    options.mochaOptions = {};
-  });
-
+describe('Mocha file resolving integration', () => {
   it('should resolve test files while respecting "files", "spec", "extension" and "exclude" properties', () => {
     const configLoader = createConfigLoader();
     process.chdir(resolveTestDir());
-    options.mochaOptions = configLoader.load(options);
-    const testRunner = createTestRunner();
-    testRunner.init();
-    expect((testRunner as any).testFileNames).deep.eq([
+    const options: MochaRunnerWithStrykerOptions = { ...testInjector.options, mochaOptions: {} };
+    const mochaOptions = configLoader.load(options);
+    const mochaAdapter = testInjector.injector.injectClass(MochaAdapter);
+    const files = mochaAdapter.collectFiles(mochaOptions);
+    expect(files).deep.eq([
       resolveTestDir('helpers/1.ts'),
       resolveTestDir('helpers/2.js'),
       resolveTestDir('specs/3.js'),
@@ -31,11 +25,6 @@ describe('Mocha 6 file resolving integration', () => {
   function createConfigLoader() {
     return testInjector.injector.injectClass(MochaOptionsLoader);
   }
-
-  function createTestRunner() {
-    return testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
-  }
-
   function resolveTestDir(fileName = '.') {
     return resolveTestResource('file-resolving', fileName);
   }

--- a/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
+++ b/packages/mocha-runner/test/integration/project-with-root-hooks.it.spec.ts
@@ -13,6 +13,10 @@ describe('Running a project with root hooks', () => {
     await sut.init();
   });
 
+  afterEach(async () => {
+    await sut.dispose();
+  });
+
   it('should have run the root hooks', async () => {
     const result = await sut.dryRun(factory.dryRunOptions({}));
     assertions.expectCompleted(result);

--- a/packages/mocha-runner/test/integration/qunit-sample.it.spec.ts
+++ b/packages/mocha-runner/test/integration/qunit-sample.it.spec.ts
@@ -28,16 +28,6 @@ describe('QUnit sample', () => {
       'Math should be able to recognize a negative number',
       'Math should be able to recognize that 0 is not a negative number',
     ]);
-  });
-
-  it('should not run tests when not configured with "qunit" ui', async () => {
-    testInjector.options.mochaOptions = createMochaOptions({
-      files: [resolveTestResource('qunit-sample', 'MyMathSpec.js')],
-    });
-    const sut = createSut();
-    await sut.init();
-    const actualResult = await sut.dryRun(factory.dryRunOptions());
-    assertions.expectCompleted(actualResult);
-    expect(actualResult.tests).lengthOf(0);
+    await sut.dispose();
   });
 });

--- a/packages/mocha-runner/test/integration/regession.it.spec.ts
+++ b/packages/mocha-runner/test/integration/regession.it.spec.ts
@@ -1,28 +1,35 @@
 import { FailedTestResult, TestStatus } from '@stryker-mutator/api/test-runner';
-import { assertions, factory, testInjector } from '@stryker-mutator/test-helpers';
+import { assertions, factory, fsPromisesCp, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
-import { createMochaTestRunnerFactory } from '../../src';
+import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';
 import { MochaRunnerWithStrykerOptions } from '../../src/mocha-runner-with-stryker-options';
-import { resolveTestResource } from '../helpers/resolve-test-resource';
+import { resolveTempTestResourceDirectory, resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('regression integration tests', () => {
   let options: MochaRunnerWithStrykerOptions;
+  let sut: MochaTestRunner;
 
   beforeEach(() => {
     options = testInjector.options as MochaRunnerWithStrykerOptions;
     options.mochaOptions = { 'no-config': true };
   });
 
+  afterEach(async () => {
+    await sut.dispose();
+  });
+
   describe('issue #2720', () => {
     beforeEach(async () => {
-      process.chdir(resolveTestResource('regression', 'issue-2720'));
+      const tmpDir = resolveTempTestResourceDirectory();
+      await fsPromisesCp(resolveTestResource('regression', 'issue-2720'), tmpDir, { recursive: true });
+      process.chdir(tmpDir);
     });
 
     it('should have report correct failing test when "beforeEach" fails', async () => {
       // Arrange
       options.mochaOptions.spec = ['failing-before-each'];
-      const sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
+      sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
       await sut.init();
 
       // Act
@@ -42,7 +49,7 @@ describe('regression integration tests', () => {
     it('should have report correct failing test when "afterEach" fails', async () => {
       // Arrange
       options.mochaOptions.spec = ['failing-after-each'];
-      const sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
+      sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
       await sut.init();
 
       // Act

--- a/packages/mocha-runner/test/integration/sample-project-instrumented.it.spec.ts
+++ b/packages/mocha-runner/test/integration/sample-project-instrumented.it.spec.ts
@@ -1,22 +1,28 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
+import path from 'path';
+
+import { testInjector, factory, assertions, fsPromisesCp } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import { MutantCoverage } from '@stryker-mutator/api/core';
 
 import { MochaTestRunner, createMochaTestRunnerFactory } from '../../src';
 import { createMochaOptions } from '../helpers/factories';
-import { resolveTestResource } from '../helpers/resolve-test-resource';
+import { resolveTempTestResourceDirectory, resolveTestResource } from '../helpers/resolve-test-resource';
 
 describe('Running an instrumented project', () => {
   let sut: MochaTestRunner;
 
   beforeEach(async () => {
-    const spec = [
-      resolveTestResource('sample-project-instrumented', 'MyMath.js'),
-      resolveTestResource('sample-project-instrumented', 'MyMathSpec.js'),
-    ];
+    // Work in a tmp dir, files can only be loaded once.
+    const tmpDir = resolveTempTestResourceDirectory();
+    await fsPromisesCp(resolveTestResource('sample-project-instrumented'), tmpDir, { recursive: true });
+    const spec = [path.resolve(tmpDir, 'MyMath.js'), path.resolve(tmpDir, 'MyMathSpec.js')];
     testInjector.options.mochaOptions = createMochaOptions({ spec });
     sut = testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
     await sut.init();
+  });
+
+  afterEach(async () => {
+    await sut.dispose();
   });
 
   describe('dryRun', () => {
@@ -104,26 +110,26 @@ describe('Running an instrumented project', () => {
 
   describe('mutantRun', () => {
     it('should be able to survive a mutant', async () => {
-      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '0' }) }));
+      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '0' }) }));
       assertions.expectSurvived(result);
     });
 
     it('should be able to kill a mutant', async () => {
-      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '3' }) }));
+      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '3' }) }));
       assertions.expectKilled(result);
       expect(result.killedBy).deep.eq(['MyMath should be able to add two numbers']);
       expect(result.failureMessage).eq('expected -3 to equal 7');
     });
 
     it('should bail after the first failed test', async () => {
-      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '8' }) }));
+      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '8' }) }));
       assertions.expectKilled(result);
       expect(result.killedBy).deep.eq(['MyMath should be able to recognize a negative number']);
       expect(result.nrOfTests).eq(4); // 5th test shouldn't have run
     });
 
     it('should report all killedBy tests when bail is disabled', async () => {
-      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '8' }), disableBail: true }));
+      const result = await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '8' }), disableBail: true }));
       assertions.expectKilled(result);
       expect(result.killedBy).deep.eq([
         'MyMath should be able to recognize a negative number',
@@ -134,7 +140,7 @@ describe('Running an instrumented project', () => {
 
     it('should be able to kill a mutant with filtered test', async () => {
       const result = await sut.mutantRun(
-        factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '3' }), testFilter: ['MyMath should be able to add two numbers'] })
+        factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '3' }), testFilter: ['MyMath should be able to add two numbers'] })
       );
       assertions.expectKilled(result);
       expect(result.killedBy).deep.eq(['MyMath should be able to add two numbers']);
@@ -144,7 +150,7 @@ describe('Running an instrumented project', () => {
     it('should be able to survive if killer test is not filtered', async () => {
       const result = await sut.mutantRun(
         factory.mutantRunOptions({
-          activeMutant: factory.mutant({ id: '3' }),
+          activeMutant: factory.mutantTestCoverage({ id: '3' }),
           testFilter: ['MyMath should be able negate a number', 'MyMath should be able to recognize a negative number'],
         })
       );

--- a/packages/mocha-runner/test/integration/sample-project.it.spec.ts
+++ b/packages/mocha-runner/test/integration/sample-project.it.spec.ts
@@ -1,10 +1,12 @@
-import { testInjector, factory, assertions } from '@stryker-mutator/test-helpers';
+import path from 'path';
+
+import { testInjector, factory, assertions, fsPromisesCp } from '@stryker-mutator/test-helpers';
 import { TestResult, CompleteDryRunResult, TestStatus } from '@stryker-mutator/api/test-runner';
 import { expect } from 'chai';
 
 import { createMochaOptions } from '../helpers/factories';
 import { createMochaTestRunnerFactory, MochaTestRunner } from '../../src';
-import { resolveTestResource } from '../helpers/resolve-test-resource';
+import { resolveTempTestResourceDirectory, resolveTestResource } from '../helpers/resolve-test-resource';
 
 const countTests = (runResult: CompleteDryRunResult, predicate: (result: TestResult) => boolean) => runResult.tests.filter(predicate).length;
 
@@ -13,20 +15,30 @@ const countFailed = (runResult: CompleteDryRunResult) => countTests(runResult, (
 
 describe('Running a sample project', () => {
   let sut: MochaTestRunner;
-  let spec: string[];
+  let resolveTestFile: (...pathSegments: string[]) => string;
 
   function createSut() {
     return testInjector.injector.injectFunction(createMochaTestRunnerFactory('__stryker2__'));
   }
 
+  beforeEach(async () => {
+    // Work in a tmp dir, files can only be loaded once.
+    const tmpDir = resolveTempTestResourceDirectory();
+    await fsPromisesCp(resolveTestResource('sample-project'), tmpDir, { recursive: true });
+    resolveTestFile = path.resolve.bind(undefined, tmpDir);
+  });
+
   describe('when tests pass', () => {
-    beforeEach(() => {
-      spec = [resolveTestResource('sample-project', 'MyMath.js'), resolveTestResource('sample-project', 'MyMathSpec.js')];
+    beforeEach(async () => {
+      const spec = [resolveTestFile('MyMathSpec.js')];
       testInjector.options.mochaOptions = createMochaOptions({ spec });
       sut = createSut();
-      return sut.init();
+      await sut.init();
     });
 
+    afterEach(async () => {
+      await sut.dispose();
+    });
     it('should report completed tests', async () => {
       const runResult = await sut.dryRun(factory.dryRunOptions());
       assertions.expectCompleted(runResult);
@@ -43,28 +55,15 @@ describe('Running a sample project', () => {
     });
   });
 
-  describe('with an error in an un-included input file', () => {
-    beforeEach(() => {
-      spec = [resolveTestResource('sample-project', 'MyMath.js'), resolveTestResource('sample-project', 'MyMathSpec.js')];
-      testInjector.options.mochaOptions = createMochaOptions({
-        files: spec,
-      });
-      sut = createSut();
-      return sut.init();
-    });
-
-    it('should report completed tests without errors', async () => {
-      const runResult = await sut.dryRun(factory.dryRunOptions());
-      assertions.expectCompleted(runResult);
-    });
-  });
-
   describe('with multiple failed tests', () => {
-    before(() => {
-      spec = [resolveTestResource('sample-project', 'MyMath.js'), resolveTestResource('sample-project', 'MyMathFailedSpec.js')];
+    beforeEach(() => {
+      const spec = [resolveTestFile('MyMathFailedSpec.js')];
       testInjector.options.mochaOptions = createMochaOptions({ spec });
       sut = createSut();
       return sut.init();
+    });
+    afterEach(async () => {
+      await sut.dispose();
     });
 
     it('should only report the first failure (bail)', async () => {
@@ -82,12 +81,15 @@ describe('Running a sample project', () => {
 
   describe('when no tests are executed', () => {
     beforeEach(() => {
-      spec = [resolveTestResource('sample-project', 'MyMath.js')];
+      const spec = [resolveTestFile('MyMath.js')];
       testInjector.options.mochaOptions = createMochaOptions({ spec });
       sut = createSut();
       return sut.init();
     });
 
+    afterEach(async () => {
+      await sut.dispose();
+    });
     it('should report no completed tests', async () => {
       const runResult = await sut.dryRun(factory.dryRunOptions());
       assertions.expectCompleted(runResult);

--- a/packages/mocha-runner/test/setup.ts
+++ b/packages/mocha-runner/test/setup.ts
@@ -22,6 +22,11 @@ export const mochaHooks = {
     StrykerMochaReporter.currentInstance = undefined;
     delete global.__stryker2__?.activeMutant;
     delete global.__stryker2__?.currentTestId;
-    delete global.__stryker2__?.mutantCoverage;
+    if (global.__stryker2__?.mutantCoverage?.perTest) {
+      global.__stryker2__.mutantCoverage.perTest = {};
+    }
+    if (global.__stryker2__?.mutantCoverage?.static) {
+      global.__stryker2__.mutantCoverage.static = {};
+    }
   },
 };

--- a/packages/mocha-runner/test/unit/mocha-adapter.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-adapter.spec.ts
@@ -38,84 +38,20 @@ describe(MochaAdapter.name, () => {
   });
 
   describe(MochaAdapter.prototype.collectFiles.name, () => {
-    let globStub: sinon.SinonStub;
+    let discoveredFiles: string[];
 
-    describe('when mocha version < 6', () => {
-      beforeEach(() => {
-        collectFilesStub.value(undefined);
-        globStub = sinon.stub(LibWrapper, 'glob');
-      });
-
-      it('should log about mocha < 6 detection', async () => {
-        globStub.returns(['foo.js']);
-        sut.collectFiles({});
-        expect(testInjector.logger.debug).calledWith('Mocha < 6 detected. Using custom logic to discover files');
-      });
-
-      it('should support both `files` as `spec`', async () => {
-        globStub.returns(['foo.js']);
-        sut.collectFiles({
-          files: ['bar'],
-          spec: ['foo'],
-        });
-        expect(globStub).calledWith('foo');
-        expect(globStub).calledWith('bar');
-      });
-
-      it('should match given file names with configured mocha files as `string`', () => {
-        // Arrange
-        const relativeGlobPattern = '*.js';
-        const expectedFiles = ['foo.js', 'bar.js'];
-        globStub.returns(expectedFiles);
-
-        // Act
-        const actualFiles = sut.collectFiles({ files: relativeGlobPattern });
-
-        // Assert
-        expect(globStub).calledWith(relativeGlobPattern);
-        expect(actualFiles).deep.eq(expectedFiles);
-      });
-
-      it('should match given file names with default mocha pattern "test/**/*.js"', () => {
-        globStub.returns(['foo.js']);
-        sut.collectFiles({});
-        expect(globStub).calledWith('test/**/*.js');
-      });
-
-      it('should reject if no files could be discovered', async () => {
-        // Arrange
-        globStub.returns([]);
-        const relativeGlobbing = JSON.stringify(['test/**/*.js'], null, 2);
-
-        // Act & assert
-        expect(() => sut.collectFiles({})).throws(
-          `[MochaTestRunner] No files discovered (tried pattern(s) ${relativeGlobbing}). Please specify the files (glob patterns) containing your tests in mochaOptions.spec in your config file.`
-        );
-        expect(testInjector.logger.debug).calledWith(`Tried ${relativeGlobbing} but did not result in any files.`);
-      });
+    beforeEach(() => {
+      discoveredFiles = [];
+      collectFilesStub.returns(discoveredFiles);
     });
 
-    describe('when mocha version >= 6', () => {
-      let discoveredFiles: string[];
-
-      beforeEach(() => {
-        discoveredFiles = [];
-        collectFilesStub.returns(discoveredFiles);
-      });
-
-      it('should log about mocha >= 6 detection', async () => {
-        sut.collectFiles({});
-        expect(testInjector.logger.debug).calledWith("Mocha >= 6 detected. Using mocha's `collectFiles` to load files");
-      });
-
-      it('should mock away the `process.exit` method when calling the mocha function (unfortunate side effect)', async () => {
-        const originalProcessExit = process.exit;
-        let stubbedProcessExit = process.exit;
-        collectFilesStub.callsFake(() => (stubbedProcessExit = process.exit));
-        sut.collectFiles({});
-        expect(originalProcessExit, "Process.exit doesn't seem to be stubbed away").not.eq(stubbedProcessExit);
-        expect(originalProcessExit, "Process.exit doesn't seem to be reset").eq(process.exit);
-      });
+    it('should mock away the `process.exit` method when calling the mocha function (unfortunate side effect)', async () => {
+      const originalProcessExit = process.exit;
+      let stubbedProcessExit = process.exit;
+      collectFilesStub.callsFake(() => (stubbedProcessExit = process.exit));
+      sut.collectFiles({});
+      expect(originalProcessExit, "Process.exit doesn't seem to be stubbed away").not.eq(stubbedProcessExit);
+      expect(originalProcessExit, "Process.exit doesn't seem to be reset").eq(process.exit);
     });
   });
 

--- a/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
@@ -18,6 +18,7 @@ describe(MochaTestRunner.name, () => {
   let mochaAdapterMock: sinon.SinonStubbedInstance<MochaAdapter>;
   let mochaOptionsLoaderMock: sinon.SinonStubbedInstance<MochaOptionsLoader>;
   let reporterMock: sinon.SinonStubbedInstance<StrykerMochaReporter>;
+  let testFileNames: string[];
 
   beforeEach(() => {
     reporterMock = sinon.createStubInstance(StrykerMochaReporter);
@@ -27,7 +28,10 @@ describe(MochaTestRunner.name, () => {
     mochaOptionsLoaderMock = sinon.createStubInstance(MochaOptionsLoader);
     mocha = sinon.createStubInstance(Mocha) as any;
     mocha.suite = sinon.createStubInstance(Mocha.Suite) as any;
+    mocha.suite.suites = [];
     mochaAdapterMock.create.returns(mocha as unknown as Mocha);
+    testFileNames = [];
+    mochaAdapterMock.collectFiles.returns(testFileNames);
   });
 
   afterEach(() => {
@@ -52,9 +56,9 @@ describe(MochaTestRunner.name, () => {
   });
 
   describe('capabilities', () => {
-    it('should communicate reloadEnvironment=true', () => {
-      const expectedCapabilities: TestRunnerCapabilities = { reloadEnvironment: true };
-      expect(createSut().capabilities()).deep.eq(expectedCapabilities);
+    it('should communicate reloadEnvironment=false', async () => {
+      const expectedCapabilities: TestRunnerCapabilities = { reloadEnvironment: false };
+      expect(await createSut().capabilities()).deep.eq(expectedCapabilities);
     });
   });
 
@@ -71,15 +75,16 @@ describe(MochaTestRunner.name, () => {
     });
 
     it('should collect the files', async () => {
-      const expectedTestFileNames = ['foo.js', 'foo.spec.js'];
+      testFileNames.push('foo.js', 'foo.spec.js');
       const mochaOptions = Object.freeze(createMochaOptions());
       mochaOptionsLoaderMock.load.returns(mochaOptions);
-      mochaAdapterMock.collectFiles.returns(expectedTestFileNames);
 
       await sut.init();
 
       expect(mochaAdapterMock.collectFiles).calledWithExactly(mochaOptions);
-      expect(sut.testFileNames).eq(expectedTestFileNames);
+      testFileNames.forEach((fileName) => {
+        expect(mocha.addFile).calledWith(fileName);
+      });
     });
 
     it('should not handle requires when there are no `requires`', async () => {
@@ -97,7 +102,8 @@ describe(MochaTestRunner.name, () => {
 
       await sut.init();
 
-      expect(sut.rootHooks).eq(expectedRootHooks);
+      const expectedMochaOptions: Mocha.MochaOptions = { rootHooks: expectedRootHooks };
+      expect(mochaAdapterMock.create).calledWith(sinon.match(expectedMochaOptions));
     });
 
     it('should reject when requires contains "esm" (see #3014)', async () => {
@@ -107,29 +113,22 @@ describe(MochaTestRunner.name, () => {
         'Config option "mochaOptions.require" does not support "esm", please use `"testRunnerNodeArgs": ["--require", "esm"]` instead. See https://github.com/stryker-mutator/stryker-js/issues/3014 for more information.'
       );
     });
-  });
-
-  describe(MochaTestRunner.prototype.dryRun.name, () => {
-    let sut: MochaTestRunner;
-    let testFileNames: string[];
-    beforeEach(() => {
-      testFileNames = [];
-      sut = createSut();
-      sut.testFileNames = testFileNames;
-      sut.mochaOptions = {};
-    });
 
     it('should pass along supported options to mocha', async () => {
       // Arrange
-      testFileNames.push('foo.js', 'bar.js', 'foo2.js');
-      sut.mochaOptions['async-only'] = true;
-      sut.mochaOptions.grep = 'grepme';
-      sut.mochaOptions.opts = 'opts';
-      sut.mochaOptions.require = [];
-      sut.mochaOptions.ui = 'exports';
+      const mochaOptions = Object.freeze(
+        createMochaOptions({
+          'async-only': true,
+          grep: 'grepme',
+          opts: 'opts',
+          require: [],
+          ui: 'exports',
+        })
+      );
+      mochaOptionsLoaderMock.load.returns(mochaOptions);
 
       // Act
-      await actDryRun();
+      await sut.init();
 
       // Assert
       expect(mocha.asyncOnly).called;
@@ -138,59 +137,81 @@ describe(MochaTestRunner.name, () => {
     });
 
     it('should force timeout off', async () => {
-      await actDryRun();
+      mochaOptionsLoaderMock.load.returns({});
+      await sut.init();
       expect(mochaAdapterMock.create).calledWithMatch({ timeout: false });
     });
 
+    it('should not set asyncOnly if asyncOnly is false', async () => {
+      // Arrange
+      const mochaOptions = Object.freeze(
+        createMochaOptions({
+          'async-only': false,
+        })
+      );
+      mochaOptionsLoaderMock.load.returns(mochaOptions);
+
+      // Act
+      await sut.init();
+      expect(mocha.asyncOnly).not.called;
+    });
+  });
+
+  describe(MochaTestRunner.prototype.dryRun.name, () => {
+    let sut: MochaTestRunner;
+    beforeEach(async () => {
+      mochaOptionsLoaderMock.load.returns({});
+      sut = createSut();
+      await sut.init();
+    });
+
+    it('should load files the first time', async () => {
+      await actDryRun();
+      expect(mocha.loadFilesAsync).calledOnceWithExactly();
+      expect(mocha.loadFilesAsync).calledBefore(mocha.run);
+    });
+
+    it('should not load files again the second time', async () => {
+      await actDryRun();
+      await actDryRun();
+      expect(mocha.loadFilesAsync).calledOnceWithExactly();
+    });
+
     it('should set bail to true when disableBail is false', async () => {
+      const childSuite = sinon.createStubInstance(Mocha.Suite);
+      mocha.suite.suites.push(childSuite);
+      childSuite.suites = [];
       await actDryRun(factory.dryRunOptions({ disableBail: false }));
-      expect(mochaAdapterMock.create).calledWithMatch({ bail: true });
+      expect(mocha.suite.bail).calledWith(true);
+      expect(childSuite.bail).calledWith(true);
     });
 
     it('should set bail to false when disableBail is true', async () => {
+      const childSuite = sinon.createStubInstance(Mocha.Suite);
+      mocha.suite.suites.push(childSuite);
+      childSuite.suites = [];
       await actDryRun(factory.dryRunOptions({ disableBail: true }));
-      expect(mochaAdapterMock.create).calledWithMatch({ bail: false });
-    });
-
-    it("should don't set asyncOnly if asyncOnly is false", async () => {
-      sut.mochaOptions['async-only'] = false;
-      await actDryRun();
-      expect(mocha.asyncOnly).not.called;
-    });
-
-    it('should pass rootHooks to the mocha instance', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      const rootHooks = { beforeEach() {} };
-      sut.rootHooks = rootHooks;
-      await actDryRun();
-      expect(mochaAdapterMock.create).calledWithMatch({ rootHooks });
-    });
-
-    it('should add collected files ', async () => {
-      sut.testFileNames!.push('foo.js', 'bar.js', 'foo2.js');
-      await actDryRun();
-      expect(mocha.addFile).calledThrice;
-      expect(mocha.addFile).calledWith('foo.js');
-      expect(mocha.addFile).calledWith('foo2.js');
-      expect(mocha.addFile).calledWith('bar.js');
+      expect(mocha.suite.bail).calledWith(false);
+      expect(childSuite.bail).calledWith(false);
     });
 
     it('should add a beforeEach hook if coverage analysis is "perTest"', async () => {
-      testFileNames.push('');
-      await actDryRun(factory.dryRunOptions({ coverageAnalysis: 'perTest' }));
-      expect(mocha.suite.beforeEach).calledWithMatch('StrykerIntercept', sinon.match.func);
-      mocha.suite.beforeEach.callArgOnWith(1, { currentTest: { fullTitle: () => 'foo should be bar' } });
+      const runPromise = sut.dryRun(factory.dryRunOptions({ coverageAnalysis: 'perTest' }));
+      sut.beforeEach!({ currentTest: { fullTitle: () => 'foo should be bar' } } as Mocha.Context);
+      mocha.run.callsArg(0);
+      await runPromise;
+      expect(sut.beforeEach).undefined;
       expect(global.__stryker2__?.currentTestId).eq('foo should be bar');
     });
 
     it('should not add a beforeEach hook if coverage analysis isn\'t "perTest"', async () => {
-      testFileNames.push('');
-      await actDryRun(factory.dryRunOptions({ coverageAnalysis: 'all' }));
-      expect(mocha.suite.beforeEach).not.called;
+      const runPromise = sut.dryRun(factory.dryRunOptions({ coverageAnalysis: 'all' }));
+      expect(sut.beforeEach).undefined;
+      mocha.run.callsArg(0);
+      await runPromise;
     });
 
     it('should collect mutant coverage', async () => {
-      testFileNames.push('');
       StrykerMochaReporter.currentInstance = reporterMock;
       reporterMock.tests = [];
       global.__stryker2__!.mutantCoverage = factory.mutantCoverage({ static: { 1: 2 } });
@@ -200,7 +221,6 @@ describe(MochaTestRunner.name, () => {
     });
 
     it('should not collect mutant coverage if coverageAnalysis is "off"', async () => {
-      testFileNames.push('');
       StrykerMochaReporter.currentInstance = reporterMock;
       reporterMock.tests = [];
       global.__stryker2__!.mutantCoverage = factory.mutantCoverage({ static: { 1: 2 } });
@@ -210,7 +230,6 @@ describe(MochaTestRunner.name, () => {
     });
 
     it('should result in the reported tests', async () => {
-      testFileNames.push('');
       const expectedTests = [factory.successTestResult(), factory.failedTestResult()];
       StrykerMochaReporter.currentInstance = reporterMock;
       reporterMock.tests = expectedTests;
@@ -220,58 +239,47 @@ describe(MochaTestRunner.name, () => {
     });
 
     it("should result an error if the StrykerMochaReporter isn't set correctly", async () => {
-      testFileNames.push('');
       const result = await actDryRun(factory.dryRunOptions({ coverageAnalysis: 'off' }));
       assertions.expectErrored(result);
       expect(result.errorMessage).eq("Mocha didn't instantiate the StrykerMochaReporter correctly. Test result cannot be reported.");
     });
 
-    it('should collect and purge the requireCache between runs', async () => {
-      // Arrange
-      testFileNames.push('');
-
-      // Act
-      await actDryRun(factory.dryRunOptions());
-
-      // Assert
-      expect(directoryRequireCacheMock.clear).called;
-      expect(directoryRequireCacheMock.record).called;
-      expect(directoryRequireCacheMock.clear).calledBefore(directoryRequireCacheMock.record);
-    });
-
-    it('should dispose of mocha when it supports it', async () => {
-      await actDryRun();
-      expect(mocha.dispose).called;
-    });
-
     async function actDryRun(options = factory.dryRunOptions()) {
-      mocha.run.onFirstCall().callsArg(0);
+      mocha.run.callsArg(0);
       return sut.dryRun(options);
     }
   });
 
   describe(MochaTestRunner.prototype.mutantRun.name, () => {
     let sut: MochaTestRunner;
-    beforeEach(() => {
+    beforeEach(async () => {
+      mochaOptionsLoaderMock.load.returns({});
       sut = createSut();
-      sut.testFileNames = [];
-      sut.mochaOptions = {};
+      await sut.init();
       StrykerMochaReporter.currentInstance = reporterMock;
     });
 
     it('should activate the given mutant', async () => {
-      await actMutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '42' }) }));
+      await actMutantRun(factory.mutantRunOptions({ activeMutant: factory.mutantTestCoverage({ id: '42' }) }));
       expect(global.__stryker2__?.activeMutant).eq('42');
     });
 
-    it('should set bail to false when disableBail is true', async () => {
-      await actMutantRun(factory.mutantRunOptions({ disableBail: true }));
-      expect(mochaAdapterMock.create).calledWithMatch({ bail: false });
+    it('should set bail to true when disableBail is false', async () => {
+      const childSuite = sinon.createStubInstance(Mocha.Suite);
+      mocha.suite.suites.push(childSuite);
+      childSuite.suites = [];
+      await actMutantRun(factory.mutantRunOptions({ disableBail: false }));
+      expect(mocha.suite.bail).calledWith(true);
+      expect(childSuite.bail).calledWith(true);
     });
 
-    it('should set bail to true when disableBail is false', async () => {
-      await actMutantRun(factory.mutantRunOptions({ disableBail: false }));
-      expect(mochaAdapterMock.create).calledWithMatch({ bail: true });
+    it('should set bail to false when disableBail is true', async () => {
+      const childSuite = sinon.createStubInstance(Mocha.Suite);
+      mocha.suite.suites.push(childSuite);
+      childSuite.suites = [];
+      await actMutantRun(factory.mutantRunOptions({ disableBail: true }));
+      expect(mocha.suite.bail).calledWith(false);
+      expect(childSuite.bail).calledWith(false);
     });
 
     it('should use `grep` to when the test filter is specified', async () => {
@@ -324,5 +332,19 @@ describe(MochaTestRunner.name, () => {
       global.__stryker2__!.hitCount = hitCount;
       return result;
     }
+  });
+
+  describe(MochaTestRunner.prototype.dispose.name, () => {
+    let sut: MochaTestRunner;
+    beforeEach(async () => {
+      mochaOptionsLoaderMock.load.returns({});
+      sut = createSut();
+      await sut.init();
+    });
+
+    it('should dispose of mocha', async () => {
+      await sut.dispose();
+      expect(mocha.dispose).called;
+    });
   });
 });

--- a/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
+++ b/packages/mocha-runner/test/unit/mocha-test-runner.spec.ts
@@ -139,7 +139,7 @@ describe(MochaTestRunner.name, () => {
     it('should force timeout off', async () => {
       mochaOptionsLoaderMock.load.returns({});
       await sut.init();
-      expect(mochaAdapterMock.create).calledWithMatch({ timeout: false });
+      expect(mochaAdapterMock.create).calledWithMatch({ timeout: 0 });
     });
 
     it('should not set asyncOnly if asyncOnly is false', async () => {

--- a/packages/test-helpers/src/fs-promises-cp.ts
+++ b/packages/test-helpers/src/fs-promises-cp.ts
@@ -1,0 +1,35 @@
+import { fail } from 'assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * fs.promises.cp replacement, because it is coming from v16
+ *
+ * @see https://nodejs.org/api/fs.html#fspromisescpsrc-dest-options
+ */
+export async function fsPromisesCp(src: string, dest: string, options: { recursive: true }): Promise<void> {
+  let exists = false;
+  try {
+    await fs.access(dest);
+    exists = true;
+  } catch {}
+  if (exists) {
+    fail(`${dest} already exists!`);
+  }
+
+  const dirEntries = await fs.readdir(src, { withFileTypes: true });
+
+  await fs.mkdir(dest, { recursive: true });
+  await Promise.all(
+    dirEntries.map(async (dirEntry) => {
+      const srcFileName = path.join(src, dirEntry.name);
+      if (dirEntry.isDirectory()) {
+        await fsPromisesCp(srcFileName, path.join(dest, dirEntry.name), options);
+      } else if (dirEntry.isFile()) {
+        await fs.copyFile(srcFileName, path.join(dest, dirEntry.name));
+      } else {
+        fail(`${dest} is not a file or directory, not yet supported to copy.`);
+      }
+    })
+  );
+}

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -3,3 +3,4 @@ export * as assertions from './assertions';
 export * from './test-injector';
 export * from './logging-server';
 export * from './tick';
+export * from './fs-promises-cp';


### PR DESCRIPTION
Support native es modules (esm) in the mocha runner. 

* Uses `loadAsync()` to load the esm files.
* Uses [`cleanReferencesAfterRun(false)`](https://mochajs.org/api/mocha#cleanReferencesAfterRun) in order to reuse mocha instances between runs. This comes with a big performance boost (4x) and closes #2413 
* Sets `reloadEnvironment` capabilities to `false`. Meaning that static mutants will always force a reload of the environment. This comes with a performance penalty. If you don't want that, please run with `--ignoreStatic`.
* Also adds a e2e test for logging, since the `mocha-old-version` e2e test was previously also responsible for testing the logging. This now got moved to its separate test.

Closes #2413 

BREAKING CHANGE: The `@stryker-mutator/mocha-runner` now requires `mocha@7.2` or higher. 