### PR TITLE
refactor(utils): overload `propertyPath`

### DIFF
--- a/packages/core/src/di/plugin-loader.ts
+++ b/packages/core/src/di/plugin-loader.ts
@@ -139,8 +139,8 @@ export class PluginLoader {
         this.log.warn(
           'Module "%s" did not contribute a StrykerJS plugin. It didn\'t export a "%s" or "%s".',
           descriptor,
-          propertyPath<PluginModule>('strykerPlugins'),
-          propertyPath<SchemaValidationContribution>('strykerValidationSchema')
+          propertyPath<PluginModule>()('strykerPlugins'),
+          propertyPath<SchemaValidationContribution>()('strykerValidationSchema')
         );
       }
     } catch (e: any) {

--- a/packages/core/src/initializer/gitignore-writer.ts
+++ b/packages/core/src/initializer/gitignore-writer.ts
@@ -14,7 +14,7 @@ export class GitignoreWriter {
   constructor(private readonly out: typeof console.log) {}
 
   public async addStrykerTempFolder(): Promise<void> {
-    const defaultTempDirName = defaultOptions().tempDirName;
+    const defaultTempDirName = defaultOptions.tempDirName;
     if (existsSync(GITIGNORE_FILE)) {
       const gitignoreContent = await fs.readFile(GITIGNORE_FILE);
       if (!gitignoreContent.toString().includes(defaultTempDirName)) {

--- a/packages/core/src/input/input-file-resolver.ts
+++ b/packages/core/src/input/input-file-resolver.ts
@@ -14,9 +14,7 @@ import minimatch, { type IMinimatch } from 'minimatch';
 import { coreTokens } from '../di/index.js';
 import { StrictReporter } from '../reporters/strict-reporter.js';
 import { MAX_CONCURRENT_FILE_IO } from '../utils/file-utils.js';
-import { defaultOptions } from '../config/options-validator.js';
-
-import { FileMatcher } from '../config/index.js';
+import { defaultOptions, FileMatcher } from '../config/index.js';
 
 import { InputFileCollection } from './input-file-collection.js';
 
@@ -56,7 +54,7 @@ export class InputFileResolver {
   }
 
   private resolveMutateFiles(inputFileNames: string[]) {
-    return this.filterPatterns(inputFileNames, this.mutatePatterns, !isDeepStrictEqual(this.mutatePatterns, defaultOptions().mutate));
+    return this.filterPatterns(inputFileNames, this.mutatePatterns, !isDeepStrictEqual(this.mutatePatterns, defaultOptions.mutate));
   }
 
   private resolveMutationRange(): MutationRange[] {

--- a/packages/core/src/sandbox/disable-type-checks-preprocessor.ts
+++ b/packages/core/src/sandbox/disable-type-checks-preprocessor.ts
@@ -4,8 +4,8 @@ import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { File, StrykerOptions } from '@stryker-mutator/api/core';
 import type { disableTypeChecks } from '@stryker-mutator/instrumenter';
 import { Logger } from '@stryker-mutator/api/logging';
-import { propertyPath, PropertyPathBuilder } from '@stryker-mutator/util';
 
+import { optionsPath } from '../utils/index.js';
 import { coreTokens } from '../di/index.js';
 import { objectUtils } from '../utils/object-utils.js';
 import { FileMatcher } from '../config/index.js';
@@ -34,7 +34,7 @@ export class DisableTypeChecksPreprocessor implements FilePreprocessor {
               this.log.warn(
                 `Unable to disable type checking for file "${
                   file.name
-                }". Shouldn't type checking be disabled for this file? Consider configuring a more restrictive "${propertyPath<StrykerOptions>(
+                }". Shouldn't type checking be disabled for this file? Consider configuring a more restrictive "${optionsPath(
                   'disableTypeChecks'
                 )}" settings (or turn it completely off with \`false\`)`,
                 err
@@ -48,7 +48,7 @@ export class DisableTypeChecksPreprocessor implements FilePreprocessor {
       })
     );
     if (warningLogged) {
-      this.log.warn(`(disable "${PropertyPathBuilder.create<StrykerOptions>().prop('warnings').prop('preprocessorErrors')}" to ignore this warning`);
+      this.log.warn(`(disable "${optionsPath('warnings', 'preprocessorErrors')}" to ignore this warning`);
     }
     return outFiles;
   }

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -8,7 +8,7 @@ import { MutantResult, DashboardOptions, ALL_REPORT_TYPES, PartialStrykerOptions
 import { initializerFactory } from './initializer/index.js';
 import { LogConfigurator } from './logging/index.js';
 import { Stryker } from './stryker.js';
-import { defaultOptions } from './config/options-validator.js';
+import { defaultOptions } from './config/index.js';
 import { strykerEngines, strykerVersion } from './stryker-package.js';
 
 /**
@@ -46,7 +46,6 @@ export class StrykerCli {
 
   public run(): void {
     const dashboard: Partial<DashboardOptions> = {};
-    const defaultValues = defaultOptions();
     this.program
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       .version(strykerVersion)
@@ -91,7 +90,7 @@ export class StrykerCli {
       )
       .option('--checkerNodeArgs <listOfNodeArgs>', 'A list of node args to be passed to checker child processes.', createSplitter(' '))
       .option(
-        `--coverageAnalysis <perTest|all|off>', 'The coverage analysis strategy you want to use. Default value: "${defaultValues.coverageAnalysis}"`
+        `--coverageAnalysis <perTest|all|off>', 'The coverage analysis strategy you want to use. Default value: "${defaultOptions.coverageAnalysis}"`
       )
       .option('--testRunner <name>', 'The name of the test runner you want to use')
       .option(
@@ -123,11 +122,11 @@ export class StrykerCli {
       )
       .option(
         '--logLevel <level>',
-        `Set the log level for the console. Possible values: fatal, error, warn, info, debug, trace and off. Default is "${defaultValues.logLevel}"`
+        `Set the log level for the console. Possible values: fatal, error, warn, info, debug, trace and off. Default is "${defaultOptions.logLevel}"`
       )
       .option(
         '--fileLogLevel <level>',
-        `Set the log4js log level for the "stryker.log" file. Possible values: fatal, error, warn, info, debug, trace and off. Default is "${defaultValues.fileLogLevel}"`
+        `Set the log4js log level for the "stryker.log" file. Possible values: fatal, error, warn, info, debug, trace and off. Default is "${defaultOptions.fileLogLevel}"`
       )
       .option('--allowConsoleColors <true/false>', 'Indicates whether or not Stryker should use colors in console.', parseBoolean)
       .option(
@@ -147,12 +146,12 @@ export class StrykerCli {
       )
       .option(
         '--dashboard.baseUrl <url>',
-        `Indicates which baseUrl to use when reporting to the stryker dashboard. Default: "${defaultValues.dashboard.baseUrl}"`,
+        `Indicates which baseUrl to use when reporting to the stryker dashboard. Default: "${defaultOptions.dashboard.baseUrl}"`,
         deepOption(dashboard, 'baseUrl')
       )
       .option(
         `--dashboard.reportType <${ALL_REPORT_TYPES.join('|')}>`,
-        `Send a full report (inc. source code and mutant results) or only the mutation score. Default: ${defaultValues.dashboard.reportType}`,
+        `Send a full report (inc. source code and mutant results) or only the mutation score. Default: ${defaultOptions.dashboard.reportType}`,
         deepOption(dashboard, 'reportType')
       )
       .option(
@@ -165,7 +164,7 @@ export class StrykerCli {
       )
       .option(
         '--cleanTempDir <true/false>',
-        `Choose whether or not to clean the temp dir (which is "${defaultValues.tempDirName}" inside the current working directory by default) after a successful run. The temp dir will never be removed when the run failed for some reason (for debugging purposes).`,
+        `Choose whether or not to clean the temp dir (which is "${defaultOptions.tempDirName}" inside the current working directory by default) after a successful run. The temp dir will never be removed when the run failed for some reason (for debugging purposes).`,
         parseBoolean
       )
       .showSuggestionAfterError()

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './file-utils.js';
+export * from './net-utils.js';
+export * from './object-utils.js';
+export * from './string-builder.js';
+export * from './string-utils.js';
+export * from './temporary-directory.js';
+export * from './timer.js';

--- a/packages/core/src/utils/string-utils.ts
+++ b/packages/core/src/utils/string-utils.ts
@@ -1,3 +1,6 @@
+import { propertyPath } from '@stryker-mutator/util';
+import { StrykerOptions } from '@stryker-mutator/api/core';
+
 export function wrapInClosure(codeFragment: string): string {
   return `
     (function (window) {
@@ -27,3 +30,8 @@ export function serialize(thing: unknown): string {
 export function deserialize<T>(stringified: string): T {
   return JSON.parse(stringified);
 }
+
+/**
+ * Print the name of (or path to) a stryker option
+ */
+export const optionsPath = propertyPath<StrykerOptions>();

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -5,11 +5,10 @@ import { LogLevel, ReportType, strykerCoreSchema, StrykerOptions } from '@stryke
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
-import { propertyPath } from '@stryker-mutator/util';
-
 import { OptionsValidator } from '../../../src/config/options-validator.js';
 import { coreTokens } from '../../../src/di/index.js';
 import { createCpuInfo } from '../../helpers/producers.js';
+import { optionsPath } from '../../../src/utils/index.js';
 
 describe(OptionsValidator.name, () => {
   let sut: OptionsValidator;
@@ -104,13 +103,13 @@ describe(OptionsValidator.name, () => {
       );
     });
 
-    it(`should rewrite them to "${propertyPath<StrykerOptions>('ignorePatterns')}"`, () => {
+    it(`should rewrite them to "${optionsPath('ignorePatterns')}"`, () => {
       testInjector.options.files = ['src/**/*.js', '!src/index.js'];
       sut.validate(testInjector.options);
       expect(testInjector.options.ignorePatterns).deep.eq(['**', '!src/**/*.js', 'src/index.js']);
     });
 
-    it(`should not clear existing "${propertyPath<StrykerOptions>('ignorePatterns')}" when rewritting "files"`, () => {
+    it(`should not clear existing "${optionsPath('ignorePatterns')}" when rewritting "files"`, () => {
       testInjector.options.files = ['src/**/*.js'];
       testInjector.options.ignorePatterns = ['src/index.js'];
       sut.validate(testInjector.options);

--- a/packages/jest-runner/src/jest-plugins/with-coverage-analysis.ts
+++ b/packages/jest-runner/src/jest-plugins/with-coverage-analysis.ts
@@ -61,7 +61,7 @@ function setupFramework(jestConfig: Config.InitialOptions, overrides: Config.Ini
     // 'jest-circus/runner' is supported, via handleTestEvent, see https://jestjs.io/docs/en/configuration#testenvironment-string
     // Use includes here, since "react-scripts" will specify the full path to `jest-circus`, see https://github.com/stryker-mutator/stryker-js/issues/2789
     throw new Error(
-      `The @stryker-mutator/jest-runner doesn't support ${propertyPath<StrykerOptions>(
+      `The @stryker-mutator/jest-runner doesn't support ${propertyPath<StrykerOptions>()(
         'coverageAnalysis'
       )} "perTest" with "jestConfig.testRunner": "${
         jestConfig.testRunner

--- a/packages/typescript-checker/src/typescript-checker.ts
+++ b/packages/typescript-checker/src/typescript-checker.ts
@@ -125,7 +125,7 @@ export class TypescriptChecker implements Checker {
       throw new Error(
         `The tsconfig file does not exist at: "${path.resolve(
           this.tsconfigFile
-        )}". Please configure the tsconfig file in your stryker.conf file using "${propertyPath<StrykerOptions>('tsconfigFile')}"`
+        )}". Please configure the tsconfig file in your stryker.conf file using "${propertyPath<StrykerOptions>()('tsconfigFile')}"`
       );
     }
   }

--- a/packages/util/src/string-utils.ts
+++ b/packages/util/src/string-utils.ts
@@ -11,12 +11,23 @@ export function normalizeWhitespaces(str: string): string {
   return str.replace(/\s+/g, ' ').trim();
 }
 
+export interface PropertyPathOverloads<T> {
+  (key: KnownKeys<T>): string;
+  <TProp1 extends KnownKeys<T>>(key: TProp1, key2: KnownKeys<OnlyObject<T[TProp1]>>): string;
+  <TProp1 extends KnownKeys<T>, TProp2 extends KnownKeys<OnlyObject<T[TProp1]>>>(
+    key: TProp1,
+    key2: TProp2,
+    key3: KnownKeys<OnlyObject<OnlyObject<T[TProp1]>[TProp2]>>
+  ): string;
+}
+
 /**
  * Given a base type, allows type safe access to the name of a property.
  * @param prop The property name
  */
-export function propertyPath<T>(prop: KnownKeys<T>): string {
-  return String(prop);
+export function propertyPath<T>(): PropertyPathOverloads<T> {
+  const fn: PropertyPathOverloads<T> = ((...args: string[]) => args.join('.')) as unknown as PropertyPathOverloads<T>;
+  return fn;
 }
 
 /**

--- a/packages/util/test/unit/string-utils.spec.ts
+++ b/packages/util/test/unit/string-utils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral, escapeRegExp, PropertyPathBuilder } from '../../src/index.js';
+import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral, escapeRegExp } from '../../src/index.js';
 
 describe('stringUtils', () => {
   describe(normalizeWhitespaces.name, () => {
@@ -17,8 +17,12 @@ describe('stringUtils', () => {
     });
   });
 
-  describe(PropertyPathBuilder.name, () => {
+  describe(propertyPath.name, () => {
     interface Foo {
+      bar: string;
+      [name: string]: string;
+    }
+    interface Bar {
       bar: {
         baz: string;
       };
@@ -27,32 +31,40 @@ describe('stringUtils', () => {
         quux: string;
       };
     }
-
-    it('should be able to point to a path', () => {
-      const path = PropertyPathBuilder.create<Foo>().prop('bar').prop('baz');
-      expect(path.build()).eq('bar.baz');
-      expect(path.toString()).eq('bar.baz');
-    });
-
-    it('should not be able to point to a path non-existing path', () => {
-      // @ts-expect-error Argument of type '"bar"' is not assignable to parameter of type '"quux"'.ts(2345)
-      PropertyPathBuilder.create<Foo>().prop('qux').prop('bar');
-    });
-  });
-
-  describe(propertyPath.name, () => {
-    interface Foo {
-      bar: string;
-      [name: string]: string;
+    interface Baz {
+      flags:
+        | false
+        | {
+            f1: boolean;
+            f2:
+              | false
+              | {
+                  f3: boolean;
+                };
+          };
     }
 
-    it('should be able to point to a path', () => {
-      expect(propertyPath<Foo>('bar')).eq('bar');
+    it('should be able to point to a path of lenght 1', () => {
+      expect(propertyPath<Foo>()('bar')).eq('bar');
     });
 
-    it('should not be able to point to a non-existing path', () => {
+    it('should not be able to point to a non-existing path of length 1', () => {
       // @ts-expect-error Argument of type '"baz"' is not assignable to parameter of type '"bar"'.ts(2345)
-      propertyPath<Foo>('baz');
+      propertyPath<Foo>()('baz');
+    });
+
+    it('should be able to point to a path of length 2', () => {
+      expect(propertyPath<Bar>()('bar', 'baz')).eq('bar.baz');
+    });
+
+    it('should not be able to point to a path non-existing path of length 2', () => {
+      // @ts-expect-error Argument of type '"bar"' is not assignable to parameter of type '"quux"'.ts(2345)
+      propertyPath<Bar>()('qux', 'bar');
+    });
+
+    it('should be able to point to a path of a union type', () => {
+      expect(propertyPath<Baz>()('flags', 'f1')).eq('flags.f1');
+      expect(propertyPath<Baz>()('flags', 'f2', 'f3')).eq('flags.f2.f3');
     });
   });
 


### PR DESCRIPTION
Overload the `propertyPath` function and remove the `PropertyPathBuilder`. I found this to be much more elagent.

This:

```ts

```

Becomes:
