### PR TITLE
feat: Accept hidden config file.

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -51,8 +51,10 @@ You can use your editor's autocompletion to help you author your configuration f
 
 By default, Stryker will look for a "stryker.conf.js" or "stryker.conf.json" file in the current working directory (cwd). You can also use a different configuration file with a second argument to the `run` command.
 
+Since Stryker version 6 you can use hidden file: ".stryker.conf.js" or ".stryker.conf.json".
+
 ```shell
-# Use "stryker.conf.[js,json,mjs]" in the cwd
+# Use "stryker.conf.[js,json,mjs]" or ".stryker.conf.[js,json,mjs]" in the cwd
 npx stryker run
 # Use "alternative-stryker.conf.json"
 npx stryker run alternative-stryker.conf.json

--- a/packages/core/src/config/config-file-formats.ts
+++ b/packages/core/src/config/config-file-formats.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_CONFIG_FILE_BASE_NAME = 'stryker.conf';
+export const SUPPORTED_CONFIG_FILE_BASE_NAMES = Object.freeze(['stryker.conf', '.stryker.conf'] as const);
 export const SUPPORTED_CONFIG_FILE_EXTENSIONS = Object.freeze(['.json', '.js', '.mjs', '.cjs'] as const);

--- a/packages/core/src/config/config-reader.ts
+++ b/packages/core/src/config/config-reader.ts
@@ -12,7 +12,7 @@ import { ConfigError } from '../errors.js';
 import { fileUtils } from '../utils/file-utils.js';
 
 import { OptionsValidator } from './options-validator.js';
-import { DEFAULT_CONFIG_FILE_BASE_NAME, SUPPORTED_CONFIG_FILE_EXTENSIONS } from './config-file-formats.js';
+import { SUPPORTED_CONFIG_FILE_BASE_NAMES, SUPPORTED_CONFIG_FILE_EXTENSIONS } from './config-file-formats.js';
 
 export const CONFIG_SYNTAX_HELP = `
 Example of how a config file should look:
@@ -73,10 +73,11 @@ export class ConfigReader {
         throw new ConfigReaderError('File does not exist!', configFileName);
       }
     }
-    const candidates = SUPPORTED_CONFIG_FILE_EXTENSIONS.map((ext) => `${DEFAULT_CONFIG_FILE_BASE_NAME}${ext}`);
-    for (const candidate of candidates) {
-      if (await fileUtils.exists(candidate)) {
-        return candidate;
+    for (const file of SUPPORTED_CONFIG_FILE_BASE_NAMES) {
+      for (const ext of SUPPORTED_CONFIG_FILE_EXTENSIONS) {
+        if (await fileUtils.exists(`${file}${ext}`)) {
+          return `${file}${ext}`;
+        }
       }
     }
     return undefined;

--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -7,7 +7,7 @@ import { childProcessAsPromised } from '@stryker-mutator/util';
 
 import { fileUtils } from '../utils/file-utils.js';
 import { CommandTestRunner } from '../test-runner/command-test-runner.js';
-import { DEFAULT_CONFIG_FILE_BASE_NAME, SUPPORTED_CONFIG_FILE_EXTENSIONS } from '../config/index.js';
+import { SUPPORTED_CONFIG_FILE_BASE_NAMES, SUPPORTED_CONFIG_FILE_EXTENSIONS } from '../config/index.js';
 
 import { PresetConfiguration } from './presets/preset-configuration.js';
 import { PromptOption } from './prompt-option.js';
@@ -19,8 +19,10 @@ export class StrykerConfigWriter {
   constructor(private readonly log: Logger, private readonly out: typeof console.log) {}
 
   public async guardForExistingConfig(): Promise<void> {
-    for (const ext of SUPPORTED_CONFIG_FILE_EXTENSIONS) {
-      await this.checkIfConfigFileExists(`${DEFAULT_CONFIG_FILE_BASE_NAME}${ext}`);
+    for (const file of SUPPORTED_CONFIG_FILE_BASE_NAMES) {
+      for (const ext of SUPPORTED_CONFIG_FILE_EXTENSIONS) {
+        await this.checkIfConfigFileExists(`${file}${ext}`);
+      }
     }
   }
 
@@ -82,7 +84,7 @@ export class StrykerConfigWriter {
   }
 
   private async writeJsConfig(commentedConfig: PartialStrykerOptions) {
-    const configFileName = `${DEFAULT_CONFIG_FILE_BASE_NAME}.mjs`;
+    const configFileName = `${SUPPORTED_CONFIG_FILE_BASE_NAMES[0]}.mjs`;
     this.out(`Writing & formatting ${configFileName} ...`);
     const rawConfig = this.stringify(commentedConfig);
 
@@ -101,7 +103,7 @@ export class StrykerConfigWriter {
   }
 
   private async writeJsonConfig(commentedConfig: PartialStrykerOptions) {
-    const configFileName = `${DEFAULT_CONFIG_FILE_BASE_NAME}.json`;
+    const configFileName = `${SUPPORTED_CONFIG_FILE_BASE_NAMES[0]}.json`;
     this.out(`Writing & formatting ${configFileName}...`);
     const typedConfig = {
       $schema: './node_modules/@stryker-mutator/core/schema/stryker-schema.json',

--- a/packages/core/test/integration/config-reader/config-reader.it.spec.ts
+++ b/packages/core/test/integration/config-reader/config-reader.it.spec.ts
@@ -84,6 +84,16 @@ describe(ConfigReader.name, () => {
         expect(testInjector.logger.warn).not.called;
       });
 
+      it('should use the .stryker.conf.js file in cwd', async () => {
+        process.chdir(resolveTestResource('hidden'));
+        sut = createSut();
+
+        const result = await sut.readConfig({});
+
+        expect(result.hidden).to.be.eq(true);
+        expect(testInjector.logger.warn).not.called;
+      });
+
       it('should use the default config if no stryker.conf file was found', async () => {
         process.chdir(resolveTestResource('no-config'));
 

--- a/packages/core/test/unit/config/config-reader.spec.ts
+++ b/packages/core/test/unit/config/config-reader.spec.ts
@@ -90,6 +90,22 @@ describe(ConfigReader.name, () => {
       sinon.assert.calledWithExactly(optionsValidatorMock.validate, expectedOptions);
       expect(result).deep.eq(expectedOptions);
     });
+
+    it(`should load .stryker.conf.${ext} by default`, async () => {
+      // Arrange
+      const strykerConfFile = `.stryker.conf.${ext}`;
+      const expectedOptions = { testRunner: 'my-runner' };
+      existsStub.withArgs(strykerConfFile).resolves(true);
+      readFileStub.resolves(JSON.stringify(expectedOptions));
+      importModuleStub.withArgs(pathToFileURL(path.resolve(strykerConfFile)).toString()).resolves({ default: expectedOptions });
+
+      // Act
+      const result = await sut.readConfig({});
+
+      // Assert
+      sinon.assert.calledWithExactly(optionsValidatorMock.validate, expectedOptions);
+      expect(result).deep.eq(expectedOptions);
+    });
   });
 
   it('should use cli options if no config file is available', async () => {

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -431,6 +431,15 @@ describe(StrykerInitializer.name, () => {
         `Stryker config file "stryker.conf${ext}" already exists in the current directory. Please remove it and try again.`
       );
     });
+
+    it(`should log an error and quit when \`.stryker.conf${ext}\` file already exists`, async () => {
+      existsStub.withArgs(`.stryker.conf${ext}`).resolves(true);
+
+      await expect(sut.initialize()).to.be.rejected;
+      expect(testInjector.logger.error).calledWith(
+        `Stryker config file ".stryker.conf${ext}" already exists in the current directory. Please remove it and try again.`
+      );
+    });
   });
 
   const stubTestRunners = (...testRunners: string[]) => {

--- a/packages/core/testResources/config-reader/hidden/.stryker.conf.js
+++ b/packages/core/testResources/config-reader/hidden/.stryker.conf.js
@@ -1,0 +1,5 @@
+export default {
+  valid: 'config',
+  should: 'be',
+  hidden: true,
+};


### PR DESCRIPTION
Accept hidden files (starting with a dot) for configuration. Configuration files are often hidden files (such as _.mocharc.js_ or _.eslintrc.js_).

With this pull request, the `stryker.conf.(json|js|mjs|cjs)` and `.stryker.conf.(json|js|mjs|cjs)` files are searched by default.