### PR TITLE
Fix jsom typo to be jsdom

### DIFF
--- a/docs/jest-runner.md
+++ b/docs/jest-runner.md
@@ -107,7 +107,7 @@ Becomes:
 
 ```js
 /**
- * @jest-environment @stryker-mutator/jest-runner/jest-env/jsom
+ * @jest-environment @stryker-mutator/jest-runner/jest-env/jsdom
  */
 ```
 
@@ -116,8 +116,8 @@ This is the list of jest environments that are shipped with @stryker-mutator/jes
 | Jest test environment          | @stryker-mutator/jest-runner override              |
 | ------------------------------ | -------------------------------------------------- |
 | node                           | @stryker-mutator/jest-runner/jest-env/node         |
-| jsdom                          | @stryker-mutator/jest-runner/jest-env/jsom         |
-| jest-environment-jsdom-sixteen | @stryker-mutator/jest-runner/jest-env/jsom-sixteen |
+| jsdom                          | @stryker-mutator/jest-runner/jest-env/jsdom         |
+| jest-environment-jsdom-sixteen | @stryker-mutator/jest-runner/jest-env/jsdom-sixteen |
 
 Don't worry; using Stryker's alternative is harmless during regular unit testing.
 


### PR DESCRIPTION
Current documentation has a typo for jsdom