### PR TITLE
fix(core): report failed check results only once

### DIFF
--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -117,7 +117,10 @@ export class MutationTestExecutor {
     let passedMutant$ = input$;
     for (const checkerName of this.options.checkers) {
       // Use this checker
-      const [checkFailedResult$, checkPassedResult$] = partition(this.executeSingleChecker(checkerName, passedMutant$), isEarlyResult);
+      const [checkFailedResult$, checkPassedResult$] = partition(
+        this.executeSingleChecker(checkerName, passedMutant$).pipe(shareReplay()),
+        isEarlyResult
+      );
 
       // Prepare for the next one
       passedMutant$ = checkPassedResult$;
@@ -150,7 +153,6 @@ export class MutationTestExecutor {
       .schedule(group$, (checker, group) => checker.check(checkerName, group))
       .pipe(
         mergeMap((mutantGroupResults) => mutantGroupResults),
-        shareReplay(),
         map(([mutantRunPlan, checkResult]) =>
           checkResult.status === CheckStatus.Passed
             ? mutantRunPlan

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -282,6 +282,25 @@ describe(MutationTestExecutor.name, () => {
       sinon.assert.calledWithExactly(checker.check, 'foo', [plan2]);
     });
 
+    it('should report failed check mutants only once (#3461)', async () => {
+      // Arrange
+      const plan1 = mutantRunPlan({ id: '1' });
+      const plan2 = mutantRunPlan({ id: '2' });
+      const failedCheckResult = factory.failedCheckResult();
+      arrangeScenario({ checkResult: failedCheckResult });
+      checker.group.resolves([[plan1], [plan2]]);
+      mutantTestPlans.push(plan1);
+      mutantTestPlans.push(plan2);
+
+      // Act
+      await sut.execute();
+
+      // Assert
+      expect(mutationTestReportHelperMock.reportCheckFailed).calledTwice;
+      sinon.assert.calledWithExactly(mutationTestReportHelperMock.reportCheckFailed, plan1.mutant, failedCheckResult);
+      sinon.assert.calledWithExactly(mutationTestReportHelperMock.reportCheckFailed, plan1.mutant, failedCheckResult);
+    });
+
     it('should free checker resources after checking stage is complete', async () => {
       // Arrange
       const plan = mutantRunPlan({ id: '1' });


### PR DESCRIPTION
Share the replay of failed check results accross all subscribers using the `shareReplay()` rxjs operator.

Reporting of a failed checks is done using a side effect (with the `tap()` operator). When later we subscribe to it twice, which is a result of the `partition()` operator, the reporting was done twice.

Fixes #3461