### PR TITLE
feat(warn slow): warn users for slow runs

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -226,6 +226,11 @@
           "description": "decide whether or not to log warnings when a configuration options are unserializable. For example, using a `/regex/` or `function` in your configuration options.",
           "type": "boolean",
           "default": true
+        },
+        "slow": {
+          "description": "decide whether or not to log warnings when Stryker detects a slow part of mutation that can be sped up by changing some configuration. For example using `--ignoreStatic`.",
+          "type": "boolean",
+          "default": true
         }
       }
     }

--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -1,16 +1,7 @@
 import { from, partition, merge, Observable, lastValueFrom, EMPTY, concat, bufferTime, mergeMap } from 'rxjs';
 import { toArray, map, shareReplay, tap } from 'rxjs/operators';
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
-import {
-  MutantResult,
-  MutantStatus,
-  Mutant,
-  StrykerOptions,
-  PlanKind,
-  MutantTestPlan,
-  MutantEarlyResultPlan,
-  MutantRunPlan,
-} from '@stryker-mutator/api/core';
+import { MutantResult, MutantStatus, Mutant, StrykerOptions, PlanKind, MutantTestPlan, MutantRunPlan } from '@stryker-mutator/api/core';
 import { TestRunner } from '@stryker-mutator/api/test-runner';
 import { Logger } from '@stryker-mutator/api/logging';
 import { I } from '@stryker-mutator/util';
@@ -21,7 +12,7 @@ import { StrictReporter } from '../reporters/strict-reporter.js';
 import { MutationTestReportHelper } from '../reporters/mutation-test-report-helper.js';
 import { Timer } from '../utils/timer.js';
 import { ConcurrencyTokenProvider, Pool } from '../concurrent/index.js';
-import { MutantTestPlanner } from '../mutants/index.js';
+import { isEarlyResult, MutantTestPlanner } from '../mutants/index.js';
 import { CheckerFacade } from '../checker/index.js';
 
 import { DryRunContext } from './3-dry-run-executor.js';
@@ -191,8 +182,4 @@ function reloadEnvironmentLast(a: MutantRunPlan, b: MutantRunPlan): number {
     return 0;
   }
   return 0;
-}
-
-function isEarlyResult(mutantPlan: MutantTestPlan): mutantPlan is MutantEarlyResultPlan {
-  return mutantPlan.plan === PlanKind.EarlyResult;
 }

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -73,6 +73,7 @@ export const warningOptions = factoryMethod<WarningOptions>(() => ({
   unknownOptions: true,
   preprocessorErrors: true,
   unserializableOptions: true,
+  slow: true,
 }));
 
 export const killedMutantResult = (overrides?: Partial<Omit<MutantResult, 'status'>>): MutantResult =>


### PR DESCRIPTION
Warn users for slow runs because of a relatively big chunk of their mutants being _static mutants_.

Fixes #3435