### PR TITLE
docs(mocha-runner): fix link to loadOptions

### DIFF
--- a/docs/mocha-runner.md
+++ b/docs/mocha-runner.md
@@ -42,7 +42,7 @@ You can configure the mocha test runner in the `stryker.conf.json` (or `stryker.
 }
 ```
 
-When using Mocha version 6, @stryker-mutator/mocha-runner will use [mocha's internal file loading mechanism](https://mochajs.org/api/module-lib_cli_options.html#.loadOptions) to load your mocha configuration.
+When using Mocha version 6, @stryker-mutator/mocha-runner will use [mocha's internal file loading mechanism](https://mochajs.org/api/module-lib_cli.html#.loadOptions) to load your mocha configuration.
 So feel free to _leave out the mochaOptions entirely_ if you're using one of the [default file locations](https://mochajs.org/#configuring-mocha-nodejs).
 
 Alternatively, use `['no-config']: true`, `['no-package']: true` or `['no-opts']: true` to ignore the default mocha config, default mocha package.json and default mocha opts locations respectively.


### PR DESCRIPTION
Fix link _[mocha's internal file loading mechanism](https://mochajs.org/api/module-lib_cli_options.html#.loadOptions)_ (in [Mocha Runner](https://stryker-mutator.io/docs/stryker-js/mocha-runner#configuring)).