### PR TITLE
fix(plugin loader): no warn when not using plugins

### DIFF
--- a/packages/core/src/di/plugin-loader.ts
+++ b/packages/core/src/di/plugin-loader.ts
@@ -7,6 +7,7 @@ import { tokens, commonTokens, Plugin, PluginKind } from '@stryker-mutator/api/p
 import { notEmpty, propertyPath } from '@stryker-mutator/util';
 
 import { fileUtils } from '../utils/file-utils.js';
+import { defaultOptions } from '../config/options-validator.js';
 
 const IGNORED_PACKAGES = ['core', 'api', 'util', 'instrumenter'];
 
@@ -115,7 +116,7 @@ export class PluginLoader {
     const plugins = (await fs.promises.readdir(pluginDirectory))
       .filter((pluginName) => !IGNORED_PACKAGES.includes(pluginName) && regexp.test(pluginName))
       .map((pluginName) => `${org.length ? `${org}/` : ''}${pluginName}`);
-    if (plugins.length === 0) {
+    if (plugins.length === 0 && !defaultOptions.plugins.includes(pluginExpression)) {
       this.log.warn('Expression "%s" not resulted in plugins to load.', pluginExpression);
     }
     plugins.forEach((plugin) => this.log.debug('Loading plugin "%s" (matched with expression %s)', plugin, pluginExpression));

--- a/packages/core/test/unit/di/plugin-loader.spec.ts
+++ b/packages/core/test/unit/di/plugin-loader.spec.ts
@@ -11,6 +11,7 @@ import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { PluginLoader } from '../../../src/di/index.js';
 import { fileUtils } from '../../../src/utils/file-utils.js';
 import { resolveFromRoot } from '../../helpers/test-utils.js';
+import { defaultOptions } from '../../../src/config/index.js';
 
 describe(PluginLoader.name, () => {
   let sut: PluginLoader;
@@ -77,6 +78,12 @@ describe(PluginLoader.name, () => {
     readdirStub.resolves(['karma-runner', 'some-other-package']);
     await sut.load(['my-prefix-*']);
     expect(testInjector.logger.warn).calledWithExactly('Expression "%s" not resulted in plugins to load.', 'my-prefix-*');
+  });
+
+  it('should not log a warning when the default glob expression does not yield modules', async () => {
+    readdirStub.resolves([]);
+    await sut.load(defaultOptions.plugins);
+    expect(testInjector.logger.warn).not.called;
   });
 
   it('should log debug information when for glob expression', async () => {


### PR DESCRIPTION
Don't warn the user when it is running StrykerJS without plugins:

```
WARN PluginLoader Expression "@stryker-mutator/*" not resulted in plugins to load.
```

Fixes #3497