### PR TITLE
test(mutators): verify original node immutability

### DIFF
--- a/packages/instrumenter/.vscode/launch.json
+++ b/packages/instrumenter/.vscode/launch.json
@@ -18,7 +18,7 @@
       ],
       "env": {
         // Set CHAI_JEST_SNAPSHOT_UPDATE_ALL variable when you want to update the snapshot files
-        // "CHAI_JEST_SNAPSHOT_UPDATE_ALL": "true"
+        "CHAI_JEST_SNAPSHOT_UPDATE_ALL": "true"
       }
     }
   ]

--- a/packages/instrumenter/.vscode/launch.json
+++ b/packages/instrumenter/.vscode/launch.json
@@ -18,7 +18,7 @@
       ],
       "env": {
         // Set CHAI_JEST_SNAPSHOT_UPDATE_ALL variable when you want to update the snapshot files
-        "CHAI_JEST_SNAPSHOT_UPDATE_ALL": "true"
+        // "CHAI_JEST_SNAPSHOT_UPDATE_ALL": "true"
       }
     }
   ]

--- a/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
@@ -1,8 +1,8 @@
-import babel, { type types } from '@babel/core';
+import { type types } from '@babel/core';
+
+import { deepCloneNode } from '../util/index.js';
 
 import { NodeMutator } from './node-mutator.js';
-
-const { types: t } = babel;
 
 enum ArithmeticOperators {
   '+' = '-',
@@ -18,7 +18,7 @@ export const arithmeticOperatorMutator: NodeMutator = {
   *mutate(path) {
     if (path.isBinaryExpression() && isSupported(path.node.operator, path.node)) {
       const mutatedOperator = ArithmeticOperators[path.node.operator];
-      const replacement = t.cloneNode(path.node, false);
+      const replacement = deepCloneNode(path.node);
       replacement.operator = mutatedOperator;
       yield replacement;
     }

--- a/packages/instrumenter/src/mutators/array-declaration-mutator.ts
+++ b/packages/instrumenter/src/mutators/array-declaration-mutator.ts
@@ -1,5 +1,7 @@
 import babel, { type NodePath } from '@babel/core';
 
+import { deepCloneNode } from '../util/index.js';
+
 import { NodeMutator } from './node-mutator.js';
 
 const { types } = babel;
@@ -15,8 +17,8 @@ export const arrayDeclarationMutator: NodeMutator = {
     if ((path.isCallExpression() || path.isNewExpression()) && types.isIdentifier(path.node.callee) && path.node.callee.name === 'Array') {
       const mutatedCallArgs = path.node.arguments.length ? [] : [types.arrayExpression()];
       const replacement = types.isNewExpression(path)
-        ? types.newExpression(path.node.callee, mutatedCallArgs)
-        : types.callExpression(path.node.callee, mutatedCallArgs);
+        ? types.newExpression(deepCloneNode(path.node.callee), mutatedCallArgs)
+        : types.callExpression(deepCloneNode(path.node.callee), mutatedCallArgs);
       yield replacement;
     }
   },

--- a/packages/instrumenter/src/mutators/assignment-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/assignment-operator-mutator.ts
@@ -1,8 +1,8 @@
-import babel, { type types as t } from '@babel/core';
+import { type types as t } from '@babel/core';
+
+import { deepCloneNode } from '../util/index.js';
 
 import { NodeMutator } from './index.js';
-
-const { types } = babel;
 
 enum AssignmentOperators {
   '+=' = '-=',
@@ -28,7 +28,7 @@ export const assignmentOperatorMutator: NodeMutator = {
   *mutate(path) {
     if (path.isAssignmentExpression() && isSupportedAssignmentOperator(path.node.operator) && isSupported(path.node)) {
       const mutatedOperator = AssignmentOperators[path.node.operator];
-      const replacement = types.cloneNode(path.node, false);
+      const replacement = deepCloneNode(path.node);
       replacement.operator = mutatedOperator;
       yield replacement;
     }

--- a/packages/instrumenter/src/mutators/boolean-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/boolean-literal-mutator.ts
@@ -1,5 +1,7 @@
 import babel from '@babel/core';
 
+import { deepCloneNode } from '../util/index.js';
+
 const { types } = babel;
 
 import { NodeMutator } from './index.js';
@@ -12,7 +14,7 @@ export const booleanLiteralMutator: NodeMutator = {
       yield types.booleanLiteral(!path.node.value);
     }
     if (path.isUnaryExpression() && path.node.operator === '!' && path.node.prefix) {
-      yield types.cloneNode(path.node.argument, true);
+      yield deepCloneNode(path.node.argument);
     }
   },
 };

--- a/packages/instrumenter/src/mutators/conditional-expression-mutator.ts
+++ b/packages/instrumenter/src/mutators/conditional-expression-mutator.ts
@@ -1,5 +1,7 @@
 import babel, { type NodePath } from '@babel/core';
 
+import { deepCloneNode } from '../util/index.js';
+
 import { NodeMutator } from './node-mutator.js';
 
 const booleanOperators = Object.freeze(['!=', '!==', '&&', '<', '<=', '==', '===', '>', '>=', '||']);
@@ -35,12 +37,12 @@ export const conditionalExpressionMutator: NodeMutator = {
       yield types.booleanLiteral(true);
       yield types.booleanLiteral(false);
     } else if (path.isForStatement() && !path.node.test) {
-      const replacement = types.cloneNode(path.node, /* deep */ true);
+      const replacement = deepCloneNode(path.node);
       replacement.test = types.booleanLiteral(false);
       yield replacement;
     } else if (path.isSwitchCase() && path.node.consequent.length > 0) {
       // if not a fallthrough case
-      const replacement = types.cloneNode(path.node);
+      const replacement = deepCloneNode(path.node);
       replacement.consequent = [];
       yield replacement;
     }

--- a/packages/instrumenter/src/mutators/logical-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/logical-operator-mutator.ts
@@ -1,8 +1,6 @@
-import babel from '@babel/core';
+import { deepCloneNode } from '../util/index.js';
 
 import { NodeMutator } from './index.js';
-
-const { types } = babel;
 
 enum LogicalOperatorMutationMap {
   '&&' = '||',
@@ -17,7 +15,7 @@ export const logicalOperatorMutator: NodeMutator = {
     if (path.isLogicalExpression() && isSupported(path.node.operator)) {
       const mutatedOperator = LogicalOperatorMutationMap[path.node.operator];
 
-      const replacement = types.cloneNode(path.node, true);
+      const replacement = deepCloneNode(path.node);
       replacement.operator = mutatedOperator;
       yield replacement;
     }

--- a/packages/instrumenter/src/mutators/unary-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/unary-operator-mutator.ts
@@ -1,5 +1,7 @@
 import babel from '@babel/core';
 
+import { deepCloneNode } from '../util/index.js';
+
 import { NodeMutator } from './index.js';
 
 const { types } = babel;
@@ -17,8 +19,8 @@ export const unaryOperatorMutator: NodeMutator = {
     if (path.isUnaryExpression() && isSupported(path.node.operator) && path.node.prefix) {
       const mutatedOperator = UnaryOperator[path.node.operator];
       const replacement = mutatedOperator.length
-        ? types.unaryExpression(mutatedOperator as '-' | '+', path.node.argument)
-        : types.cloneNode(path.node.argument, true);
+        ? types.unaryExpression(mutatedOperator as '-' | '+', deepCloneNode(path.node.argument))
+        : deepCloneNode(path.node.argument);
 
       yield replacement;
     }

--- a/packages/instrumenter/src/mutators/update-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/update-operator-mutator.ts
@@ -1,5 +1,7 @@
 import babel from '@babel/core';
 
+import { deepCloneNode } from '../util/index.js';
+
 import { NodeMutator } from './index.js';
 
 const { types } = babel;
@@ -14,7 +16,7 @@ export const updateOperatorMutator: NodeMutator = {
 
   *mutate(path) {
     if (path.isUpdateExpression()) {
-      yield types.updateExpression(UpdateOperators[path.node.operator], babel.types.cloneNode(path.node.argument, true), path.node.prefix);
+      yield types.updateExpression(UpdateOperators[path.node.operator], deepCloneNode(path.node.argument), path.node.prefix);
     }
   },
 };

--- a/packages/instrumenter/src/mutators/update-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/update-operator-mutator.ts
@@ -14,7 +14,7 @@ export const updateOperatorMutator: NodeMutator = {
 
   *mutate(path) {
     if (path.isUpdateExpression()) {
-      yield types.updateExpression(UpdateOperators[path.node.operator], path.node.argument, path.node.prefix);
+      yield types.updateExpression(UpdateOperators[path.node.operator], babel.types.cloneNode(path.node.argument, true), path.node.prefix);
     }
   },
 };

--- a/packages/instrumenter/test/helpers/expect-mutation.ts
+++ b/packages/instrumenter/test/helpers/expect-mutation.ts
@@ -44,14 +44,26 @@ export function expectJSMutation(sut: NodeMutator, originalCode: string, ...expe
     sourceType: 'module',
   });
   const mutants: string[] = [];
+  const originalNodeSet = nodeSet(ast);
+
   babel.traverse(ast, {
     enter(path) {
       for (const replacement of sut.mutate(path)) {
         const mutatedCode = generate(replacement).code;
         const beforeMutatedCode = originalCode.substring(0, path.node.start ?? 0);
         const afterMutatedCode = originalCode.substring(path.node.end ?? 0);
+        const mutant = `${beforeMutatedCode}${mutatedCode}${afterMutatedCode}`;
+        mutants.push(mutant);
 
-        mutants.push(`${beforeMutatedCode}${mutatedCode}${afterMutatedCode}`);
+        for (const replacementNode of nodeSet(replacement, path)) {
+          if (originalNodeSet.has(replacementNode)) {
+            expect.fail(
+              `Mutated ${replacementNode.type} node \`${
+                generate(replacementNode).code
+              }\` was found in the original AST. Please be sure to deep clone it (using \`cloneNode(ast, true)\`)`
+            );
+          }
+        }
       }
     },
   });
@@ -61,4 +73,20 @@ export function expectJSMutation(sut: NodeMutator, originalCode: string, ...expe
   expectedReplacements.sort();
   /* eslint-enable @typescript-eslint/require-array-sort-compare */
   expect(mutants).to.deep.equal(expectedReplacements);
+}
+
+function nodeSet(ast: babel.Node, parentPath?: babel.NodePath) {
+  const set = new Set<babel.Node>();
+  babel.traverse(
+    ast,
+    {
+      enter(path) {
+        set.add(path.node);
+      },
+    },
+    parentPath?.scope,
+    parentPath?.state,
+    parentPath
+  );
+  return set;
 }

--- a/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
+++ b/packages/instrumenter/test/integration/transformers.it.spec.ts.snap
@@ -4960,8 +4960,7 @@ Object {
                   "type": "SequenceExpression",
                 },
                 "consequent": Object {
-                  "left": Node {
-                    "end": 14,
+                  "left": Object {
                     "extra": Object {
                       "raw": "40",
                       "rawValue": 40,
@@ -4980,7 +4979,6 @@ Object {
                         "line": 1,
                       },
                     },
-                    "start": 12,
                     "type": "NumericLiteral",
                     "value": 40,
                   },
@@ -4999,8 +4997,7 @@ Object {
                     },
                   },
                   "operator": "-",
-                  "right": Node {
-                    "end": 18,
+                  "right": Object {
                     "extra": Object {
                       "raw": "2",
                       "rawValue": 2,
@@ -5019,7 +5016,6 @@ Object {
                         "line": 1,
                       },
                     },
-                    "start": 17,
                     "type": "NumericLiteral",
                     "value": 2,
                   },
@@ -10106,8 +10102,7 @@ Object {
                   "type": "SequenceExpression",
                 },
                 "consequent": Object {
-                  "left": Node {
-                    "end": 22,
+                  "left": Object {
                     "extra": Object {
                       "raw": "40",
                       "rawValue": 40,
@@ -10126,7 +10121,6 @@ Object {
                         "line": 1,
                       },
                     },
-                    "start": 20,
                     "type": "NumericLiteral",
                     "value": 40,
                   },
@@ -10145,8 +10139,7 @@ Object {
                     },
                   },
                   "operator": "-",
-                  "right": Node {
-                    "end": 26,
+                  "right": Object {
                     "extra": Object {
                       "raw": "2",
                       "rawValue": 2,
@@ -10165,7 +10158,6 @@ Object {
                         "line": 1,
                       },
                     },
-                    "start": 25,
                     "type": "NumericLiteral",
                     "value": 2,
                   },
@@ -15220,8 +15212,7 @@ Object {
                         "type": "SequenceExpression",
                       },
                       "consequent": Object {
-                        "left": Node {
-                          "end": 14,
+                        "left": Object {
                           "extra": Object {
                             "raw": "40",
                             "rawValue": 40,
@@ -15240,7 +15231,6 @@ Object {
                               "line": 1,
                             },
                           },
-                          "start": 12,
                           "type": "NumericLiteral",
                           "value": 40,
                         },
@@ -15259,8 +15249,7 @@ Object {
                           },
                         },
                         "operator": "-",
-                        "right": Node {
-                          "end": 18,
+                        "right": Object {
                           "extra": Object {
                             "raw": "2",
                             "rawValue": 2,
@@ -15279,7 +15268,6 @@ Object {
                               "line": 1,
                             },
                           },
-                          "start": 17,
                           "type": "NumericLiteral",
                           "value": 2,
                         },


### PR DESCRIPTION
Verifies that mutators don't accidentally reinsert original parts of the AST inside mutated parts. This has been a problem in the past, so probably best to avoid it using an assertion helper.

Fixes #3510