### PR TITLE
feat(warn): no longer warn about non-existing node_modules

### DIFF
--- a/packages/core/src/sandbox/sandbox.ts
+++ b/packages/core/src/sandbox/sandbox.ts
@@ -115,7 +115,7 @@ export class Sandbox implements Disposable {
             });
         }
       } else {
-        this.log.warn(`Could not find a node_modules folder to symlink into the sandbox directory. Search "${basePath}" and its parent directories`);
+        this.log.debug(`Could not find a node_modules folder to symlink into the sandbox directory. Search "${basePath}" and its parent directories`);
       }
     }
   }

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -227,12 +227,12 @@ describe(Sandbox.name, () => {
       );
     });
 
-    it('should not symlink node modules in sandbox directory if no node_modules exist', async () => {
+    it('should not symlink node_modules in sandbox directory if no node_modules exist', async () => {
       findNodeModulesListStub.resolves([]);
       const sut = createSut();
       await sut.init();
-      expect(testInjector.logger.warn).calledWithMatch('Could not find a node_modules');
-      expect(testInjector.logger.warn).calledWithMatch(process.cwd());
+      expect(testInjector.logger.debug).calledWithMatch('Could not find a node_modules');
+      expect(testInjector.logger.debug).calledWithMatch(process.cwd());
       expect(symlinkJunctionStub).not.called;
     });
 


### PR DESCRIPTION
Log missing `node_modules` for symlinking as 'debug' rather than 'warning'.

When running Stryker in a child directory of a mono-repo, which doesn't have a `node_modules` directory, Stryker would log a warning. This is far too aggressive. 