### PR TITLE
chore(npm run): Stop linking parent bin

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -39,7 +39,6 @@
         "karma-mocha": "~2.0.1",
         "karma-sourcemap-loader": "~0.3.8",
         "karma-webpack": "~5.0.0",
-        "link-parent-bin": "^2.0.0",
         "load-grunt-tasks": "~5.1.0",
         "mocha": "~10.0.0",
         "mutation-testing-metrics": "1.7.10",
@@ -4445,15 +4444,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -4520,18 +4510,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cmd-shim": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-4.1.0.tgz",
-      "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
-      "dev": true,
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/co": {
@@ -6644,12 +6622,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -10340,35 +10312,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "node_modules/link-parent-bin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/link-parent-bin/-/link-parent-bin-2.0.0.tgz",
-      "integrity": "sha512-Z5k5dJ7R5mmZpVSnyt3q21wI6goJuL7eYdKgdoZLWtSepY7rvwLGa03W+NqHLQl5ruTgoqn8XD/HYBQuyHHkRg==",
-      "dev": true,
-      "dependencies": {
-        "cmd-shim": "^4.0.2",
-        "commander": "^6.1.0",
-        "log4js": "^6.3.0",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0"
-      },
-      "bin": {
-        "link-parent-bin": "bin/link-parent-bin"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/link-parent-bin/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/load-grunt-tasks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-5.1.0.tgz",
@@ -10738,20 +10681,6 @@
       "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
-      "integrity": "sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
       },
       "engines": {
         "node": ">=10"
@@ -17176,12 +17105,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -17237,15 +17160,6 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
-      }
-    },
-    "cmd-shim": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-4.1.0.tgz",
-      "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
-      "dev": true,
-      "requires": {
-        "mkdirp-infer-owner": "^2.0.0"
       }
     },
     "co": {
@@ -18871,12 +18785,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
-    },
-    "infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true
     },
     "inflight": {
@@ -21674,28 +21582,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "link-parent-bin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/link-parent-bin/-/link-parent-bin-2.0.0.tgz",
-      "integrity": "sha512-Z5k5dJ7R5mmZpVSnyt3q21wI6goJuL7eYdKgdoZLWtSepY7rvwLGa03W+NqHLQl5ruTgoqn8XD/HYBQuyHHkRg==",
-      "dev": true,
-      "requires": {
-        "cmd-shim": "^4.0.2",
-        "commander": "^6.1.0",
-        "log4js": "^6.3.0",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
-        }
-      }
-    },
     "load-grunt-tasks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-5.1.0.tgz",
@@ -21986,17 +21872,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
-    },
-    "mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
-      "integrity": "sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==",
-      "dev": true,
-      "requires": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      }
     },
     "mocha": {
       "version": "10.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -34,7 +34,6 @@
     "karma-mocha": "~2.0.1",
     "karma-sourcemap-loader": "~0.3.8",
     "karma-webpack": "~5.0.0",
-    "link-parent-bin": "^2.0.0",
     "load-grunt-tasks": "~5.1.0",
     "mocha": "~10.0.0",
     "mutation-testing-metrics": "1.7.10",
@@ -50,9 +49,8 @@
   },
   "scripts": {
     "bootstrap": "node ../node_modules/lerna/cli.js bootstrap",
-    "postinstall": "(npm run bootstrap || npm run bootstrap) && npm run install-local-dependencies && npm run link-parent-bin",
+    "postinstall": "(npm run bootstrap || npm run bootstrap) && npm run install-local-dependencies",
     "install-local-dependencies": "node tasks/install-local-dependencies.js",
-    "link-parent-bin": "link-parent-bin -c test --link-local-dependencies true",
     "lint": "tsc -p tsconfig.json && eslint . --resolve-plugins-relative-to . --ext .ts,.js",
     "test": "node tasks/run-e2e-tests.js",
     "test:update": "cross-env CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "jasmine-core": "~4.1.0",
         "json-schema-to-typescript": "~10.1.5",
         "lerna": "~4.0.0",
-        "link-parent-bin": "~2.0.0",
         "minimatch": "~5.0.1",
         "mocha": "~10.0.0",
         "prettier": "2.6.2",
@@ -3184,15 +3183,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/compare-func": {
@@ -6708,48 +6698,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "node_modules/link-parent-bin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/link-parent-bin/-/link-parent-bin-2.0.0.tgz",
-      "integrity": "sha512-Z5k5dJ7R5mmZpVSnyt3q21wI6goJuL7eYdKgdoZLWtSepY7rvwLGa03W+NqHLQl5ruTgoqn8XD/HYBQuyHHkRg==",
-      "dev": true,
-      "dependencies": {
-        "cmd-shim": "^4.0.2",
-        "commander": "^6.1.0",
-        "log4js": "^6.3.0",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0"
-      },
-      "bin": {
-        "link-parent-bin": "bin/link-parent-bin"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/link-parent-bin/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/link-parent-bin/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/load-json-file": {
       "version": "6.2.0",
@@ -13501,12 +13449,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true
-    },
     "compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -16256,41 +16198,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "link-parent-bin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/link-parent-bin/-/link-parent-bin-2.0.0.tgz",
-      "integrity": "sha512-Z5k5dJ7R5mmZpVSnyt3q21wI6goJuL7eYdKgdoZLWtSepY7rvwLGa03W+NqHLQl5ruTgoqn8XD/HYBQuyHHkRg==",
-      "dev": true,
-      "requires": {
-        "cmd-shim": "^4.0.2",
-        "commander": "^6.1.0",
-        "log4js": "^6.3.0",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
     },
     "load-json-file": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "jasmine-core": "~4.1.0",
     "json-schema-to-typescript": "~10.1.5",
     "lerna": "~4.0.0",
-    "link-parent-bin": "~2.0.0",
     "minimatch": "~5.0.1",
     "mocha": "~10.0.0",
     "prettier": "2.6.2",
@@ -48,7 +47,7 @@
   },
   "scripts": {
     "all": "npm run clean && npm run build && npm run lint && npm run test",
-    "postinstall": "lerna bootstrap --no-ci -- --legacy-peer-deps && link-parent-bin",
+    "postinstall": "lerna bootstrap --no-ci -- --legacy-peer-deps",
     "lint": "eslint . --resolve-plugins-relative-to . --ext .ts,.js",
     "lint:fix": "npm run lint -- --fix",
     "clean": "rimraf \"packages/*/{package-lock.json,.nyc_output,reports,coverage,src-generated,*.tsbuildinfo,.stryker-tmp,dist,testResources/tmp}\" \"packages/core/schema/stryker-schema.json\"",


### PR DESCRIPTION
Stop linking parent binaries in `node_modules/.bin` directories of packages, as this is no longer needed. Recent releases of NPM already add the parent `node_module/.bin` directory to the PATH env variable when running with `npm run`
