### PR TITLE
updates note on local installation usage

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Optionally, you could also install Stryker directly yourself.
 npm install --save-dev @stryker-mutator/core
 ```
 
-If you choose to not install the stryker-cli, use `npx stryker` (after installing `@stryker-mutator/core` locally) instead of `stryker` for the rest of the quickstart.
+If you choose to not install the stryker-cli, use `npx stryker-cli` (after installing `@stryker-mutator/core` locally) instead of `stryker` for the rest of the quickstart.
 
 ---
 


### PR DESCRIPTION
see issue [#1440](https://github.com/stryker-mutator/stryker-js/issues/1440#issuecomment-470831538)

## Summary
Looks like there was a very old issue looking to address the npx/stryker/cli command but can only imagine community didn't find enough value to pursue, so suggesting this change for those following the getting started page using a local installation.

## Issue
Following getting started advice:
> If you choose to not install the stryker-cli, use npx stryker (after installing @stryker-mutator/core locally) instead of stryker for the rest of the quickstart.

Seems following this advice has resulted in a host of issues as per a quick google search on the matter. Recently, my attempt resulted in rather obtuse console output:

```
$ npx stryker init
Unexpected token {
$
```