### PR TITLE
fix(jest): allow mixin jest env for unit testing

### DIFF
--- a/packages/jest-runner/src/jest-plugins/cjs/mixin-jest-environment.ts
+++ b/packages/jest-runner/src/jest-plugins/cjs/mixin-jest-environment.ts
@@ -36,7 +36,7 @@ export function mixinJestEnvironment<T extends typeof JestEnvironment>(JestEnvir
 
       constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
         super(config, context);
-        this.strykerContext = this.global[this.global.__strykerGlobalNamespace__] = state.instrumenterContext;
+        this.strykerContext = this.global[this.global.__strykerGlobalNamespace__ ?? '__stryker__'] = state.instrumenterContext;
         state.testFilesWithStrykerEnvironment.add(context.testPath);
       }
 

--- a/packages/jest-runner/test/unit/jest-plugins/mixin-jest-environment.spec.ts
+++ b/packages/jest-runner/test/unit/jest-plugins/mixin-jest-environment.spec.ts
@@ -38,6 +38,23 @@ describe(`jest plugins ${mixinJestEnvironment.name}`, () => {
       expect(sut.global.__stryker2__).eq(state.instrumenterContext);
     });
 
+    it('should default to __stryker__ when there is no global stryker variable name configured', () => {
+      // Arrange
+      state.clear();
+
+      // Act
+      const sut = new (mixinJestEnvironment(
+        class extends JestEnvironmentNode {
+          public async handleTestEvent(_event: Circus.Event, _eventState: Circus.State) {
+            // Idle
+          }
+        }
+      ))(producers.createEnvironmentConfig(), producers.createEnvironmentContext());
+
+      // Assert
+      expect(sut.global.__stryker__).eq(state.instrumenterContext);
+    });
+
     it('should add the testPath to the test files with stryker environment', async () => {
       // Arrange
       state.clear();


### PR DESCRIPTION
Allow `mixinJestEnvironment` to be used under normal unit testing without Stryker.

This way was already documented, but broke in v6 release:
https://stryker-mutator.io/docs/stryker-js/jest-runner/#coverage-reporting

Fixes #3584