### PR TITLE
refactor(eslint): enable 'no-floating-promises' rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,7 @@ module.exports = {
     // prettier rules
     'prettier/prettier': ['error'],
 
-    // customised typescript-eslint rules
+    // customized typescript-eslint rules
     '@typescript-eslint/array-type': [
       'error',
       {
@@ -60,6 +60,7 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_*', ignoreRestSiblings: true, varsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-floating-promises': 'error',
 
     // disabled typescript-eslint rules we should enable in some way
 
@@ -72,7 +73,6 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/await-thenable': 'off',
-    '@typescript-eslint/no-floating-promises': 'off',
 
     // fix - separate PR
     '@typescript-eslint/unbound-method': 'off',

--- a/e2e/test/mocha-old-version/verify/verify.js
+++ b/e2e/test/mocha-old-version/verify/verify.js
@@ -1,7 +1,7 @@
 import { expectMetricsJsonToMatchSnapshot } from '../../../helpers.js';
 
 describe('Verify stryker runs on the lowest supported mocha version', () => {
-  it('should have run correctly', () => {
-    expectMetricsJsonToMatchSnapshot();
+  it('should have run correctly', async () => {
+    await expectMetricsJsonToMatchSnapshot();
   });
 });

--- a/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
+++ b/packages/jasmine-runner/test/unit/jasmine-test-runner.spec.ts
@@ -99,10 +99,10 @@ describe(JasmineTestRunner.name, () => {
 
       // Assert
       expect(global.__stryker2__?.activeMutant).eq('23');
-      customReporter!.jasmineStarted!(createJasmineStartedInfo());
+      await customReporter!.jasmineStarted!(createJasmineStartedInfo());
       expect(global.__stryker2__?.activeMutant).eq('23');
       const doneInfo = createJasmineDoneInfo();
-      customReporter!.jasmineDone!(doneInfo);
+      await customReporter!.jasmineDone!(doneInfo);
       executeTask.resolve(doneInfo);
       await onGoingAct;
     });
@@ -123,10 +123,10 @@ describe(JasmineTestRunner.name, () => {
 
       // Assert
       expect(global.__stryker2__?.activeMutant).undefined;
-      customReporter!.jasmineStarted!(createJasmineStartedInfo());
+      await customReporter!.jasmineStarted!(createJasmineStartedInfo());
       expect(global.__stryker2__?.activeMutant).eq('23');
       const doneInfo = createJasmineDoneInfo();
-      customReporter!.jasmineDone!(doneInfo);
+      await customReporter!.jasmineDone!(doneInfo);
       executeTask.resolve(doneInfo);
       await onGoingAct;
     });
@@ -138,7 +138,7 @@ describe(JasmineTestRunner.name, () => {
       }
       jasmineEnvStub.addReporter.callsFake(addReporter);
       jasmineStub.execute.callsFake(async () => {
-        customReporter.jasmineDone!(createJasmineDoneInfo());
+        await customReporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
       return sut.mutantRun(factory.mutantRunOptions({ activeMutant, testFilter, timeout: 2000, sandboxFileName }));
@@ -151,10 +151,10 @@ describe(JasmineTestRunner.name, () => {
       clock.setSystemTime(new Date(2010, 1, 1));
       jasmineStub.execute.callsFake(async () => {
         const spec = createSpecResult();
-        reporter.specStarted!(spec);
+        await reporter.specStarted!(spec);
         clock.tick(10);
-        reporter.specDone!(spec);
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.specDone!(spec);
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 
@@ -169,7 +169,7 @@ describe(JasmineTestRunner.name, () => {
     it('should configure failFast: false when bail is disabled', async () => {
       // Arrange
       jasmineStub.execute.callsFake(async () => {
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 
@@ -191,7 +191,7 @@ describe(JasmineTestRunner.name, () => {
         };
         global.__stryker2__!.mutantCoverage = expectedMutationCoverage;
         jasmineStub.execute.callsFake(async () => {
-          reporter.jasmineDone!(createJasmineDoneInfo());
+          await reporter.jasmineDone!(createJasmineDoneInfo());
           return createJasmineDoneInfo();
         });
 
@@ -216,7 +216,7 @@ describe(JasmineTestRunner.name, () => {
       };
       global.__stryker2__!.mutantCoverage = expectedMutationCoverage;
       jasmineStub.execute.callsFake(async () => {
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 
@@ -239,13 +239,13 @@ describe(JasmineTestRunner.name, () => {
       jasmineStub.execute.callsFake(async () => {
         const spec0 = createSpecResult({ id: 'spec0' });
         const spec1 = createSpecResult({ id: 'spec23' });
-        reporter.specStarted!(spec0);
+        await reporter.specStarted!(spec0);
         firstCurrentTestId = global.__stryker2__!.currentTestId;
-        reporter.specDone!(spec0);
-        reporter.specStarted!(spec1);
+        await reporter.specDone!(spec0);
+        await reporter.specStarted!(spec1);
         secondCurrentTestId = global.__stryker2__!.currentTestId;
-        reporter.specDone!(spec1);
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.specDone!(spec1);
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 
@@ -262,10 +262,10 @@ describe(JasmineTestRunner.name, () => {
       let firstCurrentTestId: string | undefined;
       jasmineStub.execute.callsFake(async () => {
         const spec0 = createSpecResult({ id: 'spec0' });
-        reporter.specStarted!(spec0);
+        await reporter.specStarted!(spec0);
         firstCurrentTestId = global.__stryker2__!.currentTestId;
-        reporter.specDone!(spec0);
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.specDone!(spec0);
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 
@@ -279,8 +279,8 @@ describe(JasmineTestRunner.name, () => {
     it('should report completed specs', async () => {
       // Arrange
       jasmineStub.execute.callsFake(async () => {
-        reporter.specDone!(createSpecResult({ id: 'spec0', fullName: 'foo spec', status: 'success', description: 'string' }));
-        reporter.specDone!(
+        await reporter.specDone!(createSpecResult({ id: 'spec0', fullName: 'foo spec', status: 'success', description: 'string' }));
+        await reporter.specDone!(
           createSpecResult({
             id: 'spec1',
             fullName: 'bar spec',
@@ -289,10 +289,10 @@ describe(JasmineTestRunner.name, () => {
             description: 'string',
           })
         );
-        reporter.specDone!(createSpecResult({ id: 'spec2', fullName: 'disabled', status: 'disabled', description: 'string' }));
-        reporter.specDone!(createSpecResult({ id: 'spec3', fullName: 'pending', status: 'pending', description: 'string' }));
-        reporter.specDone!(createSpecResult({ id: 'spec4', fullName: 'excluded', status: 'excluded', description: 'string' }));
-        reporter.jasmineDone!(createJasmineDoneInfo());
+        await reporter.specDone!(createSpecResult({ id: 'spec2', fullName: 'disabled', status: 'disabled', description: 'string' }));
+        await reporter.specDone!(createSpecResult({ id: 'spec3', fullName: 'pending', status: 'pending', description: 'string' }));
+        await reporter.specDone!(createSpecResult({ id: 'spec4', fullName: 'excluded', status: 'excluded', description: 'string' }));
+        await reporter.jasmineDone!(createJasmineDoneInfo());
         return createJasmineDoneInfo();
       });
 

--- a/packages/karma-runner/test/unit/karma-test-runner.spec.ts
+++ b/packages/karma-runner/test/unit/karma-test-runner.spec.ts
@@ -132,7 +132,7 @@ describe(KarmaTestRunner.name, () => {
       const onGoingInit = sut.init();
 
       // Act
-      sut.dispose();
+      await sut.dispose();
       exitTask.resolve(0);
 
       // Assert

--- a/tasks/instrument-test-resources.js
+++ b/tasks/instrument-test-resources.js
@@ -83,4 +83,7 @@ async function instrument(fromTo, globalNamespace = INSTRUMENTER_CONSTANTS.NAMES
     console.log(`✅ ${toFileName}`);
   });
 }
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -83,10 +83,8 @@
       "**/.DS_Store": true,
       "?(check).js": true
     },
-    "eslint.validate": [
-      "javascript",
-      "typescript"
-    ],
+    "eslint.validate": ["javascript", "typescript"],
+    "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
     "task.autoDetect": "off",
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true
@@ -118,9 +116,6 @@
     "cSpell.language": "en"
   },
   "extensions": {
-    "recommendations": [
-      "dbaeumer.vscode-eslint",
-      "EditorConfig.EditorConfig"
-    ]
+    "recommendations": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig"]
   }
 }


### PR DESCRIPTION
Enable the no-floating-promises rule and fix all linting errors.
Also configure eslint plugin for vscode to show all errors as warnings.
