### PR TITLE
fix(reporting): make all file paths relative in report

### DIFF
--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -92,8 +92,15 @@ export async function readMutationTestingJsonResult(jsonReportFile = path.resolv
    * @type {import('mutation-testing-report-schema/api').MutationTestResult}
    */
   const report = JSON.parse(mutationTestReportContent);
-  const metricsResult = calculateMutationTestMetrics(report);
-  return metricsResult;
+  return report;
+}
+
+/**
+ * @param {string} [jsonReportFile]
+ * @returns {Promise<import('mutation-testing-metrics').MutationTestMetricsResult>}
+ */
+export async function readMutationTestingJsonResultAsMetricsResult(jsonReportFile = path.resolve('reports', 'mutation', 'mutation.json')) {
+  return calculateMutationTestMetrics(await readMutationTestingJsonResult(jsonReportFile));
 }
 
 /**
@@ -105,6 +112,6 @@ export function readLogFile(fileName = path.resolve('stryker.log')) {
 }
 
 export async function expectMetricsJsonToMatchSnapshot() {
-  const actualMetricsResult = await readMutationTestingJsonResult();
+  const actualMetricsResult = await readMutationTestingJsonResultAsMetricsResult();
   expect(actualMetricsResult.systemUnderTestMetrics.metrics).to.matchSnapshot();
 }

--- a/e2e/test/disable-bail/verify/verify.js
+++ b/e2e/test/disable-bail/verify/verify.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { expect } from 'chai';
 
-import { readMutationTestingJsonResult, execStryker } from '../../../helpers.js';
+import { readMutationTestingJsonResultAsMetricsResult, execStryker } from '../../../helpers.js';
 
 describe('disableBail', () => {
   beforeEach(async () => {
@@ -33,7 +33,7 @@ describe('disableBail', () => {
 async function assertBailWasDisabled(
   [killedByName1, killedByName2] = ['add should result in 42 for 40 and 2', 'add should result in 42 for 41 and 1']
 ) {
-  const result = await readMutationTestingJsonResult();
+  const result = await readMutationTestingJsonResultAsMetricsResult();
   const theMutant = result.systemUnderTestMetrics.childResults[0].file.mutants.find((mutant) => mutant.replacement === 'a - b');
   expect(theMutant.killedByTests).lengthOf(2);
   expect(theMutant.killedByTests[0].name).eq(killedByName1);

--- a/e2e/test/ignore-project/verify/verify.js
+++ b/e2e/test/ignore-project/verify/verify.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import { MutantStatus } from 'mutation-testing-report-schema';
 
-import { expectMetricsJsonToMatchSnapshot, readMutationTestingJsonResult } from '../../../helpers.js';
+import { expectMetricsJsonToMatchSnapshot, readMutationTestingJsonResultAsMetricsResult } from '../../../helpers.js';
 
 describe('After running stryker on jest-react project', () => {
   it('should report expected scores', async () => {
     await expectMetricsJsonToMatchSnapshot();
   });
   it('should report mutants that are disabled by a comment with correct ignore reason', async () => {
-    const actualMetricsResult = await readMutationTestingJsonResult();
+    const actualMetricsResult = await readMutationTestingJsonResultAsMetricsResult();
     const addResult = actualMetricsResult.systemUnderTestMetrics.childResults.find((file) => file.name.endsWith('Add.js')).file;
     const mutantsAtLine31 = addResult.mutants.filter(({ location }) => location.start.line === 31);
     const booleanLiteralMutants = mutantsAtLine31.filter(({ mutatorName }) => mutatorName === 'BooleanLiteral');
@@ -27,7 +27,7 @@ describe('After running stryker on jest-react project', () => {
     });
   });
   it('should report mutants that result from excluded mutators with the correct ignore reason', async () => {
-    const actualMetricsResult = await readMutationTestingJsonResult();
+    const actualMetricsResult = await readMutationTestingJsonResultAsMetricsResult();
     const circleResult = actualMetricsResult.systemUnderTestMetrics.childResults.find((file) => file.name.endsWith('Circle.js')).file;
     const mutantsAtLine3 = circleResult.mutants.filter(({ location }) => location.start.line === 3);
     mutantsAtLine3.forEach((mutant) => {

--- a/e2e/test/jest-node/verify/verify.js
+++ b/e2e/test/jest-node/verify/verify.js
@@ -14,7 +14,7 @@ describe('After running stryker with test runner jest on test environment "node"
     const sumTestFileName = fileURLToPath(new URL('../src/sum.test.js', import.meta.url));
     const report = JSON.parse(await fsPromises.readFile(fileURLToPath(new URL('../reports/mutation/mutation.json', import.meta.url)), 'utf-8'));
     const expectedTestFiles = {
-      [sumTestFileName]: {
+      ['src/sum.test.js']: {
         source: await fsPromises.readFile(sumTestFileName, 'utf-8'),
         tests: [
           {

--- a/e2e/test/reporters-e2e/verify/verify.js
+++ b/e2e/test/reporters-e2e/verify/verify.js
@@ -27,8 +27,18 @@ describe('Verify stryker has ran correctly', () => {
 
   it('should report json report with expected results', async () => {
     const result = await readMutationTestingJsonResult();
-    expect(result.files).matchSnapshot();
-    expect(result.testFiles).matchSnapshot();
+    const files = Object.fromEntries(
+      Object.entries(result.files)
+        .map(([fileName, fileResult]) => [fileName, { ...fileResult, mutants: fileResult.mutants.sort((a, b) => (a.id < b.id ? -1 : 1)) }])
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+    );
+    const testFiles = Object.fromEntries(
+      Object.entries(result.testFiles)
+        .map(([fileName, fileResult]) => [fileName, { ...fileResult, tests: fileResult.tests.sort((a, b) => (a.id < b.id ? -1 : 1)) }])
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+    );
+    expect(files).matchSnapshot();
+    expect(testFiles).matchSnapshot();
   });
 
   describe('clearText report', () => {

--- a/e2e/test/reporters-e2e/verify/verify.js
+++ b/e2e/test/reporters-e2e/verify/verify.js
@@ -3,6 +3,8 @@ import fs from 'fs';
 import { expect } from 'chai';
 import { describe } from 'mocha';
 
+import { readMutationTestingJsonResult } from '../../../helpers.js';
+
 describe('Verify stryker has ran correctly', () => {
   /**
    * @param {string} fileName
@@ -21,6 +23,12 @@ describe('Verify stryker has ran correctly', () => {
 
   it('should have a json report', () => {
     expectExists('reports/mutation/mutation.json');
+  });
+
+  it('should report json report with expected results', async () => {
+    const result = await readMutationTestingJsonResult();
+    expect(result.files).matchSnapshot();
+    expect(result.testFiles).matchSnapshot();
   });
 
   describe('clearText report', () => {

--- a/e2e/test/reporters-e2e/verify/verify.js.snap
+++ b/e2e/test/reporters-e2e/verify/verify.js.snap
@@ -1,0 +1,727 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Verify stryker has ran correctly should report json report with expected results 1`] = `
+Object {
+  "src/Add.js": Object {
+    "language": "javascript",
+    "mutants": Array [
+      Object {
+        "coveredBy": Array [],
+        "id": "6",
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 16,
+          },
+          "start": Object {
+            "column": 46,
+            "line": 14,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "7",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "true",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "8",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "false",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "9",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "EqualityOperator",
+        "replacement": "number >= 10",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "10",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "EqualityOperator",
+        "replacement": "number <= 10",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [
+          "0",
+        ],
+        "id": "1",
+        "killedBy": Array [
+          "0",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 2,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "num1 - num2",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected -3 to equal 7",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "1",
+        ],
+        "id": "2",
+        "killedBy": Array [
+          "1",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 5,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 3",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "1",
+        ],
+        "id": "3",
+        "killedBy": Array [
+          "1",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 11,
+            "line": 6,
+          },
+          "start": Object {
+            "column": 3,
+            "line": 6,
+          },
+        },
+        "mutatorName": "UpdateOperator",
+        "replacement": "number--",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 1 to equal 3",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "2",
+        ],
+        "id": "4",
+        "killedBy": Array [
+          "2",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 12,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 10,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal -2",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "2",
+        ],
+        "id": "5",
+        "killedBy": Array [
+          "2",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 17,
+            "line": 11,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 11,
+          },
+        },
+        "mutatorName": "UnaryOperator",
+        "replacement": "+number",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 2 to equal -2",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "11",
+        "killedBy": Array [
+          "3",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 24,
+          },
+          "start": Object {
+            "column": 52,
+            "line": 18,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to be true",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "12",
+        "killedBy": Array [
+          "4",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 25,
+            "line": 19,
+          },
+          "start": Object {
+            "column": 20,
+            "line": 19,
+          },
+        },
+        "mutatorName": "BooleanLiteral",
+        "replacement": "true",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected true to be false",
+        "testsCompleted": 2,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "13",
+        "killedBy": Array [
+          "4",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 16,
+            "line": 20,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 20,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "true",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected true to be false",
+        "testsCompleted": 2,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "14",
+        "killedBy": Array [
+          "3",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 16,
+            "line": 20,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 20,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "false",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected false to be true",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "15",
+        "killedBy": Array [
+          "4",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 16,
+            "line": 20,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 20,
+          },
+        },
+        "mutatorName": "EqualityOperator",
+        "replacement": "number <= 0",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected true to be false",
+        "testsCompleted": 2,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+          "4",
+        ],
+        "id": "16",
+        "killedBy": Array [
+          "3",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 16,
+            "line": 20,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 20,
+          },
+        },
+        "mutatorName": "EqualityOperator",
+        "replacement": "number >= 0",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected false to be true",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+        ],
+        "id": "17",
+        "killedBy": Array [
+          "3",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 4,
+            "line": 22,
+          },
+          "start": Object {
+            "column": 17,
+            "line": 20,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected false to be true",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "0",
+        ],
+        "id": "0",
+        "killedBy": Array [
+          "0",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 43,
+            "line": 1,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 7",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "3",
+        ],
+        "id": "18",
+        "killedBy": Array [
+          "3",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 22,
+            "line": 21,
+          },
+          "start": Object {
+            "column": 18,
+            "line": 21,
+          },
+        },
+        "mutatorName": "BooleanLiteral",
+        "replacement": "false",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected false to be true",
+        "testsCompleted": 1,
+      },
+    ],
+    "source": "module.exports.add = function(num1, num2) {
+  return num1 + num2;
+};
+
+module.exports.addOne = function(number) {
+  number++;
+  return number;
+};
+
+module.exports.negate = function(number) {
+  return -number;
+};
+
+module.exports.notCovered = function(number) {
+  return number > 10;
+};
+
+module.exports.isNegativeNumber = function(number) {
+  var isNegative = false;
+  if(number < 0){
+    isNegative = true;
+  }
+  return isNegative;
+};
+
+
+",
+  },
+  "src/Circle.js": Object {
+    "language": "javascript",
+    "mutants": Array [
+      Object {
+        "coveredBy": Array [],
+        "id": "22",
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 46,
+            "line": 6,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "23",
+        "location": Object {
+          "end": Object {
+            "column": 20,
+            "line": 7,
+          },
+          "start": Object {
+            "column": 11,
+            "line": 7,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "5 / 2 / 3",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "24",
+        "location": Object {
+          "end": Object {
+            "column": 16,
+            "line": 7,
+          },
+          "start": Object {
+            "column": 11,
+            "line": 7,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "5 * 2",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "20",
+        "location": Object {
+          "end": Object {
+            "column": 30,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 3,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "2 * Math.PI / radius",
+        "static": false,
+        "status": "Survived",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "19",
+        "killedBy": Array [
+          "5",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 52,
+            "line": 1,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 6.283185307179586",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "21",
+        "killedBy": Array [
+          "5",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 3,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "2 / Math.PI",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 0.6366197723675814 to equal 6.283185307179586",
+        "testsCompleted": 1,
+      },
+    ],
+    "source": "module.exports.getCircumference = function(radius) {
+  //Function to test multiple math mutations in a single function.
+  return 2 * Math.PI * radius;
+};
+
+module.exports.untestedFunction = function() {
+  var i = 5 / 2 * 3;
+};
+",
+  },
+}
+`;
+
+exports[`Verify stryker has ran correctly should report json report with expected results 2`] = `
+Object {
+  "test/unit/AddSpec.js": Object {
+    "source": "var addModule = require('../../src/Add');
+var add = addModule.add;
+var addOne = addModule.addOne;
+var isNegativeNumber = addModule.isNegativeNumber;
+var negate = addModule.negate;
+var notCovered = addModule.notCovered;
+
+describe('Add', function() {
+  it('should be able to add two numbers', function() {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = num1 + num2;
+
+    var actual = add(num1, num2);
+
+    expect(actual).to.be.equal(expected);
+  });
+
+  it('should be able 1 to a number', function() {
+    var number = 2;
+    var expected = 3;
+
+    var actual = addOne(number);
+
+    expect(actual).to.be.equal(expected);
+  });
+
+  it('should be able negate a number', function() {
+    var number = 2;
+    var expected = -2;
+
+    var actual = negate(number);
+
+    expect(actual).to.be.equal(expected);
+  });
+
+  it('should be able to recognize a negative number', function() {
+    var number = -2;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).to.be.true;
+  });
+
+  it('should be able to recognize that 0 is not a negative number', function() {
+    var number = 0;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).to.be.false;
+  });
+});
+",
+    "tests": Array [
+      Object {
+        "id": "0",
+        "name": "Add should be able to add two numbers",
+      },
+      Object {
+        "id": "1",
+        "name": "Add should be able 1 to a number",
+      },
+      Object {
+        "id": "2",
+        "name": "Add should be able negate a number",
+      },
+      Object {
+        "id": "3",
+        "name": "Add should be able to recognize a negative number",
+      },
+      Object {
+        "id": "4",
+        "name": "Add should be able to recognize that 0 is not a negative number",
+      },
+    ],
+  },
+  "test/unit/CircleSpec.js": Object {
+    "source": "var circleModule = require('../../src/Circle');
+var getCircumference = circleModule.getCircumference;
+
+describe('Circle', function() {
+  it('should have a circumference of 2PI when the radius is 1', function() {
+    var radius = 1;
+    var expectedCircumference = 2 * Math.PI;
+
+    var circumference = getCircumference(radius);
+
+    expect(circumference).to.be.equal(expectedCircumference);
+  });
+});
+",
+    "tests": Array [
+      Object {
+        "id": "5",
+        "name": "Circle should have a circumference of 2PI when the radius is 1",
+      },
+    ],
+  },
+}
+`;

--- a/e2e/test/reporters-e2e/verify/verify.js.snap
+++ b/e2e/test/reporters-e2e/verify/verify.js.snap
@@ -6,94 +6,29 @@ Object {
     "language": "javascript",
     "mutants": Array [
       Object {
-        "coveredBy": Array [],
-        "id": "6",
+        "coveredBy": Array [
+          "0",
+        ],
+        "id": "0",
+        "killedBy": Array [
+          "0",
+        ],
         "location": Object {
           "end": Object {
             "column": 2,
-            "line": 16,
+            "line": 3,
           },
           "start": Object {
-            "column": 46,
-            "line": 14,
+            "column": 43,
+            "line": 1,
           },
         },
         "mutatorName": "BlockStatement",
         "replacement": "{}",
         "static": false,
-        "status": "NoCoverage",
-      },
-      Object {
-        "coveredBy": Array [],
-        "id": "7",
-        "location": Object {
-          "end": Object {
-            "column": 21,
-            "line": 15,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 15,
-          },
-        },
-        "mutatorName": "ConditionalExpression",
-        "replacement": "true",
-        "static": false,
-        "status": "NoCoverage",
-      },
-      Object {
-        "coveredBy": Array [],
-        "id": "8",
-        "location": Object {
-          "end": Object {
-            "column": 21,
-            "line": 15,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 15,
-          },
-        },
-        "mutatorName": "ConditionalExpression",
-        "replacement": "false",
-        "static": false,
-        "status": "NoCoverage",
-      },
-      Object {
-        "coveredBy": Array [],
-        "id": "9",
-        "location": Object {
-          "end": Object {
-            "column": 21,
-            "line": 15,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 15,
-          },
-        },
-        "mutatorName": "EqualityOperator",
-        "replacement": "number >= 10",
-        "static": false,
-        "status": "NoCoverage",
-      },
-      Object {
-        "coveredBy": Array [],
-        "id": "10",
-        "location": Object {
-          "end": Object {
-            "column": 21,
-            "line": 15,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 15,
-          },
-        },
-        "mutatorName": "EqualityOperator",
-        "replacement": "number <= 10",
-        "static": false,
-        "status": "NoCoverage",
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 7",
+        "testsCompleted": 1,
       },
       Object {
         "coveredBy": Array [
@@ -121,104 +56,22 @@ Object {
         "testsCompleted": 1,
       },
       Object {
-        "coveredBy": Array [
-          "1",
-        ],
-        "id": "2",
-        "killedBy": Array [
-          "1",
-        ],
+        "coveredBy": Array [],
+        "id": "10",
         "location": Object {
           "end": Object {
-            "column": 2,
-            "line": 8,
-          },
-          "start": Object {
-            "column": 42,
-            "line": 5,
-          },
-        },
-        "mutatorName": "BlockStatement",
-        "replacement": "{}",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected undefined to equal 3",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
-          "1",
-        ],
-        "id": "3",
-        "killedBy": Array [
-          "1",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 11,
-            "line": 6,
-          },
-          "start": Object {
-            "column": 3,
-            "line": 6,
-          },
-        },
-        "mutatorName": "UpdateOperator",
-        "replacement": "number--",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected 1 to equal 3",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
-          "2",
-        ],
-        "id": "4",
-        "killedBy": Array [
-          "2",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 2,
-            "line": 12,
-          },
-          "start": Object {
-            "column": 42,
-            "line": 10,
-          },
-        },
-        "mutatorName": "BlockStatement",
-        "replacement": "{}",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected undefined to equal -2",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
-          "2",
-        ],
-        "id": "5",
-        "killedBy": Array [
-          "2",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 17,
-            "line": 11,
+            "column": 21,
+            "line": 15,
           },
           "start": Object {
             "column": 10,
-            "line": 11,
+            "line": 15,
           },
         },
-        "mutatorName": "UnaryOperator",
-        "replacement": "+number",
+        "mutatorName": "EqualityOperator",
+        "replacement": "number <= 10",
         "static": false,
-        "status": "Killed",
-        "statusReason": "expected 2 to equal -2",
-        "testsCompleted": 1,
+        "status": "NoCoverage",
       },
       Object {
         "coveredBy": Array [
@@ -403,31 +256,6 @@ Object {
       },
       Object {
         "coveredBy": Array [
-          "0",
-        ],
-        "id": "0",
-        "killedBy": Array [
-          "0",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 2,
-            "line": 3,
-          },
-          "start": Object {
-            "column": 43,
-            "line": 1,
-          },
-        },
-        "mutatorName": "BlockStatement",
-        "replacement": "{}",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected undefined to equal 7",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
           "3",
         ],
         "id": "18",
@@ -450,6 +278,178 @@ Object {
         "status": "Killed",
         "statusReason": "expected false to be true",
         "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "1",
+        ],
+        "id": "2",
+        "killedBy": Array [
+          "1",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 5,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 3",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "1",
+        ],
+        "id": "3",
+        "killedBy": Array [
+          "1",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 11,
+            "line": 6,
+          },
+          "start": Object {
+            "column": 3,
+            "line": 6,
+          },
+        },
+        "mutatorName": "UpdateOperator",
+        "replacement": "number--",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 1 to equal 3",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "2",
+        ],
+        "id": "4",
+        "killedBy": Array [
+          "2",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 12,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 10,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal -2",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "2",
+        ],
+        "id": "5",
+        "killedBy": Array [
+          "2",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 17,
+            "line": 11,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 11,
+          },
+        },
+        "mutatorName": "UnaryOperator",
+        "replacement": "+number",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 2 to equal -2",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "6",
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 16,
+          },
+          "start": Object {
+            "column": 46,
+            "line": 14,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "7",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "true",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "8",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "ConditionalExpression",
+        "replacement": "false",
+        "static": false,
+        "status": "NoCoverage",
+      },
+      Object {
+        "coveredBy": Array [],
+        "id": "9",
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 15,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 15,
+          },
+        },
+        "mutatorName": "EqualityOperator",
+        "replacement": "number >= 10",
+        "static": false,
+        "status": "NoCoverage",
       },
     ],
     "source": "module.exports.add = function(num1, num2) {
@@ -483,6 +483,77 @@ module.exports.isNegativeNumber = function(number) {
   "src/Circle.js": Object {
     "language": "javascript",
     "mutants": Array [
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "19",
+        "killedBy": Array [
+          "5",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 52,
+            "line": 1,
+          },
+        },
+        "mutatorName": "BlockStatement",
+        "replacement": "{}",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected undefined to equal 6.283185307179586",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "20",
+        "location": Object {
+          "end": Object {
+            "column": 30,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 3,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "2 * Math.PI / radius",
+        "static": false,
+        "status": "Survived",
+        "testsCompleted": 1,
+      },
+      Object {
+        "coveredBy": Array [
+          "5",
+        ],
+        "id": "21",
+        "killedBy": Array [
+          "5",
+        ],
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 3,
+          },
+        },
+        "mutatorName": "ArithmeticOperator",
+        "replacement": "2 / Math.PI",
+        "static": false,
+        "status": "Killed",
+        "statusReason": "expected 0.6366197723675814 to equal 6.283185307179586",
+        "testsCompleted": 1,
+      },
       Object {
         "coveredBy": Array [],
         "id": "22",
@@ -536,77 +607,6 @@ module.exports.isNegativeNumber = function(number) {
         "replacement": "5 * 2",
         "static": false,
         "status": "NoCoverage",
-      },
-      Object {
-        "coveredBy": Array [
-          "5",
-        ],
-        "id": "20",
-        "location": Object {
-          "end": Object {
-            "column": 30,
-            "line": 3,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 3,
-          },
-        },
-        "mutatorName": "ArithmeticOperator",
-        "replacement": "2 * Math.PI / radius",
-        "static": false,
-        "status": "Survived",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
-          "5",
-        ],
-        "id": "19",
-        "killedBy": Array [
-          "5",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 2,
-            "line": 4,
-          },
-          "start": Object {
-            "column": 52,
-            "line": 1,
-          },
-        },
-        "mutatorName": "BlockStatement",
-        "replacement": "{}",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected undefined to equal 6.283185307179586",
-        "testsCompleted": 1,
-      },
-      Object {
-        "coveredBy": Array [
-          "5",
-        ],
-        "id": "21",
-        "killedBy": Array [
-          "5",
-        ],
-        "location": Object {
-          "end": Object {
-            "column": 21,
-            "line": 3,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 3,
-          },
-        },
-        "mutatorName": "ArithmeticOperator",
-        "replacement": "2 / Math.PI",
-        "static": false,
-        "status": "Killed",
-        "statusReason": "expected 0.6366197723675814 to equal 6.283185307179586",
-        "testsCompleted": 1,
       },
     ],
     "source": "module.exports.getCircumference = function(radius) {

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -4,7 +4,7 @@ import { Location, Position, StrykerOptions, MutantTestCoverage, MutantResult, s
 import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { Reporter } from '@stryker-mutator/api/report';
-import { normalizeWhitespaces, type requireResolve } from '@stryker-mutator/util';
+import { normalizeFileName, normalizeWhitespaces, type requireResolve } from '@stryker-mutator/util';
 import { calculateMutationTestMetrics, MutationTestMetricsResult } from 'mutation-testing-metrics';
 import { CompleteDryRunResult, MutantRunResult, MutantRunStatus, TestResult } from '@stryker-mutator/api/test-runner';
 import { CheckStatus, PassedCheckResult, CheckResult } from '@stryker-mutator/api/check';
@@ -166,7 +166,8 @@ export class MutationTestReportHelper {
     );
 
     return results.reduce<schema.FileResultDictionary>((acc, mutantResult) => {
-      const fileResult = acc[mutantResult.fileName] ?? (acc[mutantResult.fileName] = fileResultsByName.get(mutantResult.fileName)!);
+      const reportFileName = normalizeReportFileName(mutantResult.fileName);
+      const fileResult = acc[reportFileName] ?? (acc[reportFileName] = fileResultsByName.get(mutantResult.fileName)!);
       fileResult.mutants.push(this.toMutantResult(mutantResult, remapTestIds));
       return acc;
     }, {});
@@ -175,16 +176,16 @@ export class MutationTestReportHelper {
   private async toTestFiles(remapTestId: (id: string) => string): Promise<schema.TestFileDefinitionDictionary> {
     const testResultsByName = new Map<string, schema.TestFile>(
       await Promise.all(
-        [...new Set(this.dryRunResult.tests.map(({ fileName }) => fileName && path.relative(process.cwd(), fileName)))].map(
-          async (fileName) => [fileName ?? '', await this.toTestFile(fileName)] as const
+        [...new Set(this.dryRunResult.tests.map(({ fileName }) => fileName))].map(
+          async (fileName) => [normalizeReportFileName(fileName), await this.toTestFile(fileName)] as const
         )
       )
     );
 
     return this.dryRunResult.tests.reduce<schema.TestFileDefinitionDictionary>((acc, testResult) => {
       const test = this.toTestDefinition(testResult, remapTestId);
-      const fileName = (testResult.fileName && path.relative(process.cwd(), testResult.fileName)) ?? ''; // by default we accumulate tests under the '' key
-      const testFile = acc[fileName] ?? (acc[fileName] = testResultsByName.get(fileName)!);
+      const reportFileName = normalizeReportFileName(testResult.fileName);
+      const testFile = acc[reportFileName] ?? (acc[reportFileName] = testResultsByName.get(reportFileName)!);
       testFile.tests.push(test);
       return acc;
     }, {});
@@ -308,4 +309,12 @@ export class MutationTestReportHelper {
       return acc;
     }, {});
   }
+}
+
+function normalizeReportFileName(fileName: string | undefined) {
+  if (fileName) {
+    return normalizeFileName(path.relative(process.cwd(), fileName));
+  }
+  // File name is not required for test files. By default we accumulate tests under the '' key
+  return '';
 }

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -175,7 +175,7 @@ export class MutationTestReportHelper {
   private async toTestFiles(remapTestId: (id: string) => string): Promise<schema.TestFileDefinitionDictionary> {
     const testResultsByName = new Map<string, schema.TestFile>(
       await Promise.all(
-        [...new Set(this.dryRunResult.tests.map(({ fileName }) => fileName))].map(
+        [...new Set(this.dryRunResult.tests.map(({ fileName }) => fileName && path.relative(process.cwd(), fileName)))].map(
           async (fileName) => [fileName ?? '', await this.toTestFile(fileName)] as const
         )
       )
@@ -183,7 +183,7 @@ export class MutationTestReportHelper {
 
     return this.dryRunResult.tests.reduce<schema.TestFileDefinitionDictionary>((acc, testResult) => {
       const test = this.toTestDefinition(testResult, remapTestId);
-      const fileName = testResult.fileName ?? ''; // by default we accumulate tests under the '' key
+      const fileName = (testResult.fileName && path.relative(process.cwd(), testResult.fileName)) ?? ''; // by default we accumulate tests under the '' key
       const testFile = acc[fileName] ?? (acc[fileName] = testResultsByName.get(fileName)!);
       testFile.tests.push(test);
       return acc;

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import sinon from 'sinon';
 import { Location, MutantResult, MutantStatus, schema } from '@stryker-mutator/api/core';
 import { Reporter } from '@stryker-mutator/api/report';
@@ -335,6 +337,19 @@ describe(MutationTestReportHelper.name, () => {
         expect(actualReport.testFiles!['foo.spec.js'].tests[0].name).eq('1');
         expect(actualReport.testFiles!['foo.spec.js'].tests[1].name).eq('3');
         expect(actualReport.testFiles!['bar.spec.js'].tests[0].name).eq('2');
+      });
+
+      it('should make test file names relative', async () => {
+        // Arrange
+        dryRunResult.tests.push(factory.testResult({ fileName: path.resolve('test', 'unit', 'foo.spec.js'), name: '1' }));
+        fileSystemTestDouble.files['test/unit/foo.spec.js'] = '';
+
+        // Act
+        const [actualReport] = await actReportAll();
+
+        // Assert
+        expect(Object.keys(actualReport.testFiles!)).lengthOf(1);
+        expect(actualReport.testFiles![path.join('test', 'unit', 'foo.spec.js')].tests).lengthOf(1);
       });
 
       it('should log a warning the test file could not be found', async () => {

--- a/packages/util/src/string-utils.ts
+++ b/packages/util/src/string-utils.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import { KnownKeys } from './known-keys';
 import { Primitive } from './primitive';
 

--- a/packages/util/src/string-utils.ts
+++ b/packages/util/src/string-utils.ts
@@ -43,3 +43,10 @@ export function escapeRegExpLiteral(input: string): string {
 export function escapeRegExp(input: string): string {
   return input.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
+
+/**
+ * Normalizes relative or absolute file names to be in posix format (forward slashes '/')
+ */
+export function normalizeFileName(fileName: string): string {
+  return fileName.replace(/\/|\\/g, '/');
+}

--- a/packages/util/src/string-utils.ts
+++ b/packages/util/src/string-utils.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { KnownKeys } from './known-keys';
 import { Primitive } from './primitive';
 

--- a/packages/util/test/unit/string-utils.spec.ts
+++ b/packages/util/test/unit/string-utils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral, escapeRegExp } from '../../src/index.js';
+import { normalizeWhitespaces, propertyPath, escapeRegExpLiteral, escapeRegExp, normalizeFileName } from '../../src/index.js';
 
 describe('stringUtils', () => {
   describe(normalizeWhitespaces.name, () => {
@@ -94,5 +94,14 @@ describe('stringUtils', () => {
         expect(escapeRegExp(letter)).eq(`\\${letter}`);
       });
     }
+  });
+
+  describe(normalizeFileName.name, () => {
+    it('should normalize `\\`', () => {
+      expect(normalizeFileName('test\\util\\foo.spec.js')).eq('test/util/foo.spec.js');
+    });
+    it('should normalize `/`', () => {
+      expect(normalizeFileName('test/util/foo.spec.js')).eq('test/util/foo.spec.js');
+    });
   });
 });


### PR DESCRIPTION
Make all file paths relative in the JSON report. This is needed to make the JSON portable between servers/machines when using `--incremental` mode.
