### PR TITLE
chore(npmrc): configure legacy peer deps using npmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "all": "npm run clean && npm run build && npm run lint && npm run test",
-    "postinstall": "lerna bootstrap -- --legacy-peer-deps",
+    "postinstall": "lerna bootstrap",
     "lint": "eslint . --resolve-plugins-relative-to . --ext .ts,.js",
     "lint:fix": "npm run lint -- --fix",
     "clean": "rimraf \"packages/*/{.nyc_output,reports,coverage,src-generated,*.tsbuildinfo,.stryker-tmp,dist,testResources/tmp}\" \"packages/core/schema/stryker-schema.json\"",

--- a/packages/api/.npmrc
+++ b/packages/api/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/core/.npmrc
+++ b/packages/core/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/cucumber-runner/.npmrc
+++ b/packages/cucumber-runner/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/grunt-stryker/.npmrc
+++ b/packages/grunt-stryker/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/instrumenter/.npmrc
+++ b/packages/instrumenter/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/jasmine-runner/.npmrc
+++ b/packages/jasmine-runner/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/jest-runner/.npmrc
+++ b/packages/jest-runner/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/karma-runner/.npmrc
+++ b/packages/karma-runner/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/mocha-runner/.npmrc
+++ b/packages/mocha-runner/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/test-helpers/.npmrc
+++ b/packages/test-helpers/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/typescript-checker/.npmrc
+++ b/packages/typescript-checker/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/util/.npmrc
+++ b/packages/util/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Configure legacy peer dependencies using `.npmrc` files instead of a lerna cli argument. I hope that this way: renovate bot will also be aware if this flag.
