### PR TITLE
typo in docs: config file example for dashboard

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,7 @@ Config file:
 
 ```json
 {
-  "dasboard": {
+  "dashboard": {
     "project": "github.com/my-org/my-project",
     "version": "branch-or-tag",
     "module": "my-module",


### PR DESCRIPTION
at: https://stryker-mutator.io/docs/stryker-js/configuration/#dashboard-dashboardoptions
the "config file" example has a typo:
**dasboard** instead of **dashboard**