### PR TITLE
fix(mutant placing): computed member expressions

### DIFF
--- a/packages/instrumenter/test/integration/instrumenter.it.spec.ts
+++ b/packages/instrumenter/test/integration/instrumenter.it.spec.ts
@@ -59,6 +59,9 @@ describe('instrumenter integration', () => {
   it('should be able to instrument string literals in different places', async () => {
     await arrangeAndActAssert('string-mutations.ts');
   });
+  it('should be able to place exotic mutants', async () => {
+    await arrangeAndActAssert('mutant-placing.ts');
+  });
 
   describe('type declarations', () => {
     it('should not produce mutants for TS type definitions', async () => {

--- a/packages/instrumenter/testResources/instrumenter/mutant-placing.ts
+++ b/packages/instrumenter/testResources/instrumenter/mutant-placing.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+
+// https://github.com/stryker-mutator/stryker-js/issues/3702
+directoryFiles[file[0].substr(1)] = file[1]

--- a/packages/instrumenter/testResources/instrumenter/mutant-placing.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/mutant-placing.ts.out.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`instrumenter integration should be able to instrument optional chains 1`] = `
-"function stryNS_9fa48() {
+exports[`instrumenter integration should be able to place exotic mutants 1`] = `
+"// @ts-nocheck
+// https://github.com/stryker-mutator/stryker-js/issues/3702
+function stryNS_9fa48() {
   var g = new Function(\\"return this\\")();
   var ns = g.__stryker__ || (g.__stryker__ = {});
 
@@ -63,9 +65,5 @@ function stryMutAct_9fa48(id) {
   return isActive(id);
 }
 
-const baz = stryMutAct_9fa48(\\"0\\") ? foo?.bar?.()?.[1] && 'qux' : (stryCov_9fa48(\\"0\\"), (stryMutAct_9fa48(\\"1\\") ? foo?.bar?.()[1] : (stryCov_9fa48(\\"1\\"), (stryMutAct_9fa48(\\"3\\") ? foo.bar?.() : stryMutAct_9fa48(\\"2\\") ? foo?.bar() : (stryCov_9fa48(\\"2\\", \\"3\\"), foo?.bar?.()))?.[1])) ?? (stryMutAct_9fa48(\\"4\\") ? \\"\\" : (stryCov_9fa48(\\"4\\"), 'qux')));
-stryMutAct_9fa48(\\"5\\") ? qux().map() : (stryCov_9fa48(\\"5\\"), qux()?.map());
-const directiveRanges = stryMutAct_9fa48(\\"6\\") ? comments.map(tryParseTSDirective) : (stryCov_9fa48(\\"6\\"), comments?.map(tryParseTSDirective));
-const qux = quux(stryMutAct_9fa48(\\"7\\") ? corge.cov() : (stryCov_9fa48(\\"7\\"), corge?.cov()));
-(stryMutAct_9fa48(\\"8\\") ? input.id : (stryCov_9fa48(\\"8\\"), input?.id))!.toString();"
+directoryFiles[stryMutAct_9fa48(\\"0\\") ? file[0] : (stryCov_9fa48(\\"0\\"), file[0].substr(1))] = file[1];"
 `;


### PR DESCRIPTION
Allow the conditional expression mutant placer to place mutants inside computed member expressions.

For example, allow mutants to be placed in `foo.bar()` here:
```js
baz[foo.bar()]
```

Fixes #3702
Fixes #3647