### PR TITLE
fix(jest): support multiple jest installations

### DIFF
--- a/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
+++ b/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
@@ -8,7 +8,7 @@ import { Config } from '@jest/types';
 import type { requireResolve } from '@stryker-mutator/util';
 
 import { JestRunnerOptionsWithStrykerOptions } from '../jest-runner-options-with-stryker-options.js';
-import * as pluginTokens from '../plugin-tokens.js';
+import { pluginTokens } from '../plugin-di.js';
 
 import { JestConfigLoader } from './jest-config-loader.js';
 

--- a/packages/jest-runner/src/config-loaders/index.ts
+++ b/packages/jest-runner/src/config-loaders/index.ts
@@ -1,13 +1,10 @@
-import { createRequire } from 'module';
-
-import { tokens, commonTokens, Injector, PluginContext } from '@stryker-mutator/api/plugin';
+import { tokens, commonTokens, Injector } from '@stryker-mutator/api/plugin';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
-
 import { requireResolve } from '@stryker-mutator/util';
 
 import { JestRunnerOptionsWithStrykerOptions } from '../jest-runner-options-with-stryker-options.js';
-import * as pluginTokens from '../plugin-tokens.js';
+import { JestPluginContext, pluginTokens } from '../plugin-di.js';
 
 import { CustomJestConfigLoader } from './custom-jest-config-loader.js';
 import { ReactScriptsJestConfigLoader } from './react-scripts-jest-config-loader.js';
@@ -15,7 +12,7 @@ import { ReactScriptsJestConfigLoader } from './react-scripts-jest-config-loader
 configLoaderFactory.inject = tokens(commonTokens.options, commonTokens.injector, commonTokens.logger);
 export function configLoaderFactory(
   options: StrykerOptions,
-  injector: Injector<PluginContext>,
+  injector: Injector<JestPluginContext>,
   log: Logger
 ): CustomJestConfigLoader | ReactScriptsJestConfigLoader {
   const warnAboutConfigFile = (projectType: string, configFile: string | undefined) => {
@@ -24,16 +21,12 @@ export function configLoaderFactory(
     }
   };
   const optionsWithJest: JestRunnerOptionsWithStrykerOptions = options as JestRunnerOptionsWithStrykerOptions;
-  const configLoaderInjector = injector
-    .provideValue(pluginTokens.resolve, createRequire(import.meta.url).resolve)
-    .provideValue(pluginTokens.requireFromCwd, requireResolve)
-    .provideValue(pluginTokens.processEnv, process.env);
   switch (optionsWithJest.jest.projectType) {
     case 'custom':
-      return configLoaderInjector.injectClass(CustomJestConfigLoader);
+      return injector.injectClass(CustomJestConfigLoader);
     case 'create-react-app':
       warnAboutConfigFile(optionsWithJest.jest.projectType, optionsWithJest.jest.configFile);
-      return configLoaderInjector.injectClass(ReactScriptsJestConfigLoader);
+      return injector.injectClass(ReactScriptsJestConfigLoader);
     default:
       throw new Error(`No configLoader available for ${optionsWithJest.jest.projectType}`);
   }

--- a/packages/jest-runner/src/config-loaders/index.ts
+++ b/packages/jest-runner/src/config-loaders/index.ts
@@ -1,10 +1,9 @@
 import { tokens, commonTokens, Injector } from '@stryker-mutator/api/plugin';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
-import { requireResolve } from '@stryker-mutator/util';
 
 import { JestRunnerOptionsWithStrykerOptions } from '../jest-runner-options-with-stryker-options.js';
-import { JestPluginContext, pluginTokens } from '../plugin-di.js';
+import { JestPluginContext } from '../plugin-di.js';
 
 import { CustomJestConfigLoader } from './custom-jest-config-loader.js';
 import { ReactScriptsJestConfigLoader } from './react-scripts-jest-config-loader.js';

--- a/packages/jest-runner/src/jest-plugins/cjs/import-jest-environment.ts
+++ b/packages/jest-runner/src/jest-plugins/cjs/import-jest-environment.ts
@@ -1,8 +1,10 @@
 import type { JestEnvironment } from '@jest/environment';
 
+import { state } from './messaging.js';
+
 export function loadJestEnvironment(name: string): typeof JestEnvironment {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const jestEnvironmentModule = require(require.resolve(name, { paths: [process.cwd()] }));
+  const jestEnvironmentModule = require(require.resolve(name, { paths: [state.resolveFromDirectory] }));
 
   return jestEnvironmentModule.default ?? jestEnvironmentModule;
 }

--- a/packages/jest-runner/src/jest-plugins/cjs/messaging.ts
+++ b/packages/jest-runner/src/jest-plugins/cjs/messaging.ts
@@ -5,6 +5,7 @@ class State {
   public testFilesWithStrykerEnvironment = new Set<string>();
   public coverageAnalysis!: CoverageAnalysis;
   public jestEnvironment!: string;
+  public resolveFromDirectory!: string;
 
   constructor() {
     this.clear();
@@ -15,6 +16,7 @@ class State {
     this.instrumenterContext = {};
     this.coverageAnalysis = 'off';
     this.jestEnvironment = 'jest-environment-node';
+    this.resolveFromDirectory = process.cwd();
   }
 }
 

--- a/packages/jest-runner/src/jest-test-adapters/jest-greater-than-25-adapter.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-greater-than-25-adapter.ts
@@ -1,12 +1,16 @@
-import { jestWrapper } from '../utils/index.js';
 import { JestRunResult } from '../jest-run-result.js';
+import { pluginTokens } from '../plugin-di.js';
+import { JestWrapper } from '../utils/jest-wrapper.js';
 
 import { JestTestAdapter, RunSettings } from './jest-test-adapter.js';
 
 export class JestGreaterThan25TestAdapter implements JestTestAdapter {
+  public static readonly inject = [pluginTokens.jestWrapper] as const;
+  constructor(private readonly jestWrapper: JestWrapper) {}
+
   public async run({ jestConfig, fileNamesUnderTest, testNamePattern, testLocationInResults }: RunSettings): Promise<JestRunResult> {
     const config = JSON.stringify(jestConfig);
-    const result = await jestWrapper.runCLI(
+    const result = await this.jestWrapper.runCLI(
       {
         $0: 'stryker',
         _: fileNamesUnderTest ? fileNamesUnderTest : [],

--- a/packages/jest-runner/src/jest-test-adapters/jest-less-than-25-adapter.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-less-than-25-adapter.ts
@@ -1,5 +1,6 @@
-import { jestWrapper } from '../utils/index.js';
 import { JestRunResult } from '../jest-run-result.js';
+import { JestWrapper } from '../utils/jest-wrapper.js';
+import { pluginTokens } from '../plugin-di.js';
 
 import { RunSettings, JestTestAdapter } from './jest-test-adapter.js';
 
@@ -8,9 +9,12 @@ import { RunSettings, JestTestAdapter } from './jest-test-adapter.js';
  * It has a lot of `any` typings here, since the installed typings are not in sync.
  */
 export class JestLessThan25TestAdapter implements JestTestAdapter {
+  public static readonly inject = [pluginTokens.jestWrapper] as const;
+  constructor(private readonly jestWrapper: JestWrapper) {}
+
   public run({ jestConfig, fileNamesUnderTest, testNamePattern, testLocationInResults }: RunSettings): Promise<JestRunResult> {
     const config = JSON.stringify(jestConfig);
-    return jestWrapper.runCLI(
+    return this.jestWrapper.runCLI(
       {
         $0: 'stryker',
         _: fileNamesUnderTest ? fileNamesUnderTest : [],

--- a/packages/jest-runner/src/jest-test-adapters/jest-test-adapter-factory.ts
+++ b/packages/jest-runner/src/jest-test-adapters/jest-test-adapter-factory.ts
@@ -1,29 +1,31 @@
 import { Logger } from '@stryker-mutator/api/logging';
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { BaseContext, commonTokens, Injector, tokens } from '@stryker-mutator/api/plugin';
+import { commonTokens, Injector, tokens } from '@stryker-mutator/api/plugin';
 import semver from 'semver';
 
-import { jestVersion } from '../plugin-tokens.js';
+import { JestPluginContext, pluginTokens } from '../plugin-di.js';
+import { JestWrapper } from '../utils/jest-wrapper.js';
 
 import { JestLessThan25TestAdapter } from './jest-less-than-25-adapter.js';
 import { JestGreaterThan25TestAdapter } from './jest-greater-than-25-adapter.js';
 
 export function jestTestAdapterFactory(
   log: Logger,
-  jest: string,
+  jestWrapper: JestWrapper,
   options: StrykerOptions,
-  injector: Injector<BaseContext>
+  injector: Injector<JestPluginContext>
 ): JestGreaterThan25TestAdapter | JestLessThan25TestAdapter {
-  log.debug('Detected Jest version %s', jest);
-  guardJestVersion(jest, options, log);
+  const version = jestWrapper.getVersion();
+  log.debug('Detected Jest version %s', version);
+  guardJestVersion(version, options, log);
 
-  if (semver.satisfies(jest, '<25.0.0')) {
+  if (semver.satisfies(version, '<25.0.0')) {
     return injector.injectClass(JestLessThan25TestAdapter);
   } else {
     return injector.injectClass(JestGreaterThan25TestAdapter);
   }
 }
-jestTestAdapterFactory.inject = tokens(commonTokens.logger, jestVersion, commonTokens.options, commonTokens.injector);
+jestTestAdapterFactory.inject = tokens(commonTokens.logger, pluginTokens.jestWrapper, commonTokens.options, commonTokens.injector);
 
 function guardJestVersion(jest: string, options: StrykerOptions, log: Logger) {
   if (semver.satisfies(jest, '<22.0.0')) {

--- a/packages/jest-runner/src/jest-test-runner.ts
+++ b/packages/jest-runner/src/jest-test-runner.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { createRequire } from 'module';
 
 import { StrykerOptions, INSTRUMENTER_CONSTANTS, CoverageAnalysis } from '@stryker-mutator/api/core';
 import { Logger } from '@stryker-mutator/api/logging';
@@ -17,7 +18,7 @@ import {
   TestRunnerCapabilities,
   determineHitLimitReached,
 } from '@stryker-mutator/api/test-runner';
-import { escapeRegExp, notEmpty } from '@stryker-mutator/util';
+import { escapeRegExp, notEmpty, requireResolve } from '@stryker-mutator/util';
 import type * as jest from '@jest/types';
 import type * as jestTestResult from '@jest/test-result';
 
@@ -27,11 +28,11 @@ import { jestTestAdapterFactory } from './jest-test-adapters/index.js';
 import { JestTestAdapter, RunSettings } from './jest-test-adapters/jest-test-adapter.js';
 import { JestConfigLoader } from './config-loaders/jest-config-loader.js';
 import { withCoverageAnalysis, withHitLimit } from './jest-plugins/index.js';
-import * as pluginTokens from './plugin-tokens.js';
+import { pluginTokens } from './plugin-di.js';
 import { configLoaderFactory } from './config-loaders/index.js';
 import { JestRunnerOptionsWithStrykerOptions } from './jest-runner-options-with-stryker-options.js';
 import { JEST_OVERRIDE_OPTIONS } from './jest-override-options.js';
-import { jestWrapper, verifyAllTestFilesHaveCoverage } from './utils/index.js';
+import { determineResolveFromDirectory, JestWrapper, verifyAllTestFilesHaveCoverage } from './utils/index.js';
 import { state } from './jest-plugins/cjs/messaging.js';
 
 export function createJestTestRunnerFactory(namespace: typeof INSTRUMENTER_CONSTANTS.NAMESPACE | '__stryker2__' = INSTRUMENTER_CONSTANTS.NAMESPACE): {
@@ -41,7 +42,11 @@ export function createJestTestRunnerFactory(namespace: typeof INSTRUMENTER_CONST
   jestTestRunnerFactory.inject = tokens(commonTokens.injector);
   function jestTestRunnerFactory(injector: Injector<PluginContext>) {
     return injector
-      .provideValue(pluginTokens.jestVersion, jestWrapper.getVersion())
+      .provideValue(pluginTokens.resolve, createRequire(process.cwd()).resolve)
+      .provideFactory(pluginTokens.resolveFromDirectory, determineResolveFromDirectory)
+      .provideValue(pluginTokens.requireFromCwd, requireResolve)
+      .provideValue(pluginTokens.processEnv, process.env)
+      .provideClass(pluginTokens.jestWrapper, JestWrapper)
       .provideFactory(pluginTokens.jestTestAdapter, jestTestAdapterFactory)
       .provideFactory(pluginTokens.configLoader, configLoaderFactory)
       .provideValue(pluginTokens.globalNamespace, namespace)
@@ -62,6 +67,7 @@ export class JestTestRunner implements TestRunner {
     commonTokens.options,
     pluginTokens.jestTestAdapter,
     pluginTokens.configLoader,
+    pluginTokens.jestWrapper,
     pluginTokens.globalNamespace
   );
 
@@ -70,6 +76,7 @@ export class JestTestRunner implements TestRunner {
     options: StrykerOptions,
     private readonly jestTestAdapter: JestTestAdapter,
     configLoader: JestConfigLoader,
+    private readonly jestWrapper: JestWrapper,
     private readonly globalNamespace: typeof INSTRUMENTER_CONSTANTS.NAMESPACE | '__stryker2__'
   ) {
     this.jestOptions = (options as JestRunnerOptionsWithStrykerOptions).jest;
@@ -98,7 +105,7 @@ export class JestTestRunner implements TestRunner {
     const fileNamesUnderTest = this.enableFindRelatedTests ? files : undefined;
     const { dryRunResult, jestResult } = await this.run({
       fileNamesUnderTest,
-      jestConfig: this.configForDryRun(fileNamesUnderTest, coverageAnalysis),
+      jestConfig: this.configForDryRun(fileNamesUnderTest, coverageAnalysis, this.jestWrapper),
       testLocationInResults: true,
     });
     if (dryRunResult.status === DryRunStatus.Complete && coverageAnalysis !== 'off') {
@@ -131,7 +138,7 @@ export class JestTestRunner implements TestRunner {
       process.env[INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE] = activeMutant.id.toString();
       const { dryRunResult } = await this.run({
         fileNamesUnderTest: fileNameUnderTest ? [fileNameUnderTest] : undefined,
-        jestConfig: this.configForMutantRun(fileNameUnderTest, hitLimit),
+        jestConfig: this.configForMutantRun(fileNameUnderTest, hitLimit, this.jestWrapper),
         testNamePattern,
       });
       return toMutantRunResult(dryRunResult, disableBail);
@@ -141,12 +148,20 @@ export class JestTestRunner implements TestRunner {
     }
   }
 
-  private configForDryRun(fileNamesUnderTest: string[] | undefined, coverageAnalysis: CoverageAnalysis): jest.Config.InitialOptions {
-    return withCoverageAnalysis(this.configWithRoots(fileNamesUnderTest), coverageAnalysis);
+  private configForDryRun(
+    fileNamesUnderTest: string[] | undefined,
+    coverageAnalysis: CoverageAnalysis,
+    jestWrapper: JestWrapper
+  ): jest.Config.InitialOptions {
+    return withCoverageAnalysis(this.configWithRoots(fileNamesUnderTest), coverageAnalysis, jestWrapper);
   }
 
-  private configForMutantRun(fileNameUnderTest: string | undefined, hitLimit: number | undefined): jest.Config.InitialOptions {
-    return withHitLimit(this.configWithRoots(fileNameUnderTest ? [fileNameUnderTest] : undefined), hitLimit);
+  private configForMutantRun(
+    fileNameUnderTest: string | undefined,
+    hitLimit: number | undefined,
+    jestWrapper: JestWrapper
+  ): jest.Config.InitialOptions {
+    return withHitLimit(this.configWithRoots(fileNameUnderTest ? [fileNameUnderTest] : undefined), hitLimit, jestWrapper);
   }
 
   private configWithRoots(fileNamesUnderTest: string[] | undefined): jest.Config.InitialOptions {

--- a/packages/jest-runner/src/plugin-di.ts
+++ b/packages/jest-runner/src/plugin-di.ts
@@ -1,0 +1,22 @@
+import { PluginContext } from '@stryker-mutator/api/src/plugin';
+import { requireResolve } from '@stryker-mutator/util';
+
+import { JestWrapper } from './utils/index.js';
+
+export const pluginTokens = {
+  requireFromCwd: 'requireFromCwd',
+  resolve: 'resolve',
+  resolveFromDirectory: 'resolveFromDirectory',
+  configLoader: 'configLoader',
+  processEnv: 'processEnv',
+  jestTestAdapter: 'jestTestAdapter',
+  globalNamespace: 'globalNamespace',
+  jestWrapper: 'jestWrapper',
+} as const;
+
+export interface JestPluginContext extends PluginContext {
+  [pluginTokens.jestWrapper]: JestWrapper;
+  [pluginTokens.resolve]: RequireResolve;
+  [pluginTokens.requireFromCwd]: typeof requireResolve;
+  [pluginTokens.processEnv]: typeof process.env;
+}

--- a/packages/jest-runner/src/plugin-tokens.ts
+++ b/packages/jest-runner/src/plugin-tokens.ts
@@ -1,7 +1,0 @@
-export const requireFromCwd = 'requireFromCwd';
-export const resolve = 'resolve';
-export const configLoader = 'configLoader';
-export const processEnv = 'processEnv';
-export const jestTestAdapter = 'jestTestAdapter';
-export const jestVersion = 'jestVersion';
-export const globalNamespace = 'globalNamespace';

--- a/packages/jest-runner/src/utils/jest-wrapper.ts
+++ b/packages/jest-runner/src/utils/jest-wrapper.ts
@@ -1,19 +1,40 @@
+import path from 'path';
+
+import { StrykerOptions } from '@stryker-mutator/api/src-generated/stryker-core.js';
+import { commonTokens } from '@stryker-mutator/api/plugin';
 import { requireResolve } from '@stryker-mutator/util';
 import type * as jestModule from 'jest';
 
-// Use requireResolve, that way you can use this plugin from a different directory
-const jest = requireResolve('jest') as typeof jestModule;
+import { JestRunnerOptionsWithStrykerOptions } from '../jest-runner-options-with-stryker-options.js';
+import { pluginTokens } from '../plugin-di.js';
+
+export function determineResolveFromDirectory(options: StrykerOptions, resolve: (moduleId: string) => string): string {
+  return (options as JestRunnerOptionsWithStrykerOptions).jest.projectType === 'create-react-app'
+    ? path.join(resolve('react-scripts/package.json'), '..')
+    : process.cwd();
+}
+determineResolveFromDirectory.inject = [commonTokens.options, pluginTokens.resolve] as const;
+
+type RunCli = typeof jestModule.runCLI;
+type GetVersion = typeof jestModule.getVersion;
 
 /**
  * Direct stubbing on jest is no longer possible since jest > 25
  */
-class JestWrapper {
-  public runCLI: typeof jestModule.runCLI = (...args) => {
-    return jest.runCLI(...args);
-  };
-  public getVersion: typeof jestModule.getVersion = (...args) => {
-    return jest.getVersion(...args);
-  };
-}
+export class JestWrapper {
+  private readonly jest: typeof jestModule;
 
-export const jestWrapper = new JestWrapper();
+  public static readonly inject = [pluginTokens.resolveFromDirectory, pluginTokens.requireFromCwd] as const;
+
+  constructor(resolveFromDirectory: string, requireFrom: typeof requireResolve) {
+    // Use requireResolve, that way you can use this plugin from a different directory
+    this.jest = requireFrom('jest', resolveFromDirectory) as typeof jestModule;
+  }
+
+  public runCLI(...args: Parameters<typeof jestModule.runCLI>): ReturnType<RunCli> {
+    return this.jest.runCLI(...args);
+  }
+  public getVersion(...args: Parameters<GetVersion>): ReturnType<GetVersion> {
+    return this.jest.getVersion(...args);
+  }
+}

--- a/packages/jest-runner/test/helpers/producers.ts
+++ b/packages/jest-runner/test/helpers/producers.ts
@@ -41,6 +41,14 @@ export function createJestRunResult(overrides?: Partial<JestRunResult>): JestRun
   };
 }
 
+export function createJestConfigArgv(overrides?: Partial<Config.Argv>): Config.Argv {
+  return {
+    $0: 'stryker',
+    _: [''],
+    ...overrides,
+  };
+}
+
 export function createJestAggregatedResult(overrides?: Partial<AggregatedResult>): AggregatedResult {
   return {
     numFailedTestSuites: 0,

--- a/packages/jest-runner/test/unit/config-loaders/custom-jest-config-loader.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/custom-jest-config-loader.spec.ts
@@ -8,7 +8,7 @@ import type { requireResolve } from '@stryker-mutator/util';
 import type { Config } from '@jest/types';
 
 import { CustomJestConfigLoader } from '../../../src/config-loaders/custom-jest-config-loader.js';
-import * as pluginTokens from '../../../src/plugin-tokens.js';
+import { pluginTokens } from '../../../src/plugin-di.js';
 import { createJestOptions } from '../../helpers/producers.js';
 import { JestRunnerOptionsWithStrykerOptions } from '../../../src/jest-runner-options-with-stryker-options.js';
 

--- a/packages/jest-runner/test/unit/config-loaders/react-scripts-jest-config-loader.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/react-scripts-jest-config-loader.spec.ts
@@ -6,7 +6,7 @@ import { testInjector } from '@stryker-mutator/test-helpers';
 import type { requireResolve } from '@stryker-mutator/util';
 
 import { ReactScriptsJestConfigLoader } from '../../../src/config-loaders/react-scripts-jest-config-loader.js';
-import * as pluginTokens from '../../../src/plugin-tokens.js';
+import { pluginTokens } from '../../../src/plugin-di.js';
 import { JestRunnerOptionsWithStrykerOptions } from '../../../src/jest-runner-options-with-stryker-options.js';
 import { createJestOptions } from '../../helpers/producers.js';
 
@@ -21,7 +21,7 @@ describe(ReactScriptsJestConfigLoader.name, () => {
     createReactJestConfigStub = sinon.stub();
     requireResolveStub = sinon.stub();
     requireResolveStub.returns(path.resolve('./node_modules/react-scripts/package.json'));
-    createReactJestConfigStub.returns({ testPaths: ['example'] });
+    createReactJestConfigStub.returns({ testPaths: ['example'], watchPlugins: undefined });
     requireFromCwdStub = sinon.stub();
     requireFromCwdStub.returns(createReactJestConfigStub);
     processEnvMock = {
@@ -40,7 +40,7 @@ describe(ReactScriptsJestConfigLoader.name, () => {
     expect(requireResolveStub).calledWith('react-scripts/package.json');
     expect(requireFromCwdStub).calledWith('react-scripts/scripts/utils/createJestConfig');
     expect(createReactJestConfigStub).calledWith(sinon.match.func, process.cwd(), false);
-    expect(config).deep.eq({ testPaths: ['example'] });
+    expect(config).deep.eq({ testPaths: ['example'], watchPlugins: undefined });
   });
 
   it('should throw an error when react-scripts could not be found', () => {

--- a/packages/jest-runner/test/unit/jest-test-adapters/jest-test-adapter-factory.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-adapters/jest-test-adapter-factory.spec.ts
@@ -1,46 +1,60 @@
+import { createRequire } from 'module';
+
+import sinon from 'sinon';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
+import { requireResolve } from '@stryker-mutator/util';
 
 import { JestTestAdapter, jestTestAdapterFactory } from '../../../src/jest-test-adapters/index.js';
 import { JestGreaterThan25TestAdapter } from '../../../src/jest-test-adapters/jest-greater-than-25-adapter.js';
 import { JestLessThan25TestAdapter } from '../../../src/jest-test-adapters/jest-less-than-25-adapter.js';
-import * as pluginTokens from '../../../src/plugin-tokens.js';
+import { pluginTokens } from '../../../src/plugin-di.js';
+import { JestWrapper } from '../../../src/utils/jest-wrapper.js';
 
 describe(jestTestAdapterFactory.name, () => {
-  let jestVersion: string;
+  let jestWrapperMock: sinon.SinonStubbedInstance<JestWrapper>;
+
+  beforeEach(() => {
+    jestWrapperMock = sinon.createStubInstance(JestWrapper);
+  });
 
   function act(): JestTestAdapter {
-    return testInjector.injector.provideValue(pluginTokens.jestVersion, jestVersion).injectFunction(jestTestAdapterFactory);
+    return testInjector.injector
+      .provideValue(pluginTokens.jestWrapper, jestWrapperMock)
+      .provideValue(pluginTokens.resolve, createRequire(import.meta.url).resolve)
+      .provideValue(pluginTokens.requireFromCwd, requireResolve)
+      .provideValue(pluginTokens.processEnv, process.env)
+      .injectFunction(jestTestAdapterFactory);
   }
 
   it('should log the jest version on debug', () => {
-    jestVersion = '25.0.0';
+    jestWrapperMock.getVersion.returns('25.0.0');
     act();
-    expect(testInjector.logger.debug).calledWith('Detected Jest version %s', jestVersion);
+    expect(testInjector.logger.debug).calledWith('Detected Jest version %s', '25.0.0');
   });
 
   it('should return a JestGreaterThan25Adapter when the Jest version is higher or equal to 25.0.0', () => {
-    jestVersion = '25.0.0';
+    jestWrapperMock.getVersion.returns('25.0.0');
     const testAdapter = act();
 
     expect(testAdapter).instanceOf(JestGreaterThan25TestAdapter);
   });
   it('should return a JestLessThan25Adapter when the Jest version is higher or equal to 22.0.0, but less then 25 and coverage analysis is disabled', () => {
     testInjector.options.coverageAnalysis = 'off';
-    jestVersion = '22.0.0';
+    jestWrapperMock.getVersion.returns('22.0.0');
     const testAdapter = act();
 
     expect(testAdapter).instanceOf(JestLessThan25TestAdapter);
   });
 
   it('should throw an error when the Jest version is lower than 22.0.0', () => {
-    jestVersion = '21.0.0';
+    jestWrapperMock.getVersion.returns('21.0.0');
 
     expect(act).to.throw(Error, 'You need Jest version >= 22.0.0 to use the @stryker-mutator/jest-runner plugin, found 21.0.0');
   });
 
   it('should throw an error when the Jest version is between 22 and 24, but coverage analysis is enabled', () => {
-    jestVersion = '23.0.0';
+    jestWrapperMock.getVersion.returns('23.0.0');
     testInjector.options.coverageAnalysis = 'all';
 
     expect(act).to.throw(
@@ -50,7 +64,7 @@ describe(jestTestAdapterFactory.name, () => {
   });
 
   it('should allow Jest version is between 22 and 24 if coverage analysis is "off"', () => {
-    jestVersion = '23.0.0';
+    jestWrapperMock.getVersion.returns('23.0.0');
     testInjector.options.coverageAnalysis = 'off';
 
     expect(act).to.not.throw();
@@ -58,7 +72,7 @@ describe(jestTestAdapterFactory.name, () => {
 
   it('should log a deprecation warning when using jest version < 24 and coverage analysis is "off"', () => {
     testInjector.options.coverageAnalysis = 'off';
-    jestVersion = '23.1.2';
+    jestWrapperMock.getVersion.returns('23.1.2');
     expect(act).to.not.throw();
     expect(testInjector.logger.warn).calledWith(
       '[DEPRECATED] Support for Jest version < 24 is deprecated and will be removed in the next major version of Stryker, please upgrade your jest version (your current version is %s).',

--- a/packages/jest-runner/test/unit/utils/jest-wrapper.spec.ts
+++ b/packages/jest-runner/test/unit/utils/jest-wrapper.spec.ts
@@ -1,0 +1,71 @@
+import { requireResolve } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { determineResolveFromDirectory, JestWrapper } from '../../../src/utils/index.js';
+import { createJestConfigArgv, createJestRunnerOptionsWithStrykerOptions, createJestRunResult } from '../../helpers/producers.js';
+
+describe(determineResolveFromDirectory.name, () => {
+  it('should resolve "react-scripts" when project type is "create-react-app"', () => {
+    // Arrange
+    const resolveStub = sinon.stub<[string], string>();
+    resolveStub.returns('node_modules/react-scripts/package.json');
+    const options = createJestRunnerOptionsWithStrykerOptions({ projectType: 'create-react-app' });
+
+    // Act
+    const actualDir = determineResolveFromDirectory(options, resolveStub);
+
+    // Assert
+    sinon.assert.calledOnceWithExactly(resolveStub, 'react-scripts/package.json');
+    expect(actualDir).eq('node_modules/react-scripts');
+  });
+
+  it('should resolve to cwd when project type is "custom"', () => {
+    // Arrange
+    const resolveStub = sinon.stub<[string], string>();
+    const options = createJestRunnerOptionsWithStrykerOptions({ projectType: 'custom' });
+
+    // Act
+    const actualDir = determineResolveFromDirectory(options, resolveStub);
+
+    // Assert
+    sinon.assert.notCalled(resolveStub);
+    expect(actualDir).eq(process.cwd());
+  });
+});
+
+describe(JestWrapper.name, () => {
+  let jestModuleMock: sinon.SinonStubbedInstance<JestWrapper>;
+  let requireResolveStub: sinon.SinonStubbedMember<typeof requireResolve>;
+
+  beforeEach(() => {
+    jestModuleMock = sinon.createStubInstance(JestWrapper);
+    requireResolveStub = sinon.stub();
+    requireResolveStub.returns(jestModuleMock);
+  });
+
+  it('should resolve jest from the given directory', () => {
+    new JestWrapper('foo/bar', requireResolveStub);
+    sinon.assert.calledOnceWithExactly(requireResolveStub, 'jest', 'foo/bar');
+  });
+
+  it('should proxy "getVersion"', () => {
+    const expectedVersion = '29.0.1';
+    jestModuleMock.getVersion.returns(expectedVersion);
+    const sut = new JestWrapper('', requireResolveStub);
+    const actualVersion = sut.getVersion();
+    expect(actualVersion).eq(expectedVersion);
+  });
+
+  it('should proxy "runCLI"', async () => {
+    const expectedArgv = createJestConfigArgv({ testNamePattern: 'my-test' });
+    const expectedResult = createJestRunResult();
+    jestModuleMock.runCLI.resolves(expectedResult);
+    const sut = new JestWrapper('', requireResolveStub);
+
+    const actualResult = await sut.runCLI(expectedArgv, ['.']);
+
+    sinon.assert.calledOnceWithExactly(jestModuleMock.runCLI, expectedArgv, ['.']);
+    expect(actualResult).eq(expectedResult);
+  });
+});

--- a/packages/jest-runner/test/unit/utils/jest-wrapper.spec.ts
+++ b/packages/jest-runner/test/unit/utils/jest-wrapper.spec.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { requireResolve } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -17,7 +19,7 @@ describe(determineResolveFromDirectory.name, () => {
 
     // Assert
     sinon.assert.calledOnceWithExactly(resolveStub, 'react-scripts/package.json');
-    expect(actualDir).eq('node_modules/react-scripts');
+    expect(actualDir).eq(path.join('node_modules', 'react-scripts'));
   });
 
   it('should resolve to cwd when project type is "custom"', () => {


### PR DESCRIPTION
Use the jest instance relative to `react-scripts` when the `projectType` is `"create-react-app"`, instead of simply loading jest from the CWD. This allows users to install a newer version of `jest` right next to `react-scripts` to be used for other tasks.

Fixes #3783