### PR TITLE
test(child-process): retry flaky OOM test

### DIFF
--- a/packages/core/test/integration/child-proxy/child-process-proxy.it.spec.ts
+++ b/packages/core/test/integration/child-proxy/child-process-proxy.it.spec.ts
@@ -135,7 +135,8 @@ describe(ChildProcessProxy.name, () => {
     await expect(sut.proxy.say('something')).rejectedWith(ChildProcessCrashedError);
   });
 
-  it('should throw an OutOfMemoryError if the process went out-of-memory', async () => {
+  it('should throw an OutOfMemoryError if the process went out-of-memory', async function () {
+    this.retries(5);
     await expect(sut.proxy.memoryLeak()).rejectedWith(OutOfMemoryError);
   });
 });


### PR DESCRIPTION
Retry the flaky OOM test. Yes, it is flaky and yes, I use retry to workaround this issue.
