### PR TITLE
Set NODE_ENV parameter in jest test runner

### DIFF
--- a/packages/jest-runner/src/jest-test-runner.ts
+++ b/packages/jest-runner/src/jest-test-runner.ts
@@ -134,7 +134,7 @@ export class JestTestRunner implements TestRunner {
 
     try {
       // Use process.env to set the active mutant.
-      // We could use `state.strykerStatic.activeMutant`, but that only works with the `StrykerEnvironment` mixin, wich is optional
+      // We could use `state.strykerStatic.activeMutant`, but that only works with the `StrykerEnvironment` mixin, which is optional
       process.env[INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE] = activeMutant.id.toString();
       const { dryRunResult } = await this.run({
         fileNamesUnderTest: fileNameUnderTest ? [fileNameUnderTest] : undefined,
@@ -217,6 +217,8 @@ export class JestTestRunner implements TestRunner {
   private setEnv() {
     // Force colors off: https://github.com/chalk/supports-color#info
     process.env.FORCE_COLOR = '0';
+    // Set node environment for issues like these: https://github.com/stryker-mutator/stryker-js/issues/3580
+    process.env.NODE_ENV = 'test';
   }
 
   private processTestResults(suiteResults: jestTestResult.TestResult[]): TestResult[] {

--- a/packages/jest-runner/test/unit/jest-test-runner.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-runner.spec.ts
@@ -520,7 +520,7 @@ describe(JestTestRunner.name, () => {
       expect(process.env[INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]).to.equal(undefined);
     });
 
-    it.only('should set the node environment variable before calling jest in the dry run', async () => {
+    it('should set the node environment variable before calling jest in the dry run', async () => {
       const sut = createSut();
       jestTestAdapterMock.run.callsFake(async () => {
         expect(process.env.NODE_ENV).to.equal('test');

--- a/packages/jest-runner/test/unit/jest-test-runner.spec.ts
+++ b/packages/jest-runner/test/unit/jest-test-runner.spec.ts
@@ -520,6 +520,16 @@ describe(JestTestRunner.name, () => {
       expect(process.env[INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]).to.equal(undefined);
     });
 
+    it.only('should set the node environment variable before calling jest in the dry run', async () => {
+      const sut = createSut();
+      jestTestAdapterMock.run.callsFake(async () => {
+        expect(process.env.NODE_ENV).to.equal('test');
+        return jestRunResult;
+      });
+      await sut.dryRun(factory.dryRunOptions());
+      expect(jestTestAdapterMock.run.calledOnce).to.be.true;
+    });
+
     it('should set the __strykerGlobalNamespace__ in globals', async () => {
       const sut = createSut();
       await sut.mutantRun(factory.mutantRunOptions({ activeMutant: factory.mutant({ id: '25' }) }));


### PR DESCRIPTION
Set the NODE_ENV environment parameter before calling the jest cli to ensure features like transition animations in UI components are disabled during testing.

Fixes #3580