### PR TITLE
Add documentation to generated stryker.conf.js

### DIFF
--- a/packages/core/src/initializer/npm-client.ts
+++ b/packages/core/src/initializer/npm-client.ts
@@ -13,8 +13,9 @@ interface NpmSearchResult {
   results: Array<{ package: PackageInfo }>;
 }
 
-interface NpmPackage {
+export interface NpmPackage {
   name: string;
+  homepage?: string;
   initStrykerConfig?: Record<string, unknown>;
 }
 
@@ -50,18 +51,17 @@ export class NpmClient {
     return this.search('/v2/search?q=keywords:@stryker-mutator/reporter-plugin').then(mapSearchResultToPromptOption);
   }
 
-  public getAdditionalConfig(pkgInfo: PackageInfo): Promise<Record<string, unknown>> {
+  public getAdditionalConfig(pkgInfo: PackageInfo): Promise<NpmPackage> {
     const path = `/${pkgInfo.name}@${pkgInfo.version}/package.json`;
     return this.packageClient
       .get<NpmPackage>(path)
       .then(handleResult(path))
-      .then((pkg) => pkg.initStrykerConfig ?? {})
       .catch((err) => {
         this.log.warn(
           `Could not fetch additional initialization config for dependency ${pkgInfo.name}. You might need to configure it manually`,
           err
         );
-        return {};
+        return { name: pkgInfo.name };
       });
   }
 

--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -45,11 +45,13 @@ export class StrykerConfigWriter {
     selectedPackageManager: PromptOption,
     requiredPlugins: string[],
     additionalPiecesOfConfig: Array<Partial<StrykerOptions>>,
+    homepageOfSelectedTestRunner: string,
     exportAsJson: boolean
   ): Promise<string> {
     const configObject: Partial<StrykerOptions> & { _comment: string } = {
       _comment:
-        "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information",
+        "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information. Additional information about the test runners can be found here: " +
+        homepageOfSelectedTestRunner,
       packageManager: selectedPackageManager.name as 'npm' | 'pnpm' | 'yarn',
       reporters: selectedReporters.map((rep) => rep.name),
       testRunner: selectedTestRunner.name,

--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -50,11 +50,11 @@ export class StrykerConfigWriter {
   ): Promise<string> {
     const configObject: Partial<StrykerOptions> & { _comment: string } = {
       _comment:
-        "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information. Additional information about the test runners can be found here: " +
-        homepageOfSelectedTestRunner,
+        "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
       packageManager: selectedPackageManager.name as 'npm' | 'pnpm' | 'yarn',
       reporters: selectedReporters.map((rep) => rep.name),
       testRunner: selectedTestRunner.name,
+      testRunner_comment: `More information about the ${selectedTestRunner.name} plugin can be found here: ${homepageOfSelectedTestRunner}`,
       coverageAnalysis: CommandTestRunner.is(selectedTestRunner.name) ? 'off' : 'perTest',
     };
 

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -115,7 +115,7 @@ export class StrykerInitializer {
       selectedPackageManager,
       npmDependencies.map((pkg) => pkg.name),
       additionalConfig,
-      pkgInfoOfSelectedTestRunner?.homepage ?? `URL not found for ${selectedTestRunner.name}`,
+      pkgInfoOfSelectedTestRunner?.homepage ?? 'URL not found',
       isJsonSelected
     );
     this.installNpmDependencies(
@@ -218,7 +218,7 @@ export class StrykerInitializer {
     }
   }
 
-  private async fetchAdditionalConfig(dependencies: PackageInfo[]): Promise<Array<NpmPackage>> {
+  private async fetchAdditionalConfig(dependencies: PackageInfo[]): Promise<NpmPackage[]> {
     return await Promise.all(dependencies.map((dep) => this.client.getAdditionalConfig(dep)));
   }
 }

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -5,7 +5,7 @@ import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
 import { notEmpty } from '@stryker-mutator/util';
 
-import { NpmClient } from './npm-client.js';
+import { NpmClient, NpmPackage } from './npm-client.js';
 import { PackageInfo } from './package-info.js';
 import { Preset } from './presets/preset.js';
 import { PromptOption } from './prompt-option.js';
@@ -104,13 +104,18 @@ export class StrykerInitializer {
     const selectedPackageManager = await this.selectPackageManager();
     const isJsonSelected = await this.selectJsonConfigType();
     const npmDependencies = this.getSelectedNpmDependencies([selectedTestRunner].concat(selectedReporters));
+    const packageInfo = await this.fetchAdditionalConfig(npmDependencies);
+    const pkgInfoOfSelectedTestRunner = packageInfo.find((pkg) => pkg.name == selectedTestRunner.pkg?.name);
+    const additionalConfig = packageInfo.map((dep) => dep.initStrykerConfig ?? {}).filter(notEmpty);
+
     const configFileName = await configWriter.write(
       selectedTestRunner,
       buildCommand,
       selectedReporters,
       selectedPackageManager,
       npmDependencies.map((pkg) => pkg.name),
-      await this.fetchAdditionalConfig(npmDependencies),
+      additionalConfig,
+      pkgInfoOfSelectedTestRunner?.homepage ?? `URL not found for ${selectedTestRunner.name}`,
       isJsonSelected
     );
     this.installNpmDependencies(
@@ -213,7 +218,7 @@ export class StrykerInitializer {
     }
   }
 
-  private async fetchAdditionalConfig(dependencies: PackageInfo[]): Promise<Array<Record<string, unknown>>> {
-    return (await Promise.all(dependencies.map((dep) => this.client.getAdditionalConfig(dep)))).filter(notEmpty);
+  private async fetchAdditionalConfig(dependencies: PackageInfo[]): Promise<Array<NpmPackage>> {
+    return await Promise.all(dependencies.map((dep) => this.client.getAdditionalConfig(dep)));
   }
 }

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -11,7 +11,7 @@ import typedRestClient, { type RestClient, type IRestResponse } from 'typed-rest
 
 import { fileUtils } from '../../../src/utils/file-utils.js';
 import { initializerTokens } from '../../../src/initializer/index.js';
-import { NpmClient } from '../../../src/initializer/npm-client.js';
+import { NpmClient, NpmPackage } from '../../../src/initializer/npm-client.js';
 import { PackageInfo } from '../../../src/initializer/package-info.js';
 import { Preset } from '../../../src/initializer/presets/preset.js';
 import { PresetConfiguration } from '../../../src/initializer/presets/preset-configuration.js';
@@ -251,10 +251,11 @@ describe(StrykerInitializer.name, () => {
       const expectedOutput = `// @ts-check
           /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */  
           const config =  {
-            "_comment": "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information",
+            "_comment": "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
             "packageManager": "pnpm",
             "reporters": [],
             "testRunner": "awesome",
+            "testRunner_comment": "More information about the awesome plugin can be found here: URL not found",
             "coverageAnalysis": "perTest",
             "plugins": [ "@stryker-mutator/awesome-runner" ]
           };
@@ -310,7 +311,7 @@ describe(StrykerInitializer.name, () => {
       expect(fs.promises.writeFile).calledWith(
         'stryker.conf.json',
         sinon.match(
-          '"_comment": "This config was generated using \'stryker init\'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information"'
+          '"_comment": "This config was generated using \'stryker init\'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information."'
         )
       );
     });
@@ -399,6 +400,35 @@ describe(StrykerInitializer.name, () => {
 
       expect(out).calledWith('An error occurred during installation, please try it yourself: "npm i --save-dev stryker-ghost-runner"');
       expect(fs.promises.writeFile).called;
+    });
+
+    it('should write not found if test runner homepage url as comment when not found', async () => {
+      inquirerPrompt.resolves({
+        packageManager: 'npm',
+        reporters: [],
+        testRunner: 'hyper',
+        configType: 'JSON',
+      });
+      await sut.initialize();
+      expect(fs.promises.writeFile).calledWith(
+        'stryker.conf.json',
+        sinon.match('"testRunner_comment": "More information about the hyper plugin can be found here: URL not found"')
+      );
+    });
+
+    it('should write URL if test runner homepage url as comment', async () => {
+      stubPackageClient({ 'stryker-hyper-runner': { name: 'hyper' } }, 'https://url-to-hyper.com');
+      inquirerPrompt.resolves({
+        packageManager: 'npm',
+        reporters: [],
+        testRunner: 'hyper',
+        configType: 'JSON',
+      });
+      await sut.initialize();
+      expect(fs.promises.writeFile).calledWith(
+        'stryker.conf.json',
+        sinon.match('"testRunner_comment": "More information about the hyper plugin can be found here: https://url-to-hyper.com"')
+      );
     });
   });
 
@@ -509,21 +539,17 @@ describe(StrykerInitializer.name, () => {
       statusCode: 200,
     } as unknown as IRestResponse<PackageInfo[]>);
   };
-  const stubPackageClient = (packageConfigPerPackage: Record<string, Record<string, unknown> | null>) => {
-    Object.keys(packageConfigPerPackage).forEach((packageName) => {
-      const pkgConfig: PackageInfo & { initStrykerConfig?: Record<string, unknown> } = {
-        keywords: [],
-        name: packageName,
-        version: '1.1.1',
-      };
-      const cfg = packageConfigPerPackage[packageName];
-      if (cfg) {
-        pkgConfig.initStrykerConfig = cfg;
-      }
+  const stubPackageClient = (initStrykerConfigPerPackage: Record<string, Record<string, unknown> | null>, homepage?: string | null) => {
+    Object.keys(initStrykerConfigPerPackage).forEach((packageName) => {
+      const cfg = initStrykerConfigPerPackage[packageName];
       restClientPackage.get.withArgs(`/${packageName}@1.1.1/package.json`).resolves({
-        result: pkgConfig,
+        result: {
+          name: packageName,
+          homepage: homepage,
+          initStrykerConfig: cfg ?? null,
+        },
         statusCode: 200,
-      } as unknown as IRestResponse<PackageInfo[]>);
+      } as unknown as IRestResponse<NpmPackage[]>);
     });
   };
 


### PR DESCRIPTION
**Add feature #1212**
Initial setup providing fetching the URL from the response and displaying it in the comment property of the `stryker.conf.json`.

![image](https://user-images.githubusercontent.com/27761321/198823909-8a32ea71-3259-4a16-a629-8b9a0a5dce89.png)
