### PR TITLE
feat(cicd): Add --forbid-only in mocha config

### DIFF
--- a/packages/api/.mocharc.cjs
+++ b/packages/api/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": ["dist/test/setup.js"],
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/api/.mocharc.jsonc
+++ b/packages/api/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": ["dist/test/setup.js"],
-  "timeout": 10000
-}

--- a/packages/core/.mocharc.cjs
+++ b/packages/core/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": ["./dist/test/setup.js"],
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/core/.mocharc.jsonc
+++ b/packages/core/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": ["./dist/test/setup.js"],
-  "timeout": 10000
-}

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -128,7 +128,7 @@ describe(StrykerInitializer.name, () => {
       expect(promptConfigTypes.choices).to.deep.eq(['JSON', 'JavaScript']);
     });
 
-    it('should immediately complete when a preset and package manager is chosen', async () => {
+    it.only('should immediately complete when a preset and package manager is chosen', async () => {
       inquirerPrompt.resolves({
         packageManager: 'npm',
         preset: 'awesome-preset',

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -128,7 +128,7 @@ describe(StrykerInitializer.name, () => {
       expect(promptConfigTypes.choices).to.deep.eq(['JSON', 'JavaScript']);
     });
 
-    it.only('should immediately complete when a preset and package manager is chosen', async () => {
+    it('should immediately complete when a preset and package manager is chosen', async () => {
       inquirerPrompt.resolves({
         packageManager: 'npm',
         preset: 'awesome-preset',

--- a/packages/cucumber-runner/.mocharc.cjs
+++ b/packages/cucumber-runner/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": "dist/test/setup.js",
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/cucumber-runner/.mocharc.jsonc
+++ b/packages/cucumber-runner/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": "dist/test/setup.js",
-  "timeout": 10000
-}

--- a/packages/instrumenter/.mocharc.cjs
+++ b/packages/instrumenter/.mocharc.cjs
@@ -1,8 +1,9 @@
-{
+module.exports = {
   "require": ["dist/test/setup.js"],
   "spec": [
     "dist/test/unit/**/*.js",
     "dist/test/integration/**/*.js"
   ],
-  "timeout": 10000
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
 }

--- a/packages/jasmine-runner/.mocharc.cjs
+++ b/packages/jasmine-runner/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": ["dist/test/setup.js"],
+  "timeout": 30000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/jasmine-runner/.mocharc.jsonc
+++ b/packages/jasmine-runner/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": ["dist/test/setup.js"],
-  "timeout": 30000
-}

--- a/packages/jest-runner/.mocharc.cjs
+++ b/packages/jest-runner/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": "dist/test/setup.js",
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/jest-runner/.mocharc.jsonc
+++ b/packages/jest-runner/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": "dist/test/setup.js",
-  "timeout": 10000
-}

--- a/packages/karma-runner/.mocharc.cjs
+++ b/packages/karma-runner/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": "dist/test/setup.js",
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/karma-runner/.mocharc.jsonc
+++ b/packages/karma-runner/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": "dist/test/setup.js",
-  "timeout": 10000
-}

--- a/packages/mocha-runner/.mocharc.cjs
+++ b/packages/mocha-runner/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": "dist/test/setup.js",
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/mocha-runner/.mocharc.jsonc
+++ b/packages/mocha-runner/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": "dist/test/setup.js",
-  "timeout": 10000
-}

--- a/packages/typescript-checker/.mocharc.cjs
+++ b/packages/typescript-checker/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": ["dist/test/setup.js"],
+  "timeout": 10000,
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/typescript-checker/.mocharc.jsonc
+++ b/packages/typescript-checker/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": ["dist/test/setup.js"],
-  "timeout": 10000
-}

--- a/packages/util/.mocharc.cjs
+++ b/packages/util/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  "require": ["dist/test/setup.js"],
+  "timeout": 10000, 
+  "forbidOnly": Boolean(process.env.CI)
+}

--- a/packages/util/.mocharc.jsonc
+++ b/packages/util/.mocharc.jsonc
@@ -1,4 +1,0 @@
-{
-  "require": ["dist/test/setup.js"],
-  "timeout": 10000
-}


### PR DESCRIPTION
Closes #3818 

Add the `--forbid-only` argument to mocha when running tests on the build server to give a more concrete warning when you've accidentally pused a `it.only()` test.

Before:
https://github.com/stryker-mutator/stryker-js/actions/runs/3347971096/jobs/5546534847#step:5:2780

After:
https://github.com/Giovds/stryker-js/actions/runs/3355540113/jobs/5559880282#step:5:918