### PR TITLE
Rephrase test runner docs for better clickable url

### DIFF
--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -54,7 +54,7 @@ export class StrykerConfigWriter {
       packageManager: selectedPackageManager.name as 'npm' | 'pnpm' | 'yarn',
       reporters: selectedReporters.map((rep) => rep.name),
       testRunner: selectedTestRunner.name,
-      testRunner_comment: `More information about the ${selectedTestRunner.name} plugin can be found here: ${homepageOfSelectedTestRunner}`,
+      testRunner_comment: `Please take a look at: ${homepageOfSelectedTestRunner} for information about the ${selectedTestRunner.name} plugin.`,
       coverageAnalysis: CommandTestRunner.is(selectedTestRunner.name) ? 'off' : 'perTest',
     };
 

--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -54,7 +54,7 @@ export class StrykerConfigWriter {
       packageManager: selectedPackageManager.name as 'npm' | 'pnpm' | 'yarn',
       reporters: selectedReporters.map((rep) => rep.name),
       testRunner: selectedTestRunner.name,
-      testRunner_comment: `Please take a look at: ${homepageOfSelectedTestRunner} for information about the ${selectedTestRunner.name} plugin.`,
+      testRunner_comment: `Take a look at ${homepageOfSelectedTestRunner} for information about the ${selectedTestRunner.name} plugin.`,
       coverageAnalysis: CommandTestRunner.is(selectedTestRunner.name) ? 'off' : 'perTest',
     };
 

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -115,7 +115,7 @@ export class StrykerInitializer {
       selectedPackageManager,
       npmDependencies.map((pkg) => pkg.name),
       additionalConfig,
-      pkgInfoOfSelectedTestRunner?.homepage ?? 'URL not found',
+      pkgInfoOfSelectedTestRunner?.homepage ?? "(missing 'homepage' URL in package.json)",
       isJsonSelected
     );
     this.installNpmDependencies(

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -427,7 +427,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(fs.promises.writeFile).calledWith(
         'stryker.conf.json',
-        sinon.match('"testRunner_comment": "Please take a look at: https://url-to-hyper.com for information about the hyper plugin."')
+        sinon.match('"testRunner_comment": "Take a look at https://url-to-hyper.com for information about the hyper plugin."')
       );
     });
   });

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -255,7 +255,7 @@ describe(StrykerInitializer.name, () => {
             "packageManager": "pnpm",
             "reporters": [],
             "testRunner": "awesome",
-            "testRunner_comment": "Please take a look at: URL not found for information about the awesome plugin.",
+            "testRunner_comment": "Take a look at (missing 'homepage' URL in package.json) for information about the awesome plugin.",
             "coverageAnalysis": "perTest",
             "plugins": [ "@stryker-mutator/awesome-runner" ]
           };
@@ -412,7 +412,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(fs.promises.writeFile).calledWith(
         'stryker.conf.json',
-        sinon.match('"testRunner_comment": "Please take a look at: URL not found for information about the hyper plugin."')
+        sinon.match('"testRunner_comment": "Take a look at (missing \'homepage\' URL in package.json) for information about the hyper plugin."')
       );
     });
 

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -255,7 +255,7 @@ describe(StrykerInitializer.name, () => {
             "packageManager": "pnpm",
             "reporters": [],
             "testRunner": "awesome",
-            "testRunner_comment": "More information about the awesome plugin can be found here: URL not found",
+            "testRunner_comment": "Please take a look at: URL not found for information about the awesome plugin.",
             "coverageAnalysis": "perTest",
             "plugins": [ "@stryker-mutator/awesome-runner" ]
           };
@@ -412,7 +412,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(fs.promises.writeFile).calledWith(
         'stryker.conf.json',
-        sinon.match('"testRunner_comment": "More information about the hyper plugin can be found here: URL not found"')
+        sinon.match('"testRunner_comment": "Please take a look at: URL not found for information about the hyper plugin."')
       );
     });
 
@@ -427,7 +427,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(fs.promises.writeFile).calledWith(
         'stryker.conf.json',
-        sinon.match('"testRunner_comment": "More information about the hyper plugin can be found here: https://url-to-hyper.com"')
+        sinon.match('"testRunner_comment": "Please take a look at: https://url-to-hyper.com for information about the hyper plugin."')
       );
     });
   });


### PR DESCRIPTION
Closes #3829

The URL to the test runner docs is not correctly resolved by certain editors because it contains a `"` closing the string. To avoid running in this issue the URL is away from the end of the string.

![Animation](https://user-images.githubusercontent.com/27761321/198906022-d8741228-a60e-49ce-ac7f-1bf8b5f0a6f6.gif)
