### PR TITLE
docs: restore broken static mutants documentation link

### DIFF
--- a/docs/guides/create-a-plugin.md
+++ b/docs/guides/create-a-plugin.md
@@ -285,7 +285,7 @@ After that, Stryker is done, and an excellent mutation test report gets generate
 
 #### A note on `capabilities` and `mutantActivation`
 
-Stryker relies on test runners to run mutants in quick succession, each time calling the `mutantRun` method. However, it might occur that Stryker needs to test a [static mutant](../../../mutation-testing-elements/static-mutants/) (when `--ignoreStatic` isn't enabled). In order to solve this: 
+Stryker relies on test runners to run mutants in quick succession, each time calling the `mutantRun` method. However, it might occur that Stryker needs to test a [static mutant](https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants/) (when `--ignoreStatic` isn't enabled). In order to solve this: 
 
 This pseudo code should help illustrate what needs to happen
 

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -49,7 +49,7 @@ Running in incremental mode, Stryker will do its best to produce an accurate mut
 - Detecting test file changes is only supported if the test runner plugin supports reporting the test files. (see support table below)
 - Detecting test changes is only supported if the test runner plugin supports reporting test locations. (see support table below)
 - Any other changes to your environment are not detected, such as updates to other files, updated (dev) dependencies, changes to environment variables, changes to `.snap` files, readme files, etc.
-- [Static mutants](../../mutation-testing-elements/static-mutants/) don't have test coverage; thus, Stryker won't detect test changes for them.
+- [Static mutants](https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants/) don't have test coverage; thus, Stryker won't detect test changes for them.
 
 | Test runner plugin | Test reporting                  |
 | ------------------ | ------------------------------- |


### PR DESCRIPTION
The previous link returned a 404 not found github page.
The new link returns the stryker documentation page.