### PR TITLE
fix(instrumenter): replace deprecated method call

### DIFF
--- a/packages/instrumenter/src/mutators/string-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/string-literal-mutator.ts
@@ -23,7 +23,7 @@ function isValidParent(child: NodePath<babel.types.StringLiteral>): boolean {
   return !(
     types.isImportDeclaration(parent) ||
     types.isExportDeclaration(parent) ||
-    types.isModuleDeclaration(parent) ||
+    types.isImportOrExportDeclaration(parent) ||
     types.isTSExternalModuleReference(parent) ||
     types.isJSXAttribute(parent) ||
     types.isExpressionStatement(parent) ||


### PR DESCRIPTION
Replace babel's deprecated `isModuleDeclaration` call with `isImportOrExportDeclaration`.

Fixes #4022