### PR TITLE
refactor(type imports): use public exports

### DIFF
--- a/packages/core/src/checker/checker-facade.ts
+++ b/packages/core/src/checker/checker-facade.ts
@@ -1,5 +1,5 @@
 import { CheckResult } from '@stryker-mutator/api/check';
-import { MutantRunPlan } from '@stryker-mutator/api/src/core';
+import { MutantRunPlan } from '@stryker-mutator/api/core';
 
 import { ResourceDecorator } from '../concurrent/index.js';
 

--- a/packages/core/src/checker/checker-resource.ts
+++ b/packages/core/src/checker/checker-resource.ts
@@ -1,5 +1,5 @@
 import { CheckResult } from '@stryker-mutator/api/check';
-import { Mutant } from '@stryker-mutator/api/src/core';
+import { Mutant } from '@stryker-mutator/api/core';
 
 import { Resource } from '../concurrent/index.js';
 

--- a/packages/core/src/fs/project-file.ts
+++ b/packages/core/src/fs/project-file.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { FileDescription, MutateDescription } from '@stryker-mutator/api/src/core';
+import { FileDescription, MutateDescription } from '@stryker-mutator/api/core';
 import { File } from '@stryker-mutator/instrumenter';
 import { I } from '@stryker-mutator/util';
 

--- a/packages/core/src/process/2-mutant-instrumenter-executor.ts
+++ b/packages/core/src/process/2-mutant-instrumenter-executor.ts
@@ -2,7 +2,7 @@ import { execaCommand } from 'execa';
 import { Injector, tokens, commonTokens, PluginContext } from '@stryker-mutator/api/plugin';
 import { createInstrumenter, InstrumentResult } from '@stryker-mutator/instrumenter';
 import { StrykerOptions } from '@stryker-mutator/api/core';
-import { Reporter } from '@stryker-mutator/api/src/report';
+import { Reporter } from '@stryker-mutator/api/report';
 import { I } from '@stryker-mutator/util';
 
 import { coreTokens } from '../di/index.js';

--- a/packages/core/src/reporters/progress-append-only-reporter.ts
+++ b/packages/core/src/reporters/progress-append-only-reporter.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 
-import { MutationTestingPlanReadyEvent } from '@stryker-mutator/api/src/report';
+import { MutationTestingPlanReadyEvent } from '@stryker-mutator/api/report';
 
 import { ProgressKeeper } from './progress-keeper.js';
 

--- a/packages/core/src/reporters/progress-keeper.ts
+++ b/packages/core/src/reporters/progress-keeper.ts
@@ -1,6 +1,6 @@
 import { MutantResult, MutantStatus, MutantRunPlan, MutantTestPlan, PlanKind } from '@stryker-mutator/api/core';
 import { DryRunCompletedEvent, MutationTestingPlanReadyEvent, Reporter, RunTiming } from '@stryker-mutator/api/report';
-import { TestRunnerCapabilities } from '@stryker-mutator/api/src/test-runner/test-runner-capabilities.js';
+import { TestRunnerCapabilities } from '@stryker-mutator/api/test-runner';
 
 import { Timer } from '../utils/timer.js';
 

--- a/packages/core/src/reporters/progress-reporter.ts
+++ b/packages/core/src/reporters/progress-reporter.ts
@@ -1,5 +1,5 @@
 import { MutantResult } from '@stryker-mutator/api/core';
-import { MutationTestingPlanReadyEvent } from '@stryker-mutator/api/src/report';
+import { MutationTestingPlanReadyEvent } from '@stryker-mutator/api/report';
 
 import { progressBarWrapper } from './progress-bar.js';
 import { ProgressKeeper } from './progress-keeper.js';

--- a/packages/core/test/helpers/file-system-test-double.ts
+++ b/packages/core/test/helpers/file-system-test-double.ts
@@ -1,6 +1,6 @@
 import { Dirent, PathLike } from 'fs';
 
-import { FileDescriptions, MutateDescription } from '@stryker-mutator/api/src/core/index.js';
+import { FileDescriptions, MutateDescription } from '@stryker-mutator/api/core';
 import { factory } from '@stryker-mutator/test-helpers';
 import { I } from '@stryker-mutator/util';
 

--- a/packages/core/test/integration/process/1-prepare-executor.it.spec.ts
+++ b/packages/core/test/integration/process/1-prepare-executor.it.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 
-import { PartialStrykerOptions } from '@stryker-mutator/api/src/core';
+import { PartialStrykerOptions } from '@stryker-mutator/api/core';
 import { testInjector } from '@stryker-mutator/test-helpers';
 
 import { resolveFromRoot } from '../../helpers/test-utils.js';

--- a/packages/core/test/unit/child-proxy/hello-class.ts
+++ b/packages/core/test/unit/child-proxy/hello-class.ts
@@ -1,5 +1,5 @@
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
-import { StrykerOptions } from '@stryker-mutator/api/src-generated/stryker-core';
+import { StrykerOptions } from '@stryker-mutator/api/core';
 
 export class HelloClass {
   public static inject = tokens(commonTokens.options);

--- a/packages/core/test/unit/fs/project-file.spec.ts
+++ b/packages/core/test/unit/fs/project-file.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { MutateDescription } from '@stryker-mutator/api/src/core/index.js';
+import { MutateDescription } from '@stryker-mutator/api/core';
 import { File } from '@stryker-mutator/instrumenter';
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/packages/core/test/unit/reporters/progress-keeper.spec.ts
+++ b/packages/core/test/unit/reporters/progress-keeper.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { factory } from '@stryker-mutator/test-helpers';
 import { MutantStatus } from 'mutation-testing-report-schema';
 
-import { DryRunCompletedEvent, MutationTestingPlanReadyEvent } from '@stryker-mutator/api/src/report/index.js';
+import { DryRunCompletedEvent, MutationTestingPlanReadyEvent } from '@stryker-mutator/api/report';
 
 import { ProgressKeeper } from '../../../src/reporters/progress-keeper.js';
 

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { testInjector, factory } from '@stryker-mutator/test-helpers';
 import { I, normalizeWhitespaces } from '@stryker-mutator/util';
 
-import { FileDescriptions } from '@stryker-mutator/api/src/core/file-description.js';
+import { FileDescriptions } from '@stryker-mutator/api/core';
 
 import { Sandbox } from '../../../src/sandbox/sandbox.js';
 import { coreTokens } from '../../../src/di/index.js';

--- a/packages/instrumenter/src/transformers/transformer.ts
+++ b/packages/instrumenter/src/transformers/transformer.ts
@@ -1,7 +1,7 @@
 import { MutateDescription } from '@stryker-mutator/api/core';
 import { I } from '@stryker-mutator/util';
 
-import { Logger } from '@stryker-mutator/api/src/logging/logger';
+import { Logger } from '@stryker-mutator/api/logging';
 
 import { Ast, AstByFormat, AstFormat } from '../syntax/index.js';
 

--- a/packages/jest-runner/src/plugin-di.ts
+++ b/packages/jest-runner/src/plugin-di.ts
@@ -1,4 +1,4 @@
-import { PluginContext } from '@stryker-mutator/api/src/plugin';
+import { PluginContext } from '@stryker-mutator/api/plugin';
 import { requireResolve } from '@stryker-mutator/util';
 
 import { JestWrapper, JestConfigWrapper } from './utils/index.js';

--- a/packages/jest-runner/src/utils/jest-wrapper.ts
+++ b/packages/jest-runner/src/utils/jest-wrapper.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { StrykerOptions } from '@stryker-mutator/api/src-generated/stryker-core.js';
+import { StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { requireResolve } from '@stryker-mutator/util';
 import type * as jestModule from 'jest';

--- a/packages/typescript-checker/src/grouping/create-groups.ts
+++ b/packages/typescript-checker/src/grouping/create-groups.ts
@@ -1,4 +1,4 @@
-import { Mutant } from '@stryker-mutator/api/src/core/index.js';
+import { Mutant } from '@stryker-mutator/api/core';
 
 import { toPosixFileName } from '../tsconfig-helpers.js';
 

--- a/packages/typescript-checker/src/grouping/ts-file-node.ts
+++ b/packages/typescript-checker/src/grouping/ts-file-node.ts
@@ -1,4 +1,4 @@
-import { Mutant } from '@stryker-mutator/api/src/core';
+import { Mutant } from '@stryker-mutator/api/core';
 
 import { toPosixFileName } from '../tsconfig-helpers.js';
 

--- a/packages/typescript-checker/test/unit/grouping/ts-file-node.spec.ts
+++ b/packages/typescript-checker/test/unit/grouping/ts-file-node.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { Mutant } from '@stryker-mutator/api/src/core';
+import { Mutant } from '@stryker-mutator/api/core';
 
 import { TSFileNode } from '../../../src/grouping/ts-file-node.js';
 


### PR DESCRIPTION
Refactor type imports to use the public `exports`. I.e.

```diff
-import { MutantRunPlan } from '@stryker-mutator/api/src/core';
+import { MutantRunPlan } from '@stryker-mutator/api/core';
```
