### PR TITLE
Drop node 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14.18.0', 16.x]
+        node-version: [16.x, 20.x]
         os: ['ubuntu-latest', 'windows-latest']
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 20.x]
+        node-version: [16.x, 18.x]
         os: ['ubuntu-latest', 'windows-latest']
     steps:
     - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "release": "lerna version"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   }
 }

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -18,7 +18,7 @@
         "typed-inject": "3.0.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@types/node": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://stryker-mutator.io/",
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "mutation-testing-metrics": "1.7.14",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -51,7 +51,7 @@
         "flatted": "3.2.7"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@types/diff-match-patch": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/core"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "mutation testing",

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -105,13 +105,13 @@ describe(StrykerCli.name, () => {
   });
 
   describe(guardMinimalNodeVersion.name, () => {
-    it('should fail for < v14.18.0', () => {
-      expect(() => guardMinimalNodeVersion('v14.17.0')).throws(
-        'Node.js version v14.17.0 detected. StrykerJS requires version to match >=14.18.0. Please update your Node.js version or visit https://nodejs.org/ for additional instructions'
+    it('should fail for < v16.0.0', () => {
+      expect(() => guardMinimalNodeVersion('v14.21.3')).throws(
+        'Node.js version v14.21.3 detected. StrykerJS requires version to match >=16.0.0. Please update your Node.js version or visit https://nodejs.org/ for additional instructions'
       );
     });
-    it('should not fail for >= v14.18.0', () => {
-      expect(() => guardMinimalNodeVersion('v14.18.0')).not.throws();
+    it('should not fail for >= v16.0.0', () => {
+      expect(() => guardMinimalNodeVersion('v16.0.0')).not.throws();
     });
   });
 

--- a/packages/cucumber-runner/package-lock.json
+++ b/packages/cucumber-runner/package-lock.json
@@ -17,7 +17,7 @@
         "@types/semver": "7.3.13"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@cucumber/cucumber": ">=8.0.0",

--- a/packages/cucumber-runner/package.json
+++ b/packages/cucumber-runner/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/cucumber-runner"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "stryker",

--- a/packages/grunt-stryker/package-lock.json
+++ b/packages/grunt-stryker/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "18.15.11"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0",

--- a/packages/grunt-stryker/package.json
+++ b/packages/grunt-stryker/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 8"
+    "node": ">=16.0.0"
   },
   "main": "Gruntfile.js",
   "devDependencies": {

--- a/packages/instrumenter/package-lock.json
+++ b/packages/instrumenter/package-lock.json
@@ -26,7 +26,7 @@
         "babel-plugin-transform-decorators-legacy": "1.3.5"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/instrumenter/package.json
+++ b/packages/instrumenter/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/instrumenter"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jasmine-runner/package-lock.json
+++ b/packages/jasmine-runner/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "18.15.11"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0",

--- a/packages/jasmine-runner/package.json
+++ b/packages/jasmine-runner/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-runner/package-lock.json
+++ b/packages/jest-runner/package-lock.json
@@ -23,7 +23,7 @@
         "ts-node": "10.9.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0"

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -35,7 +35,7 @@
     "directory": "packages/jest-runner"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "stryker",

--- a/packages/karma-runner/package-lock.json
+++ b/packages/karma-runner/package-lock.json
@@ -25,7 +25,7 @@
         "karma-mocha": "2.0.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0"

--- a/packages/karma-runner/package.json
+++ b/packages/karma-runner/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/karma-runner"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "stryker",

--- a/packages/mocha-runner/package-lock.json
+++ b/packages/mocha-runner/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "18.15.11"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0",

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/mocha-runner"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "stryker",

--- a/packages/typescript-checker/package-lock.json
+++ b/packages/typescript-checker/package-lock.json
@@ -15,7 +15,7 @@
         "@types/semver": "7.3.13"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "^6.4.0",

--- a/packages/typescript-checker/package.json
+++ b/packages/typescript-checker/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/typescript-checker"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
On april 30th support for [node 14 is end-of-life](https://github.com/nodejs/release#release-schedule). Because of this support will be dropped so we can support new features like the upcomming tap runner.