### PR TITLE
Fix(tap-runner): wait for spawned process to exit

### DIFF
--- a/packages/tap-runner/src/setup/env.cts
+++ b/packages/tap-runner/src/setup/env.cts
@@ -1,3 +1,6 @@
 export const strykerDryRun = 'STRYKER_DRY_RUN';
 export const strykerHitLimit = 'STRYKER_HIT_LIMIT';
 export const strykerNamespace = 'STRYKER_NAMESPACE';
+export function tempTapOutputFileName(pid: number | undefined): string {
+  return `stryker-output-${pid}.json`;
+}

--- a/packages/tap-runner/src/setup/hook.cts
+++ b/packages/tap-runner/src/setup/hook.cts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-import { strykerDryRun, strykerHitLimit, strykerNamespace } from './env.cjs';
+import { tempTapOutputFileName, strykerDryRun, strykerHitLimit, strykerNamespace } from './env.cjs';
 
 const strykerGlobalNamespace = process.env[strykerNamespace] as '__stryker__' | '__stryker2__';
 const dryRun = process.env[strykerDryRun] === 'true';
@@ -29,5 +29,5 @@ function finalCleanup() {
   if (!dryRun) {
     delete global[strykerGlobalNamespace]!.mutantCoverage;
   }
-  fs.writeFileSync(`stryker-output-${process.pid}.json`, JSON.stringify(global[strykerGlobalNamespace]));
+  fs.writeFileSync(tempTapOutputFileName(process.pid), JSON.stringify(global[strykerGlobalNamespace]));
 }

--- a/packages/tap-runner/src/tap-helper.ts
+++ b/packages/tap-runner/src/tap-helper.ts
@@ -5,6 +5,8 @@ import { ChildProcessWithoutNullStreams } from 'child_process';
 import nodeGlob from 'glob';
 import * as tap from 'tap-parser';
 
+import { TapParser } from './tap-parser-factory.js';
+
 const glob = promisify(nodeGlob);
 
 export async function findTestyLookingFiles(globPattern: string): Promise<string[]> {
@@ -20,7 +22,7 @@ export function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail
   return new Promise<TapResult>((resolve) => {
     const failedTests: tap.TapError[] = [];
     const config = { bail: !disableBail };
-    const parser = new tap.Parser(config, (result) => {
+    const parser = TapParser.Parser(config, (result) => {
       resolve({ result, failedTests });
     });
 

--- a/packages/tap-runner/src/tap-helper.ts
+++ b/packages/tap-runner/src/tap-helper.ts
@@ -20,7 +20,7 @@ export function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail
   return new Promise<TapResult>((resolve) => {
     const failedTests: tap.TapError[] = [];
     const config = { bail: !disableBail };
-    const parser = new tap.Parser(config, async (result) => {
+    const parser = new tap.Parser(config, (result) => {
       resolve({ result, failedTests });
     });
 

--- a/packages/tap-runner/src/tap-helper.ts
+++ b/packages/tap-runner/src/tap-helper.ts
@@ -1,9 +1,39 @@
+import os from 'os';
 import { promisify } from 'util';
+import { ChildProcessWithoutNullStreams } from 'child_process';
 
 import nodeGlob from 'glob';
+import * as tap from 'tap-parser';
 
 const glob = promisify(nodeGlob);
 
 export async function findTestyLookingFiles(globPattern: string): Promise<string[]> {
   return glob(globPattern, { ignore: ['**/node_modules/**'] });
+}
+
+export interface TapResult {
+  result: tap.FinalResults;
+  failedTests: tap.TapError[];
+}
+
+export function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail: boolean): Promise<TapResult> {
+  return new Promise<TapResult>((resolve) => {
+    const failedTests: tap.TapError[] = [];
+    const config = { bail: !disableBail };
+    const parser = new tap.Parser(config, async (result) => {
+      resolve({ result, failedTests });
+    });
+
+    parser.on('bailout', () => {
+      // Bailout within a test file is not supported on windows, because when the process is killed the exit handler which saves the file with the result does not run.
+      if (os.platform() !== 'win32') {
+        tapProcess.kill();
+      }
+    });
+
+    parser.on('fail', (reason: tap.TapError) => {
+      failedTests.push(reason);
+    });
+    tapProcess.stdout.pipe(parser);
+  });
 }

--- a/packages/tap-runner/src/tap-parser-factory.ts
+++ b/packages/tap-runner/src/tap-parser-factory.ts
@@ -1,5 +1,7 @@
 import * as tap from 'tap-parser';
 
+// This is a workaround for stubbing tap-parser in the tests.
+// When stubbing TypeError: ES Modules cannot be stubbed
 export const TapParser = {
   Parser: (options?: tap.ParserOptions, onComplete?: (results: tap.FinalResults) => any): tap.Parser => new tap.Parser(options, onComplete),
 };

--- a/packages/tap-runner/src/tap-parser-factory.ts
+++ b/packages/tap-runner/src/tap-parser-factory.ts
@@ -1,0 +1,5 @@
+import * as tap from 'tap-parser';
+
+export const TapParser = {
+  Parser: (options?: tap.ParserOptions, onComplete?: (results: tap.FinalResults) => any): tap.Parser => new tap.Parser(options, onComplete),
+};

--- a/packages/tap-runner/src/tap-test-runner.ts
+++ b/packages/tap-runner/src/tap-test-runner.ts
@@ -1,14 +1,7 @@
-import { ChildProcess, spawn } from 'child_process';
-
+import { spawn } from 'child_process';
 import path from 'path';
-
 import { fileURLToPath } from 'url';
-
 import { readFile, rm } from 'fs/promises';
-
-import os from 'os';
-
-import * as tap from 'tap-parser';
 
 import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import {
@@ -23,14 +16,15 @@ import {
   TestRunner,
   TestRunnerCapabilities,
   TestStatus,
+  TimeoutDryRunResult,
   toMutantRunResult,
 } from '@stryker-mutator/api/test-runner';
 import { InstrumenterContext, INSTRUMENTER_CONSTANTS, MutantCoverage, StrykerOptions } from '@stryker-mutator/api/core';
 
 import * as pluginTokens from './plugin-tokens.js';
-import { findTestyLookingFiles } from './tap-helper.js';
+import { findTestyLookingFiles, parseTap, TapResult } from './tap-helper.js';
 import { TapRunnerOptionsWithStrykerOptions } from './tap-runner-options-with-stryker-options.js';
-import { strykerHitLimit, strykerNamespace, strykerDryRun } from './setup/env.cjs';
+import { strykerHitLimit, strykerNamespace, strykerDryRun, tempTapOutputFileName } from './setup/env.cjs';
 
 export function createTapTestRunnerFactory(namespace: typeof INSTRUMENTER_CONSTANTS.NAMESPACE | '__stryker2__' = INSTRUMENTER_CONSTANTS.NAMESPACE): {
   (injector: Injector<PluginContext>): TapTestRunner;
@@ -45,7 +39,11 @@ export function createTapTestRunnerFactory(namespace: typeof INSTRUMENTER_CONSTA
 
 export const createTapTestRunner = createTapTestRunnerFactory();
 
-class HitLimitError extends Error {}
+class HitLimitError extends Error {
+  constructor(public readonly result: TimeoutDryRunResult) {
+    super(result.reason);
+  }
+}
 
 interface TapRunOptions {
   disableBail: boolean;
@@ -107,70 +105,39 @@ export class TapTestRunner implements TestRunner {
         tests: runs,
         mutantCoverage: totalCoverage,
       };
-    } catch (e) {
-      if (e instanceof HitLimitError) {
-        return {
-          status: DryRunStatus.Timeout,
-          reason: e.message,
-        };
+    } catch (err) {
+      if (err instanceof HitLimitError) {
+        return err.result;
       }
-
-      throw e;
+      throw err;
     }
   }
 
   private async runFile(testFile: string, testOptions: TapRunOptions): Promise<{ testResult: TestResult; coverage: MutantCoverage | undefined }> {
-    return new Promise((resolve, reject) => {
-      const env: NodeJS.ProcessEnv = {
-        ...process.env,
-        [strykerHitLimit]: testOptions.hitLimit?.toString(),
-        [strykerNamespace]: this.globalNamespace,
-        [INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]: testOptions.activeMutant,
-        [strykerDryRun]: testOptions.dryRun?.toString(),
-      };
-      const tapProcess = spawn('node', ['-r', TapTestRunner.hookFile, testFile], { env });
-      const tapProcessExitPromise = this.getExitPromiseOfProcess(tapProcess);
-
-      const failedTests: tap.TapError[] = [];
-      const config = { bail: !testOptions.disableBail };
-
-      const parser = new tap.Parser(config, async (result) => {
-        const fileName = `stryker-output-${tapProcess.pid}.json`;
-        const fileContent = await readFile(fileName, 'utf-8');
-        await rm(fileName);
-        const file = JSON.parse(fileContent) as InstrumenterContext;
-
-        const hitLimitReached = determineHitLimitReached(file.hitCount, testOptions.hitLimit);
-        if (hitLimitReached) {
-          reject(new HitLimitError(hitLimitReached.reason));
-          return;
-        }
-
-        // wait for the process to end before continuing, because the tapParser sometimes results before the process ends which causes a start of a new process while to current one is still running.
-        await tapProcessExitPromise;
-        resolve({ testResult: this.tapResultToTestResult(testFile, result, failedTests), coverage: file.mutantCoverage });
-      });
-
-      parser.on('bailout', () => {
-        // Bailout within a test file is not supported on windows, because when the process is killed the exit handler which saves the file with the result does not run.
-        if (os.platform() !== 'win32') {
-          tapProcess.kill();
-        }
-      });
-
-      parser.on('fail', (reason: tap.TapError) => {
-        failedTests.push(reason);
-      });
-
-      tapProcess.stdout.pipe(parser);
-    });
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      [strykerHitLimit]: testOptions.hitLimit?.toString(),
+      [strykerNamespace]: this.globalNamespace,
+      [INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]: testOptions.activeMutant,
+      [strykerDryRun]: testOptions.dryRun?.toString(),
+    };
+    const tapProcess = spawn('node', ['-r', TapTestRunner.hookFile, testFile], { env });
+    const exitAsPromised = new Promise((resolve) => tapProcess.on('exit', resolve));
+    const result = await parseTap(tapProcess, testOptions.disableBail);
+    // wait for the process to end before continuing, because the tapParser sometimes results before the process ends which causes a start of a new process while to current one is still running.
+    await exitAsPromised;
+    const fileName = tempTapOutputFileName(tapProcess.pid);
+    const fileContent = await readFile(fileName, 'utf-8');
+    await rm(fileName);
+    const file = JSON.parse(fileContent) as InstrumenterContext;
+    const hitLimitReached = determineHitLimitReached(file.hitCount, testOptions.hitLimit);
+    if (hitLimitReached) {
+      throw new HitLimitError(hitLimitReached);
+    }
+    return { testResult: this.tapResultToTestResult(testFile, result), coverage: file.mutantCoverage };
   }
 
-  private getExitPromiseOfProcess(process: ChildProcess): Promise<void> {
-    return new Promise((resolve) => process.on('exit', resolve));
-  }
-
-  private tapResultToTestResult(fileName: string, result: tap.FinalResults, failedTests: tap.TapError[]): TestResult {
+  private tapResultToTestResult(fileName: string, { result, failedTests }: TapResult): TestResult {
     const generic: BaseTestResult = {
       id: fileName,
       name: fileName,
@@ -188,7 +155,7 @@ export class TapTestRunner implements TestRunner {
       return {
         ...generic,
         status: TestStatus.Failed,
-        failureMessage: failedTests.map((f) => `${f.fullname}: ${f.name}`).join(', ') ?? 'Unkown issue',
+        failureMessage: failedTests.map((f) => `${f.fullname}: ${f.name}`).join(', ') ?? 'Unknown issue',
       };
     }
   }

--- a/packages/tap-runner/src/tap-test-runner.ts
+++ b/packages/tap-runner/src/tap-test-runner.ts
@@ -1,7 +1,7 @@
-import { spawn } from 'child_process';
+import childProcess from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { readFile, rm } from 'fs/promises';
+import fs from 'fs/promises';
 
 import { commonTokens, Injector, PluginContext, tokens } from '@stryker-mutator/api/plugin';
 import {
@@ -121,14 +121,14 @@ export class TapTestRunner implements TestRunner {
       [INSTRUMENTER_CONSTANTS.ACTIVE_MUTANT_ENV_VARIABLE]: testOptions.activeMutant,
       [strykerDryRun]: testOptions.dryRun?.toString(),
     };
-    const tapProcess = spawn('node', ['-r', TapTestRunner.hookFile, testFile], { env });
+    const tapProcess = childProcess.spawn('node', ['-r', TapTestRunner.hookFile, testFile], { env });
     const exitAsPromised = new Promise((resolve) => tapProcess.on('exit', resolve));
     const result = await parseTap(tapProcess, testOptions.disableBail);
     // wait for the process to end before continuing, because the tapParser sometimes results before the process ends which causes a start of a new process while to current one is still running.
     await exitAsPromised;
     const fileName = tempTapOutputFileName(tapProcess.pid);
-    const fileContent = await readFile(fileName, 'utf-8');
-    await rm(fileName);
+    const fileContent = await fs.readFile(fileName, 'utf-8');
+    await fs.rm(fileName);
     const file = JSON.parse(fileContent) as InstrumenterContext;
     const hitLimitReached = determineHitLimitReached(file.hitCount, testOptions.hitLimit);
     if (hitLimitReached) {

--- a/packages/tap-runner/test/setup.ts
+++ b/packages/tap-runner/test/setup.ts
@@ -3,12 +3,15 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
+import { testInjector } from '@stryker-mutator/test-helpers';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
 export const mochaHooks = {
-  afterEach(): void {
+  async afterEach(): Promise<void> {
+    await testInjector.injector.dispose();
     sinon.restore();
+    testInjector.reset();
   },
 };

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -59,7 +59,7 @@ describe(TapTestRunner.name, () => {
   });
 
   describe('mutantRun', () => {
-    it.only('should wait for process to exit before returning result', async () => {
+    it('should wait for process to exit before returning result', async () => {
       const runPromise = sut.mutantRun(factory.mutantRunOptions({ testFilter: ['test.js'] }));
       let processFinished = false;
 

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -60,6 +60,9 @@ describe(TapTestRunner.name, () => {
 
   describe('mutantRun', () => {
     it('should wait for process to exit before returning result', async () => {
+      // Added this test because it was possible that two process were trying to use the same mutated files resulting in a locked file error.
+      // For more info see: https://github.com/stryker-mutator/stryker-js/issues/4122
+
       const runPromise = sut.mutantRun(factory.mutantRunOptions({ testFilter: ['test.js'] }));
       let processFinished = false;
 

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -63,6 +63,7 @@ describe(TapTestRunner.name, () => {
       const runPromise = sut.mutantRun(factory.mutantRunOptions({ testFilter: ['test.js'] }));
       let processFinished = false;
 
+      // End the tapParser manually so the process is not killed
       tapParser.end('');
 
       childProcessMock.on('exit', () => {
@@ -74,6 +75,7 @@ describe(TapTestRunner.name, () => {
         childProcessMock.emit('exit', 0);
       }, 1000);
 
+      // Should wait for the process to finish before resolving
       await runPromise;
       expect(processFinished).to.be.true;
     });

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -1,14 +1,51 @@
+import childProcess from 'child_process';
+
+import { EventEmitter } from 'events';
+
+import { PassThrough, Readable } from 'stream';
+
+import fs from 'fs/promises';
+
+import sinon from 'sinon';
+
 import { TestRunnerCapabilities } from '@stryker-mutator/api/test-runner';
-import { testInjector } from '@stryker-mutator/test-helpers';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
+import * as tap from 'tap-parser';
+
 import { createTapTestRunnerFactory, TapTestRunner } from '../../src/tap-test-runner.js';
+import { TapParser } from '../../src/tap-parser-factory.js';
+
+class ChildProcessMock extends EventEmitter {
+  public stdout: Readable = new PassThrough();
+}
 
 describe(TapTestRunner.name, () => {
   let sut: TapTestRunner;
+  let childProcessMock: ChildProcessMock;
+  let forkStub: sinon.SinonStub;
+  let tapParser: tap.Parser;
 
   beforeEach(async () => {
+    childProcessMock = new ChildProcessMock();
+    sinon.stub(TapParser, 'Parser').callsFake((options, onComplete) => {
+      tapParser = new tap.Parser(options, onComplete);
+      return tapParser;
+    });
+
+    // Stub out the fs module because the file will not be created
+    sinon.stub(fs, 'readFile').callsFake(() => Promise.resolve('{}'));
+    sinon.stub(fs, 'rm').callsFake(() => Promise.resolve());
+
+    forkStub = sinon.stub(childProcess, 'spawn');
+    forkStub.returns(childProcessMock);
     sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
+  });
+
+  afterEach(() => {
+    childProcessMock.removeAllListeners();
+    childProcessMock.stdout.removeAllListeners();
   });
 
   describe('capabilities', () => {
@@ -18,6 +55,27 @@ describe(TapTestRunner.name, () => {
       };
 
       expect(sut.capabilities()).deep.eq(expectedCapabilities);
+    });
+  });
+
+  describe('mutantRun', () => {
+    it.only('should wait for process to exit before returning result', async () => {
+      const runPromise = sut.mutantRun(factory.mutantRunOptions({ testFilter: ['test.js'] }));
+      let processFinished = false;
+
+      tapParser.end('');
+
+      childProcessMock.on('exit', () => {
+        processFinished = true;
+      });
+
+      // Wait a second before emitting the exit event
+      setTimeout(() => {
+        childProcessMock.emit('exit', 0);
+      }, 1000);
+
+      await runPromise;
+      expect(processFinished).to.be.true;
     });
   });
 });


### PR DESCRIPTION
A (possible) fix for the issue described in [#4122.](https://github.com/stryker-mutator/stryker-js/issues/4122). The tap-runner now waits for the spawned process to exit before returning the results.

I think this will fix the problem we encounter in de ci pipeline, but I could not recreate the problem locally. 