### PR TITLE
test(instrumenter): add test for optional chaining

### DIFF
--- a/packages/instrumenter/testResources/instrumenter/optional-chains.ts
+++ b/packages/instrumenter/testResources/instrumenter/optional-chains.ts
@@ -10,3 +10,5 @@ const qux = quux(corge?.cov());
 input?.id!.toString();
 
 bar?.baz[0]
+
+state.stats[organization?.organization_id] = action.payload.stats;

--- a/packages/instrumenter/testResources/instrumenter/optional-chains.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/optional-chains.ts.out.snap
@@ -52,5 +52,6 @@ stryMutAct_9fa48(\\"5\\") ? qux().map() : (stryCov_9fa48(\\"5\\"), qux()?.map())
 const directiveRanges = stryMutAct_9fa48(\\"6\\") ? comments.map(tryParseTSDirective) : (stryCov_9fa48(\\"6\\"), comments?.map(tryParseTSDirective));
 const qux = quux(stryMutAct_9fa48(\\"7\\") ? corge.cov() : (stryCov_9fa48(\\"7\\"), corge?.cov()));
 stryMutAct_9fa48(\\"8\\") ? input.id!.toString() : (stryCov_9fa48(\\"8\\"), input?.id!.toString());
-stryMutAct_9fa48(\\"9\\") ? bar.baz[0] : (stryCov_9fa48(\\"9\\"), bar?.baz[0]);"
+stryMutAct_9fa48(\\"9\\") ? bar.baz[0] : (stryCov_9fa48(\\"9\\"), bar?.baz[0]);
+state.stats[stryMutAct_9fa48(\\"10\\") ? organization.organization_id : (stryCov_9fa48(\\"10\\"), organization?.organization_id)] = action.payload.stats;"
 `;


### PR DESCRIPTION
Add a missing test for optional chaining inside a computed property.

Fixes #3475