### PR TITLE
refactor(assertions): sort tests in `expectTestResults`

### DIFF
--- a/packages/cucumber-runner/test/integration/cucumber-runner.it.spec.ts
+++ b/packages/cucumber-runner/test/integration/cucumber-runner.it.spec.ts
@@ -39,7 +39,7 @@ describe('Running in an example project', () => {
 
     // Assert
     const fileName = path.join('features', 'simple_math.feature');
-    const expectedTests: Array<Partial<TestResult>> = [
+    const expectedTests: Array<Partial<TestResult> & Pick<TestResult, 'id'>> = [
       {
         status: TestStatus.Success,
         id: `${fileName}:7`,


### PR DESCRIPTION
Allow out-of-order test results in `expectTestResults` by sorting expectations and actuals by `testId`.
