### PR TITLE
test(incremental): add vitest and tap to e2e

### DIFF
--- a/e2e/test/incremental/package.json
+++ b/e2e/test/incremental/package.json
@@ -10,6 +10,8 @@
     "test:mocha": "mocha",
     "test:jasmine": "jasmine --config=jasmine.json",
     "test:karma": "karma start karma.conf.cjs",
+    "test:vitest": "vitest run",
+    "test:tap": "tap spec/*.tap.js",
     "test": "mocha --no-config --no-package --timeout 0 verify/verify.js"
   },
   "keywords": [],

--- a/e2e/test/incremental/spec/concat.tap.js
+++ b/e2e/test/incremental/spec/concat.tap.js
@@ -1,0 +1,18 @@
+import { test } from 'tap';
+import { concat, greet } from '../src/concat.js';
+
+test('concat', (t) => {
+  t.test('should concat a and b', (t) => {
+    t.equal(concat('foo', 'bar'), 'foobar');
+    t.end();
+  });
+  t.end();
+});
+
+test('greet', (t) => {
+  t.test('should greet me', (t) => {
+    t.equal(greet('me'), '👋 me');
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/spec/concat.tap.js.changed
+++ b/e2e/test/incremental/spec/concat.tap.js.changed
@@ -1,0 +1,19 @@
+import { test } from 'tap';
+import { concat, greet } from '../src/concat.js';
+
+test('concat', (t) => {
+  t.test('should concat a and b', (t) => {
+    t.equal(concat('foo', 'bar'), 'foobar');
+    t.end();
+  });
+  t.end();
+});
+
+test('greet', (t) => {
+  t.test('should greet me', (t) => {
+    // Change: updated test
+    t.equal(greet('me'), '👋 me 🙋‍♀️');
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/spec/concat.tap.js.original
+++ b/e2e/test/incremental/spec/concat.tap.js.original
@@ -1,0 +1,18 @@
+import { test } from 'tap';
+import { concat, greet } from '../src/concat.js';
+
+test('concat', (t) => {
+  t.test('should concat a and b', (t) => {
+    t.equal(concat('foo', 'bar'), 'foobar');
+    t.end();
+  });
+  t.end();
+});
+
+test('greet', (t) => {
+  t.test('should greet me', (t) => {
+    t.equal(greet('me'), '👋 me');
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/spec/math.tap.js
+++ b/e2e/test/incremental/spec/math.tap.js
@@ -1,0 +1,19 @@
+import { test } from 'tap';
+import { add, multiply } from '../src/math.js';
+
+test('add should add two numbers', (t) => {
+  t.test('should add two numbers', (t) => {
+    t.equal(add(1, 0), 1);
+    t.end();
+  });
+  t.end();
+});
+
+test('multiply', (t) => {
+  t.test('should multiply the numbers', (t) => {
+    // Bad test, surviving mutant when * => /
+    t.equal(multiply(2, 0), 0);
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/spec/math.tap.js.changed
+++ b/e2e/test/incremental/spec/math.tap.js.changed
@@ -1,0 +1,19 @@
+import { test } from 'tap';
+import { add, multiply } from '../src/math.js';
+
+test('add should add two numbers', (t) => {
+  t.test('should add two numbers', (t) => {
+    t.equal(add(1, 0), 1);
+    t.end();
+  });
+  t.end();
+});
+
+test('multiply', (t) => {
+  t.test('should multiply the numbers', (t) => {
+    // Change: improved test
+    t.equal(multiply(2, 3), 6);
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/spec/math.tap.js.original
+++ b/e2e/test/incremental/spec/math.tap.js.original
@@ -1,0 +1,19 @@
+import { test } from 'tap';
+import { add, multiply } from '../src/math.js';
+
+test('add should add two numbers', (t) => {
+  t.test('should add two numbers', (t) => {
+    t.equal(add(1, 0), 1);
+    t.end();
+  });
+  t.end();
+});
+
+test('multiply', (t) => {
+  t.test('should multiply the numbers', (t) => {
+    // Bad test, surviving mutant when * => /
+    t.equal(multiply(2, 0), 0);
+    t.end();
+  });
+  t.end();
+});

--- a/e2e/test/incremental/verify/verify.js
+++ b/e2e/test/incremental/verify/verify.js
@@ -41,6 +41,8 @@ describe('incremental', () => {
     withFullTestResults: 4,
     // We know which test files are changed and assume each test in that file changed
     withoutTestLocations: 2,
+    // We know which test file the test originated from, but we can't differentiate between tests in the file (TAP runner)
+    withoutTestDeviation: 6,
     // Don't know from which test files the tests originated
     withoutTestFiles: 7,
   });
@@ -53,6 +55,9 @@ describe('incremental', () => {
     ['jest', reuseCountExpectation.withFullTestResults, { testRunnerNodeArgs: ['--experimental-vm-modules'], tempDirName: 'stryker-tmp' }],
 
     ['mocha', reuseCountExpectation.withoutTestLocations],
+    ['vitest', reuseCountExpectation.withoutTestLocations],
+
+    ['tap', reuseCountExpectation.withoutTestDeviation],
 
     ['karma', reuseCountExpectation.withoutTestFiles, { karma: { configFile: 'karma.conf.cjs' } }],
     ['jasmine', reuseCountExpectation.withoutTestFiles, { jasmineConfigFile: 'jasmine.json' }],

--- a/e2e/test/incremental/verify/verify.js.snap
+++ b/e2e/test/incremental/verify/verify.js.snap
@@ -2220,7 +2220,7 @@ Array [
     "fileName": "src/concat.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#concat should concat a and b",
+        "spec/concat.spec.js#concat should concat a and b",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2244,7 +2244,7 @@ Array [
     "fileName": "src/concat.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#concat should concat a and b",
+        "spec/concat.spec.js#concat should concat a and b",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2290,7 +2290,7 @@ Array [
     "fileName": "src/concat.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#greet should greet me",
+        "spec/concat.spec.js#greet should greet me",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2314,7 +2314,7 @@ Array [
     "fileName": "src/concat.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#greet should greet me",
+        "spec/concat.spec.js#greet should greet me",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2338,7 +2338,7 @@ Array [
     "fileName": "src/log.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/log.spec.js#log should not throw",
+        "spec/log.spec.js#log should not throw",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2362,7 +2362,7 @@ Array [
     "fileName": "src/log.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/log.spec.js#log should not throw",
+        "spec/log.spec.js#log should not throw",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2386,7 +2386,7 @@ Array [
     "fileName": "src/math.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#add should add two numbers",
+        "spec/math.spec.js#add should add two numbers",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2410,7 +2410,7 @@ Array [
     "fileName": "src/math.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#add should add two numbers",
+        "spec/math.spec.js#add should add two numbers",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2434,7 +2434,7 @@ Array [
     "fileName": "src/math.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#multiply should multiply the numbers",
+        "spec/math.spec.js#multiply should multiply the numbers",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -2458,7 +2458,7 @@ Array [
     "fileName": "src/math.js",
     "mutant": Object {
       "coveredBy": Array [
-        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#multiply should multiply the numbers",
+        "spec/math.spec.js#multiply should multiply the numbers",
       ],
       "killedBy": undefined,
       "location": Object {

--- a/e2e/test/incremental/verify/verify.js.snap
+++ b/e2e/test/incremental/verify/verify.js.snap
@@ -1914,3 +1914,615 @@ Array [
   },
 ]
 `;
+
+exports[`incremental should reuse expected mutant results for tap 1`] = `
+Array [
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 0,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "spec/concat.spec.js",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\\"\\"",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 7,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 30,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/log.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/log.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 0,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "mutatorName": "ArithmeticOperator",
+      "replacement": "a + b",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 4,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 14,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "mutatorName": "ArithmeticOperator",
+      "replacement": "a / b",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 8,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 12,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 9,
+        },
+      },
+      "mutatorName": "UpdateOperator",
+      "replacement": "--a",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+]
+`;
+
+exports[`incremental should reuse expected mutant results for vitest 1`] = `
+Array [
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#concat should concat a and b",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 0,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#concat should concat a and b",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\\"\\"",
+      "static": true,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#greet should greet me",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 7,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/concat.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/concat.spec.js#greet should greet me",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 30,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/log.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/log.spec.js#log should not throw",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/log.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/log.spec.js#log should not throw",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "mutatorName": "StringLiteral",
+      "replacement": "\`\`",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#add should add two numbers",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 0,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#add should add two numbers",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "mutatorName": "ArithmeticOperator",
+      "replacement": "a + b",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#multiply should multiply the numbers",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 4,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [
+        "/home/nicojs/github/stryker-js/e2e/test/incremental/.stryker-tmp/sandbox3509700/spec/math.spec.js#multiply should multiply the numbers",
+      ],
+      "killedBy": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 14,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "mutatorName": "ArithmeticOperator",
+      "replacement": "a / b",
+      "static": false,
+      "status": undefined,
+    },
+    "plan": "Run",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 8,
+        },
+      },
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+  Object {
+    "fileName": "src/math.js",
+    "mutant": Object {
+      "coveredBy": Array [],
+      "killedBy": Array [],
+      "location": Object {
+        "end": Object {
+          "column": 12,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 9,
+        },
+      },
+      "mutatorName": "UpdateOperator",
+      "replacement": "--a",
+      "static": false,
+      "status": "NoCoverage",
+      "testsCompleted": undefined,
+    },
+    "plan": "EarlyResult",
+  },
+]
+`;

--- a/e2e/test/incremental/vitest.config.js
+++ b/e2e/test/incremental/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/packages/vitest-runner/src/file-communicator.ts
+++ b/packages/vitest-runner/src/file-communicator.ts
@@ -76,8 +76,10 @@ export class FileCommunicator {
     return `
     import path from 'path';
     import fs from 'fs/promises';
+    import { normalizeFileName } from '@stryker-mutator/util';
 
     import { beforeEach, afterAll, beforeAll, afterEach } from 'vitest';
+    const cwd = process.cwd();
 
     const ns = globalThis.${this.globalNamespace} || (globalThis.${this.globalNamespace} = {});
     ${body}`;

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -1,4 +1,7 @@
+import path from 'path';
+
 import { BaseTestResult, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
+import { normalizeFileName } from '@stryker-mutator/util';
 import type { RunMode, Suite, TaskState, Test, ResolvedConfig } from 'vitest';
 
 function convertTaskStateToTestStatus(taskState: TaskState | undefined, testMode: RunMode): TestStatus {
@@ -91,6 +94,6 @@ export function collectTestName({ name, suite }: { name: string; suite?: Suite }
 }
 
 export function toTestId(test: Test): string {
-  return `${test.file?.filepath}#${collectTestName(test)}`;
+  return `${normalizeFileName(path.relative(process.cwd(), test.file?.filepath ?? 'unknown.js'))}#${collectTestName(test)}`;
 }
 // Stryker restore all

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import { factory, assertions, testInjector, TempTestDirectorySandbox } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 import { TestStatus } from '@stryker-mutator/api/test-runner';
-import { normalizeFileName } from '@stryker-mutator/util';
 
 import { createVitestTestRunnerFactory, VitestTestRunner } from '../../src/vitest-test-runner.js';
 import { VitestRunnerOptionsWithStrykerOptions } from '../../src/vitest-runner-options-with-stryker-options.js';
@@ -26,23 +25,16 @@ describe('VitestRunner integration', () => {
   });
 
   describe('using the simple-project project', () => {
-    let test1: string;
-    let test2: string;
-    let test3: string;
-    let test4: string;
-    let test5: string;
+    const test1 = 'tests/add.spec.ts#add should be able to add two numbers';
+    const test2 = 'tests/math.spec.ts#math should be able negate a number';
+    const test3 = 'tests/math.spec.ts#math should be able to add one to a number';
+    const test4 = 'tests/math.spec.ts#math should be able to recognize a negative number';
+    const test5 = 'tests/pi.spec.ts#pi should be 3.14';
     let sandboxFileName: string;
 
     beforeEach(async () => {
       sandbox = new TempTestDirectorySandbox('simple-project');
       await sandbox.init();
-
-      // Use normalizeFileName here, because vitest uses posix file names underneath
-      test1 = `${normalizeFileName(path.resolve('tests', 'add.spec.ts'))}#add should be able to add two numbers`;
-      test2 = `${normalizeFileName(path.resolve('tests', 'math.spec.ts'))}#math should be able negate a number`;
-      test3 = `${normalizeFileName(path.resolve('tests', 'math.spec.ts'))}#math should be able to add one to a number`;
-      test4 = `${normalizeFileName(path.resolve('tests', 'math.spec.ts'))}#math should be able to recognize a negative number`;
-      test5 = `${normalizeFileName(path.resolve('tests', 'pi.spec.ts'))}#pi should be 3.14`;
       sandboxFileName = path.resolve(sandbox.tmpDir, 'math.ts');
       await sut.init();
     });
@@ -262,8 +254,8 @@ describe('VitestRunner integration', () => {
     beforeEach(async () => {
       sandbox = new TempTestDirectorySandbox('workspaces');
       await sandbox.init();
-      fooTestId = `${normalizeFileName(path.resolve('packages', 'foo', 'src', 'math.spec.js'))}#min should min 44, 2 = 42`;
-      barTestId = `${normalizeFileName(path.resolve('packages', 'bar', 'src', 'math.spec.js'))}#add should add 40, 2 = 42`;
+      fooTestId = 'packages/foo/src/math.spec.js#min should min 44, 2 = 42';
+      barTestId = 'packages/bar/src/math.spec.js#add should add 40, 2 = 42';
     });
 
     it('should report mutant coverage', async () => {

--- a/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
@@ -4,6 +4,8 @@ import { Suite, Test } from 'vitest';
 import { expect } from 'chai';
 import { TestStatus } from '@stryker-mutator/api/test-runner';
 
+import { normalizeFileName } from '@stryker-mutator/util';
+
 import { collectTestsFromSuite, convertTestToTestResult, fromTestId, toTestId } from '../../src/vitest-helpers.js';
 
 describe('vitest-helpers', () => {
@@ -24,7 +26,8 @@ describe('vitest-helpers', () => {
         context: {} as any,
         file: {
           name: 'file.js',
-          filepath: path.resolve('file.js'),
+          // Using normalizeFileName here mimics the behavior of vitest on windows: using forward slashes
+          filepath: normalizeFileName(path.resolve('src', 'file.js')),
           type: 'suite',
           id: '1',
           mode: 'run',
@@ -32,7 +35,7 @@ describe('vitest-helpers', () => {
         },
       };
       const result = toTestId(test);
-      expect(result).to.be.equal(`${path.resolve('file.js')}#suite test1`);
+      expect(result).to.be.equal('src/file.js#suite test1');
     });
   });
 


### PR DESCRIPTION
Add `vitest` and `tap` runner to the `incremental` e2e test set. 
Also change the vitest-runner to report relative file names as testId:
- ✅ Smaller test ids
- ✅ Easier snapshot testing

Closes #4110
Closes #4109
