### PR TITLE
fix(vitest): use cwd for communication dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ src-generated
 dist
 dist-test
 packages/*/testResources/tmp
+packages/vitest-runner/.vitest-runner-undefined
 packages/report.*.json # Ignore heap dumps
 .idea
 *.iml

--- a/packages/vitest-runner/src/file-communicator.ts
+++ b/packages/vitest-runner/src/file-communicator.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
 
 import { MutantRunOptions } from '@stryker-mutator/api/test-runner';
 import { normalizeFileName } from '@stryker-mutator/util';
@@ -8,10 +7,7 @@ import { normalizeFileName } from '@stryker-mutator/util';
 import { collectTestName, toTestId } from './vitest-helpers.js';
 
 export class FileCommunicator {
-  private readonly communicationDir = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    `.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`
-  );
+  private readonly communicationDir = path.resolve(`.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`);
 
   public readonly files = Object.freeze({
     // Replace function is to have a valid windows path
@@ -79,15 +75,18 @@ export class FileCommunicator {
     import { normalizeFileName } from '@stryker-mutator/util';
 
     import { beforeEach, afterAll, beforeAll, afterEach } from 'vitest';
-    const cwd = process.cwd();
 
     const ns = globalThis.${this.globalNamespace} || (globalThis.${this.globalNamespace} = {});
     ${body}`;
   }
 
   private async cleanCommunicationDirectories() {
-    await fs.rm(this.communicationDir, { recursive: true, force: true });
+    await this.dispose();
     await fs.mkdir(this.files.coverageDir, { recursive: true });
     await fs.mkdir(this.files.hitCountDir, { recursive: true });
+  }
+
+  public async dispose(): Promise<void> {
+    await fs.rm(this.communicationDir, { recursive: true, force: true });
   }
 }

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -178,6 +178,7 @@ export class VitestTestRunner implements TestRunner {
   }
 
   public async dispose(): Promise<void> {
+    await this.fileCommunicator.dispose();
     await this.ctx.close();
     await this.ctx.closingPromise;
   }

--- a/packages/vitest-runner/test/unit/file-communication.spec.ts
+++ b/packages/vitest-runner/test/unit/file-communication.spec.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
 import { syncBuiltinESMExports } from 'module';
 import path from 'path';
 
@@ -24,7 +23,7 @@ describe(FileCommunicator.name, () => {
     syncBuiltinESMExports();
   });
 
-  const communicationDir = fileURLToPath(new URL(`../../src/.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`, import.meta.url));
+  const communicationDir = path.resolve(`.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`);
 
   function assertVitestSetupContains(containsText: string) {
     sinon.assert.calledOnceWithExactly(writeFileStub, sut.files.vitestSetup, sinon.match(containsText));


### PR DESCRIPTION
Base the communication directory of the vitest runner on the current working directory (cwd) rather than the `node_modules/@stryker-mutator/vitest-runner` directory.

Fixes #4214
