### PR TITLE
feat(reporter-api): remove `onAllMutantsTested`

### DIFF
--- a/packages/api/src/report/reporter.ts
+++ b/packages/api/src/report/reporter.ts
@@ -28,12 +28,6 @@ export interface Reporter {
   onMutantTested?(result: Readonly<MutantResult>): void;
 
   /**
-   * Called when all mutants were tested
-   * @param results The immutable results
-   */
-  onAllMutantsTested?(results: ReadonlyArray<Readonly<MutantResult>>): void;
-
-  /**
    * Called when mutation testing is done
    * @param report the mutation test result that is valid according to the mutation-testing-report-schema (json schema)
    * @see https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/report-schema/src/mutation-testing-report-schema.json

--- a/packages/core/src/reporters/broadcast-reporter.ts
+++ b/packages/core/src/reporters/broadcast-reporter.ts
@@ -62,7 +62,7 @@ export class BroadcastReporter implements StrictReporter {
   public onMutantTested(result: MutantResult): void {
     void this.broadcast('onMutantTested', result);
   }
-  
+
   public onMutationTestReportReady(report: schema.MutationTestResult, metrics: MutationTestMetricsResult): void {
     void this.broadcast('onMutationTestReportReady', report, metrics);
   }

--- a/packages/core/src/reporters/broadcast-reporter.ts
+++ b/packages/core/src/reporters/broadcast-reporter.ts
@@ -62,11 +62,7 @@ export class BroadcastReporter implements StrictReporter {
   public onMutantTested(result: MutantResult): void {
     void this.broadcast('onMutantTested', result);
   }
-
-  public onAllMutantsTested(results: MutantResult[]): void {
-    void this.broadcast('onAllMutantsTested', results);
-  }
-
+  
   public onMutationTestReportReady(report: schema.MutationTestResult, metrics: MutationTestMetricsResult): void {
     void this.broadcast('onMutationTestReportReady', report, metrics);
   }

--- a/packages/core/src/reporters/dots-reporter.ts
+++ b/packages/core/src/reporters/dots-reporter.ts
@@ -27,7 +27,7 @@ export class DotsReporter implements Reporter {
     process.stdout.write(toLog);
   }
 
-  public onAllMutantsTested(): void {
+  public onMutationTestReportReady(): void {
     process.stdout.write(os.EOL);
   }
 }

--- a/packages/core/src/reporters/event-recorder-reporter.ts
+++ b/packages/core/src/reporters/event-recorder-reporter.ts
@@ -56,10 +56,6 @@ export class EventRecorderReporter implements StrictReporter {
     this.work('onMutationTestReportReady', report);
   }
 
-  public onAllMutantsTested(results: MutantResult[]): void {
-    this.work('onAllMutantsTested', results);
-  }
-
   public async wrapUp(): Promise<void> {
     await this.createBaseFolderTask;
     await Promise.all(this.allWork);

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -121,7 +121,6 @@ export class MutationTestReportHelper {
   public async reportAll(results: MutantResult[]): Promise<void> {
     const report = await this.mutationTestReport(results);
     const metrics = calculateMutationTestMetrics(report);
-    this.reporter.onAllMutantsTested(results);
     this.reporter.onMutationTestReportReady(report, metrics);
     if (this.options.incremental) {
       await this.fs.mkdir(path.dirname(this.options.incrementalFile), { recursive: true });

--- a/packages/core/src/reporters/progress-append-only-reporter.ts
+++ b/packages/core/src/reporters/progress-append-only-reporter.ts
@@ -14,7 +14,7 @@ export class ProgressAppendOnlyReporter extends ProgressKeeper {
     }
   }
 
-  public onAllMutantsTested(): void {
+  public onMutationTestReportReady(): void {
     if (this.intervalReference) {
       clearInterval(this.intervalReference);
     }

--- a/packages/core/test/unit/reporters/broadcast-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/broadcast-reporter.spec.ts
@@ -81,9 +81,6 @@ describe(BroadcastReporter.name, () => {
     it('should forward "onMutantTested"', async () => {
       await actAssertShouldForward('onMutantTested', factory.mutantResult());
     });
-    it('should forward "onAllMutantsTested"', async () => {
-      await actAssertShouldForward('onAllMutantsTested', [factory.mutantResult()]);
-    });
     it('should forward "onMutationTestReportReady"', async () => {
       await actAssertShouldForward(
         'onMutationTestReportReady',
@@ -154,9 +151,6 @@ describe(BroadcastReporter.name, () => {
       });
       it('should still broadcast "onMutantTested"', async () => {
         await actAssertShouldForward('onMutantTested', factory.mutantResult());
-      });
-      it('should still broadcast "onAllMutantsTested"', async () => {
-        await actAssertShouldForward('onAllMutantsTested', [factory.mutantResult()]);
       });
       it('should still broadcast "onMutationTestReportReady"', async () => {
         await actAssertShouldForward(

--- a/packages/core/test/unit/reporters/dots-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/dots-reporter.spec.ts
@@ -18,7 +18,7 @@ describe(DotsReporter.name, () => {
     sinon.stub(process.stdout, 'write');
   });
 
-  describe('onMutantTested()', () => {
+  describe(DotsReporter.prototype.onMutantTested.name, () => {
     it('should log "." when status is Killed', () => {
       sut.onMutantTested(factory.killedMutantResult());
       expect(process.stdout.write).to.have.been.calledWith('.');
@@ -35,9 +35,9 @@ describe(DotsReporter.name, () => {
     });
   });
 
-  describe('onAllMutantsTested()', () => {
+  describe(DotsReporter.prototype.onMutationTestReportReady.name, () => {
     it('should write a new line', () => {
-      sut.onAllMutantsTested();
+      sut.onMutationTestReportReady();
       expect(process.stdout.write).to.have.been.calledWith(os.EOL);
     });
   });

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -50,16 +50,6 @@ describe(MutationTestReportHelper.name, () => {
         expect(reporterMock.onMutationTestReportReady).calledOnce;
       });
 
-      it('should report "onAllMutantsTested"', async () => {
-        await actReportAll();
-        expect(reporterMock.onAllMutantsTested).calledOnce;
-      });
-
-      it('should report "onAllMutantsTested" before mutationTestReportReady', async () => {
-        await actReportAll();
-        expect(reporterMock.onAllMutantsTested).calledBefore(reporterMock.onMutationTestReportReady);
-      });
-
       it('should copy thresholds', async () => {
         const [actualReport] = await actReportAll();
         expect(actualReport.thresholds).eq(testInjector.options.thresholds);

--- a/packages/test-helpers/src/factory.ts
+++ b/packages/test-helpers/src/factory.ts
@@ -322,7 +322,6 @@ export const ALL_REPORTER_EVENTS: Array<keyof Reporter> = [
   'onDryRunCompleted',
   'onMutationTestingPlanReady',
   'onMutantTested',
-  'onAllMutantsTested',
   'onMutationTestReportReady',
   'wrapUp',
 ];


### PR DESCRIPTION
BREAKING CHANGE: The event `onAllMutantsTested` has been removed. Plugin creators should use `onMutationTestReportReady` instead.

Fixes #4156