### PR TITLE
feat(tap-runner): support `"nodeArgs"`

### DIFF
--- a/e2e/test/incremental/verify/verify.js
+++ b/e2e/test/incremental/verify/verify.js
@@ -20,14 +20,14 @@ describe('incremental', () => {
 
   beforeEach(async () => {
     await fsPromises.rm(incrementalFile, { force: true });
-    /**
-     * @type {import('@stryker-mutator/api/core').LogLevel}
-     */
     strykerOptions = {
       incremental: true,
       concurrency: 1,
       plugins: ['./verify/mutation-run-plan-reporter.js'],
       reporters: ['mutation-run-plan', 'html'],
+      tap: {
+        testFiles: 'spec/*.tap.js',
+      },
     };
     await changeFiles('original'); // change the files back to there original state
   });
@@ -42,7 +42,7 @@ describe('incremental', () => {
     // We know which test files are changed and assume each test in that file changed
     withoutTestLocations: 2,
     // We know which test file the test originated from, but we can't differentiate between tests in the file (TAP runner)
-    withoutTestDeviation: 6,
+    withoutTestDeviation: 2,
     // Don't know from which test files the tests originated
     withoutTestFiles: 7,
   });

--- a/e2e/test/incremental/verify/verify.js.snap
+++ b/e2e/test/incremental/verify/verify.js.snap
@@ -1920,8 +1920,10 @@ Array [
   Object {
     "fileName": "src/concat.js",
     "mutant": Object {
-      "coveredBy": Array [],
-      "killedBy": Array [],
+      "coveredBy": Array [
+        "spec/concat.tap.js",
+      ],
+      "killedBy": undefined,
       "location": Object {
         "end": Object {
           "column": 1,
@@ -1935,16 +1937,17 @@ Array [
       "mutatorName": "BlockStatement",
       "replacement": "{}",
       "static": false,
-      "status": "NoCoverage",
-      "testsCompleted": undefined,
+      "status": undefined,
     },
-    "plan": "EarlyResult",
+    "plan": "Run",
   },
   Object {
     "fileName": "src/concat.js",
     "mutant": Object {
-      "coveredBy": Array [],
-      "killedBy": Array [],
+      "coveredBy": Array [
+        "spec/concat.tap.js",
+      ],
+      "killedBy": undefined,
       "location": Object {
         "end": Object {
           "column": 19,
@@ -1958,16 +1961,15 @@ Array [
       "mutatorName": "StringLiteral",
       "replacement": "\`\`",
       "static": false,
-      "status": "NoCoverage",
-      "testsCompleted": undefined,
+      "status": undefined,
     },
-    "plan": "EarlyResult",
+    "plan": "Run",
   },
   Object {
     "fileName": "src/concat.js",
     "mutant": Object {
       "coveredBy": Array [
-        "spec/concat.spec.js",
+        "spec/concat.tap.js",
       ],
       "killedBy": undefined,
       "location": Object {
@@ -1990,7 +1992,9 @@ Array [
   Object {
     "fileName": "src/concat.js",
     "mutant": Object {
-      "coveredBy": Array [],
+      "coveredBy": Array [
+        "spec/concat.tap.js",
+      ],
       "killedBy": undefined,
       "location": Object {
         "end": Object {
@@ -2012,7 +2016,9 @@ Array [
   Object {
     "fileName": "src/concat.js",
     "mutant": Object {
-      "coveredBy": Array [],
+      "coveredBy": Array [
+        "spec/concat.tap.js",
+      ],
       "killedBy": undefined,
       "location": Object {
         "end": Object {
@@ -2078,7 +2084,9 @@ Array [
   Object {
     "fileName": "src/math.js",
     "mutant": Object {
-      "coveredBy": Array [],
+      "coveredBy": Array [
+        "spec/math.tap.js",
+      ],
       "killedBy": undefined,
       "location": Object {
         "end": Object {
@@ -2100,7 +2108,9 @@ Array [
   Object {
     "fileName": "src/math.js",
     "mutant": Object {
-      "coveredBy": Array [],
+      "coveredBy": Array [
+        "spec/math.tap.js",
+      ],
       "killedBy": undefined,
       "location": Object {
         "end": Object {
@@ -2122,8 +2132,10 @@ Array [
   Object {
     "fileName": "src/math.js",
     "mutant": Object {
-      "coveredBy": Array [],
-      "killedBy": Array [],
+      "coveredBy": Array [
+        "spec/math.tap.js",
+      ],
+      "killedBy": undefined,
       "location": Object {
         "end": Object {
           "column": 1,
@@ -2137,16 +2149,17 @@ Array [
       "mutatorName": "BlockStatement",
       "replacement": "{}",
       "static": false,
-      "status": "NoCoverage",
-      "testsCompleted": undefined,
+      "status": undefined,
     },
-    "plan": "EarlyResult",
+    "plan": "Run",
   },
   Object {
     "fileName": "src/math.js",
     "mutant": Object {
-      "coveredBy": Array [],
-      "killedBy": Array [],
+      "coveredBy": Array [
+        "spec/math.tap.js",
+      ],
+      "killedBy": undefined,
       "location": Object {
         "end": Object {
           "column": 14,
@@ -2160,10 +2173,9 @@ Array [
       "mutatorName": "ArithmeticOperator",
       "replacement": "a / b",
       "static": false,
-      "status": "NoCoverage",
-      "testsCompleted": undefined,
+      "status": undefined,
     },
-    "plan": "EarlyResult",
+    "plan": "Run",
   },
   Object {
     "fileName": "src/math.js",

--- a/e2e/test/mono-schema/test/valid.json
+++ b/e2e/test/mono-schema/test/valid.json
@@ -33,6 +33,7 @@
     "configFile": "vitest.config.js"
   },
   "tap": {
-    "testFiles": "{**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx)"
+    "testFiles": "{**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx)",
+    "nodeArgs": ["--loader", "ts-node/esm"]
   }
 }

--- a/e2e/test/tap-typescript/package.json
+++ b/e2e/test/tap-typescript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tap-typescript",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A project using node-tap and typescript",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "pretest": "rimraf \"reports\"",
+    "test": "stryker run",
+    "posttest": "mocha --no-config --no-package --timeout 0 verify/verify.js",
+    "test:unit": "NODE_OPTIONS=\"--loader ts-node/esm\" tap --ts"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/e2e/test/tap-typescript/src/add.ts
+++ b/e2e/test/tap-typescript/src/add.ts
@@ -1,0 +1,3 @@
+export function add(num1: number, num2: number): number {
+  return num1 + num2;
+}

--- a/e2e/test/tap-typescript/src/increment.ts
+++ b/e2e/test/tap-typescript/src/increment.ts
@@ -1,0 +1,6 @@
+
+export function increment(n: number) {
+  n++;
+  return n;
+}
+

--- a/e2e/test/tap-typescript/src/is-negative.ts
+++ b/e2e/test/tap-typescript/src/is-negative.ts
@@ -1,0 +1,7 @@
+export function isNegativeNumber(n: number) {
+  var isNegative = false;
+  if (n < 0) {
+    isNegative = true;
+  }
+  return isNegative;
+}

--- a/e2e/test/tap-typescript/src/negate.ts
+++ b/e2e/test/tap-typescript/src/negate.ts
@@ -1,0 +1,3 @@
+export function negate(n: number) {
+  return -n;
+}

--- a/e2e/test/tap-typescript/stryker.conf.json
+++ b/e2e/test/tap-typescript/stryker.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "testRunner": "tap",
+  "concurrency": 1,
+  "reporters": ["json", "clear-text", "html", "event-recorder"],
+  "testRunnerNodeArgs_comment": ["--inspect-brk"],
+  "tap": {
+    "nodeArgs": ["--loader", "ts-node/esm"]
+  },
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ]
+}

--- a/e2e/test/tap-typescript/test/add.spec.ts
+++ b/e2e/test/tap-typescript/test/add.spec.ts
@@ -1,0 +1,12 @@
+import { test } from 'tap';
+import { add } from '../src/add.js';
+
+test('add', (t) => {
+  t.test('should be able to add two numbers', (t) => {
+    const actual = add(5, 2);
+    t.equal(actual, 7);
+    t.end();
+  });
+
+  t.end();
+});

--- a/e2e/test/tap-typescript/test/increment.spec.ts
+++ b/e2e/test/tap-typescript/test/increment.spec.ts
@@ -1,0 +1,16 @@
+import { test } from 'tap';
+import { increment } from '../src/increment.js';
+
+test('increment', (t) => {
+  t.test('should be able to add one to a number', (t) => {
+    const number = 2;
+    const expected = 3;
+
+    const actual = increment(number);
+
+    t.equal(actual, expected);
+    t.end();
+  });
+
+  t.end();
+});

--- a/e2e/test/tap-typescript/test/is-negative.spec.ts
+++ b/e2e/test/tap-typescript/test/is-negative.spec.ts
@@ -1,0 +1,9 @@
+import { test } from 'tap';
+import { isNegativeNumber } from '../src/is-negative.js';
+
+test('math - should be able to recognize a negative number', (t) => {
+  const number = -2;
+  const result = isNegativeNumber(number);
+  t.equal(result, true);
+  t.end();
+});

--- a/e2e/test/tap-typescript/test/negate.spec.ts
+++ b/e2e/test/tap-typescript/test/negate.spec.ts
@@ -1,0 +1,12 @@
+import { test } from 'tap';
+import { negate } from '../src/negate.js';
+
+test('negate', (t) => {
+  t.test('should be able to negate a number', (t) => {
+    const actual = negate(2);
+    t.equal(actual, -2);
+    t.end();
+  });
+
+  t.end();
+});

--- a/e2e/test/tap-typescript/tsconfig.json
+++ b/e2e/test/tap-typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "outDir": "dist",
+    // "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/e2e/test/tap-typescript/verify/verify.js
+++ b/e2e/test/tap-typescript/verify/verify.js
@@ -1,0 +1,7 @@
+import { expectMetricsJsonToMatchSnapshot } from '../../../helpers.js';
+
+describe('Verify stryker has ran correctly', () => {
+  it('should report correct score', async () => {
+    await expectMetricsJsonToMatchSnapshot();
+  });
+});

--- a/e2e/test/tap-typescript/verify/verify.js.snap
+++ b/e2e/test/tap-typescript/verify/verify.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Verify stryker has ran correctly should report correct score 1`] = `
+Object {
+  "compileErrors": 0,
+  "ignored": 0,
+  "killed": 11,
+  "mutationScore": 78.57142857142857,
+  "mutationScoreBasedOnCoveredCode": 78.57142857142857,
+  "noCoverage": 0,
+  "pending": 0,
+  "runtimeErrors": 0,
+  "survived": 3,
+  "timeout": 0,
+  "totalCovered": 14,
+  "totalDetected": 11,
+  "totalInvalid": 0,
+  "totalMutants": 14,
+  "totalUndetected": 3,
+  "totalValid": 14,
+}
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "sinon": "15.1.0",
         "sinon-chai": "3.7.0",
         "source-map-support": "0.5.21",
+        "ts-node": "10.9.1",
         "typescript": "5.0.4"
       },
       "engines": {
@@ -180,6 +181,28 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2543,6 +2566,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
@@ -3017,6 +3064,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -3175,6 +3231,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4511,6 +4573,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -9298,6 +9366,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -13774,6 +13848,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -14232,6 +14358,12 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -14624,6 +14756,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14739,6 +14880,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -16525,6 +16687,30 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@tufjs/canonical-json": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
@@ -16882,6 +17068,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -16999,6 +17191,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -18013,6 +18211,12 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-env": {
       "version": "7.0.3",
@@ -21659,6 +21863,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "make-fetch-happen": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -25066,6 +25276,35 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -25412,6 +25651,12 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -25718,6 +25963,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sinon": "15.1.0",
     "sinon-chai": "3.7.0",
     "source-map-support": "0.5.21",
+    "ts-node": "10.9.1",
     "typescript": "5.0.4"
   },
   "scripts": {

--- a/packages/tap-runner/schema/tap-runner-options.json
+++ b/packages/tap-runner/schema/tap-runner-options.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
   "additionalProperties": false,
+  "title": "StrykerTapRunnerOptions",
   "properties": {
     "tap": {
       "description": "Configuration for @stryker-mutator/tap-runner",
@@ -14,6 +15,14 @@
           "description": "Specify glob expressions to test files to run. Defaults to {**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx)",
           "type": "string",
           "default": "{**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx|mts|cts)"
+        },
+        "nodeArgs": {
+          "description": "Specify additional node arguments to be passed when running your test files. Note that stryker will always pass an additional `--require` flag to enable coverage analysis.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
         }
       }
     }

--- a/packages/tap-runner/src/setup/hook.cts
+++ b/packages/tap-runner/src/setup/hook.cts
@@ -2,13 +2,9 @@ import fs from 'fs';
 
 import { tempTapOutputFileName, strykerDryRun, strykerHitLimit, strykerNamespace } from './env.cjs';
 
-const strykerGlobalNamespace = process.env[strykerNamespace] as '__stryker__' | '__stryker2__';
+const strykerGlobalNamespace = (process.env[strykerNamespace] as '__stryker__' | '__stryker2__' | undefined) ?? '__stryker__';
 const dryRun = process.env[strykerDryRun] === 'true';
 const hitLimit = process.env[strykerHitLimit] ? +process.env[strykerHitLimit] : undefined;
-
-if (!strykerGlobalNamespace) {
-  throw new Error('Stryker global namespace not set');
-}
 
 global[strykerGlobalNamespace] = {};
 

--- a/packages/tap-runner/src/tap-helper.ts
+++ b/packages/tap-runner/src/tap-helper.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 import { ChildProcessWithoutNullStreams } from 'child_process';
-import type { Readable } from 'stream';
 
 import { glob } from 'glob';
 import * as tap from 'tap-parser';

--- a/packages/tap-runner/src/tap-helper.ts
+++ b/packages/tap-runner/src/tap-helper.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import { ChildProcessWithoutNullStreams } from 'child_process';
+import type { Readable } from 'stream';
 
 import { glob } from 'glob';
 import * as tap from 'tap-parser';
@@ -15,7 +16,7 @@ export interface TapResult {
   failedTests: tap.TapError[];
 }
 
-export function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail: boolean): Promise<TapResult> {
+function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail: boolean) {
   return new Promise<TapResult>((resolve) => {
     const failedTests: tap.TapError[] = [];
     const config = { bail: !disableBail };
@@ -35,4 +36,26 @@ export function parseTap(tapProcess: ChildProcessWithoutNullStreams, disableBail
     });
     tapProcess.stdout.pipe(parser);
   });
+}
+
+export async function captureTapResult(tapProcess: ChildProcessWithoutNullStreams, disableBail: boolean): Promise<TapResult> {
+  const exitAsPromised = new Promise<number>((resolve) => tapProcess.on('exit', resolve));
+  const stderrOutput: Buffer[] = [];
+  tapProcess.stderr.on('data', (chunk: Buffer) => {
+    stderrOutput.push(chunk);
+  });
+  const [exitCodeResult, tapResult] = await Promise.all([exitAsPromised, parseTap(tapProcess, disableBail)]);
+
+  if (exitCodeResult !== 0 && !tapResult.failedTests.length) {
+    // The tap process errored, but we don't have any failed tests. This is probably a syntax error in the test file.
+    throw new Error(
+      `Tap process exited with code ${exitCodeResult}. To reproduce it yourself, use the following command: 
+      cd "${process.cwd()}"
+      ${tapProcess.spawnargs.map((arg, index) => (index === 0 ? arg : `"${arg}"`)).join(' ')}
+      
+      Stderr output:
+      ${stderrOutput.join('')}`
+    );
+  }
+  return tapResult;
 }

--- a/packages/tap-runner/src/tap-runner-options-with-stryker-options.ts
+++ b/packages/tap-runner/src/tap-runner-options-with-stryker-options.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
 
-import { TapRunnerOptions } from '../src-generated/tap-runner-options.js';
+import { StrykerTapRunnerOptions } from '../src-generated/tap-runner-options.js';
 
-export interface TapRunnerOptionsWithStrykerOptions extends TapRunnerOptions, StrykerOptions {}
+export interface TapRunnerOptionsWithStrykerOptions extends StrykerTapRunnerOptions, StrykerOptions {}

--- a/packages/tap-runner/test/helpers/factory.ts
+++ b/packages/tap-runner/test/helpers/factory.ts
@@ -1,0 +1,10 @@
+import type { TapRunnerOptions } from '../../src-generated/tap-runner-options.js';
+import { strykerValidationSchema } from '../../src/index.js';
+
+export function tapRunnerOptions(overrides?: Partial<TapRunnerOptions>): TapRunnerOptions {
+  return {
+    testFiles: strykerValidationSchema.properties.tap.properties.testFiles.default,
+    nodeArgs: [...strykerValidationSchema.properties.tap.properties.nodeArgs.default],
+    ...overrides,
+  };
+}

--- a/packages/tap-runner/test/helpers/tap-test-runner-constants.ts
+++ b/packages/tap-runner/test/helpers/tap-test-runner-constants.ts
@@ -1,1 +1,0 @@
-export const defaultTestFilesGlob = '{**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx)';

--- a/packages/tap-runner/test/integration/tap-test-runner-instrumented.it.spec.ts
+++ b/packages/tap-runner/test/integration/tap-test-runner-instrumented.it.spec.ts
@@ -3,7 +3,7 @@ import { assertions, factory, TempTestDirectorySandbox, testInjector } from '@st
 
 import { createTapTestRunnerFactory, TapTestRunner } from '../../src/index.js';
 import { TapRunnerOptionsWithStrykerOptions } from '../../src/tap-runner-options-with-stryker-options.js';
-import { defaultTestFilesGlob } from '../helpers/tap-test-runner-constants.js';
+import { tapRunnerOptions } from '../helpers/factory.js';
 
 describe('Running in an example project', () => {
   let sut: TapTestRunner;
@@ -12,9 +12,7 @@ describe('Running in an example project', () => {
   beforeEach(async () => {
     sandbox = new TempTestDirectorySandbox('example-instrumented');
     await sandbox.init();
-    (testInjector.options as TapRunnerOptionsWithStrykerOptions).tap = {
-      testFiles: defaultTestFilesGlob,
-    };
+    (testInjector.options as TapRunnerOptionsWithStrykerOptions).tap = tapRunnerOptions();
     sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
     await sut.init();
   });

--- a/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
+++ b/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
@@ -158,7 +158,7 @@ describe('tap-runner integration', () => {
     });
   });
 
-  describe.only('Running on a typescript project', () => {
+  describe('Running on a typescript project', () => {
     beforeEach(async () => {
       sandbox = new TempTestDirectorySandbox('ts-example');
       await sandbox.init();

--- a/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
+++ b/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
@@ -8,126 +8,173 @@ import { TapTestRunner } from '../../src/index.js';
 import { createTapTestRunnerFactory } from '../../src/tap-test-runner.js';
 import { findTestyLookingFiles } from '../../src/tap-helper.js';
 import { TapRunnerOptionsWithStrykerOptions } from '../../src/tap-runner-options-with-stryker-options.js';
-import { defaultTestFilesGlob } from '../helpers/tap-test-runner-constants.js';
+import { tapRunnerOptions } from '../helpers/factory.js';
 
-describe('Running in an example project', () => {
+describe('tap-runner integration', () => {
   let sut: TapTestRunner;
   let sandbox: TempTestDirectorySandbox;
-  let testFilter: string[] = [];
+  let options: TapRunnerOptionsWithStrykerOptions;
 
-  beforeEach(async () => {
-    sandbox = new TempTestDirectorySandbox('example');
-    await sandbox.init();
-    (testInjector.options as TapRunnerOptionsWithStrykerOptions).tap = {
-      testFiles: defaultTestFilesGlob,
-    };
-    sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
-    await sut.init();
-
-    const excludeFiles = ['tests/bail.spec.js', 'tests/error.spec.js'];
-    testFilter = (await findTestyLookingFiles(defaultTestFilesGlob)).filter((file) => !excludeFiles.includes(file));
+  beforeEach(() => {
+    options = testInjector.options as TapRunnerOptionsWithStrykerOptions;
+    options.tap = tapRunnerOptions();
   });
   afterEach(async () => {
     await sandbox.dispose();
   });
 
-  it('should be able complete a dry run', async () => {
-    // Act
-    const run = await sut.dryRun(factory.dryRunOptions({ files: testFilter }));
+  describe('Running in an example project', () => {
+    let testFilter: string[] = [];
 
-    // Assert
-    expect(run.status).eq(DryRunStatus.Complete);
-  });
+    beforeEach(async () => {
+      sandbox = new TempTestDirectorySandbox('example');
+      await sandbox.init();
+      sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
+      await sut.init();
 
-  it('should be to run mutantRun that survives', async () => {
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter }));
+      const excludeFiles = ['tests/bail.spec.js', 'tests/error.spec.js'];
+      testFilter = (await findTestyLookingFiles(options.tap.testFiles)).filter((file) => !excludeFiles.includes(file));
+    });
 
-    // Assert
-    assertions.expectSurvived(run);
-    expect(run.nrOfTests).eq(5);
-  });
+    it('should be able complete a dry run', async () => {
+      // Act
+      const run = await sut.dryRun(factory.dryRunOptions({ files: testFilter }));
 
-  it('should be to run mutantRun that gets killed', async () => {
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ disableBail: true }));
+      // Assert
+      expect(run.status).eq(DryRunStatus.Complete);
+    });
 
-    // Assert
-    assertions.expectKilled(run);
-    // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
-    expect([...run.killedBy].sort()).deep.eq(['tests/bail.spec.js', 'tests/error.spec.js']);
-    expect(run.failureMessage).eq('Concat two strings: An error occurred');
-  });
+    it('should be to run mutantRun that survives', async () => {
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter }));
 
-  it('should be able to run test file with random output', async () => {
-    const testFiles = ['tests/random-output.spec.js'];
+      // Assert
+      assertions.expectSurvived(run);
+      expect(run.nrOfTests).eq(5);
+    });
 
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles }));
-    // Assert
-    assertions.expectSurvived(run);
-  });
+    it('should be to run mutantRun that gets killed', async () => {
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ disableBail: true }));
 
-  it('should be able to run test file without output', async () => {
-    const testFiles = ['tests/no-output.spec.js'];
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles }));
+      // Assert
+      assertions.expectKilled(run);
+      // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+      expect([...run.killedBy].sort()).deep.eq(['tests/bail.spec.js', 'tests/error.spec.js']);
+      expect(run.failureMessage).eq('Concat two strings: An error occurred');
+    });
 
-    // Assert
-    assertions.expectSurvived(run);
-  });
+    it('should be able to run test file with random output', async () => {
+      const testFiles = ['tests/random-output.spec.js'];
 
-  it('should bail out when disableBail is false', async () => {
-    const testFiles = ['tests/bail.spec.js', 'tests/formatter.spec.js'];
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles }));
+      // Assert
+      assertions.expectSurvived(run);
+    });
 
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: false }));
+    it('should be able to run test file without output', async () => {
+      const testFiles = ['tests/no-output.spec.js'];
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles }));
 
-    // Assert
-    assertions.expectKilled(run);
-    expect(run.nrOfTests).eq(1);
-    expect(run.killedBy[0]).eq('tests/bail.spec.js');
-  });
+      // Assert
+      assertions.expectSurvived(run);
+    });
 
-  it('should not bail out when disableBail is true', async () => {
-    const testFiles = ['tests/bail.spec.js', 'tests/formatter.spec.js'];
+    it('should bail out when disableBail is false', async () => {
+      const testFiles = ['tests/bail.spec.js', 'tests/formatter.spec.js'];
 
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: true }));
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: false }));
 
-    // Assert
-    assertions.expectKilled(run);
-    expect(run.nrOfTests).eq(testFiles.length);
-  });
+      // Assert
+      assertions.expectKilled(run);
+      expect(run.nrOfTests).eq(1);
+      expect(run.killedBy[0]).eq('tests/bail.spec.js');
+    });
 
-  it('should bail out current process when disableBail is false and os type is not windows', async function () {
-    if (os.platform() === 'win32') {
-      this.skip();
-    } else {
+    it('should not bail out when disableBail is true', async () => {
+      const testFiles = ['tests/bail.spec.js', 'tests/formatter.spec.js'];
+
+      // Act
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: true }));
+
+      // Assert
+      assertions.expectKilled(run);
+      expect(run.nrOfTests).eq(testFiles.length);
+    });
+
+    it('should bail out current process when disableBail is false and os type is not windows', async function () {
+      if (os.platform() === 'win32') {
+        this.skip();
+      } else {
+        const testFiles = ['tests/bail.spec.js'];
+        const startTime = Date.now();
+
+        // Act
+        const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: false }));
+        const endTime = Date.now();
+
+        // Assert
+        assertions.expectKilled(run);
+        expect(run.failureMessage).contains('This test will fail');
+        expect(endTime - startTime).at.most(4000);
+      }
+    });
+
+    it('should not bail out current process when disableBail is true', async () => {
       const testFiles = ['tests/bail.spec.js'];
       const startTime = Date.now();
 
       // Act
-      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: false }));
+      const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: true }));
       const endTime = Date.now();
 
       // Assert
       assertions.expectKilled(run);
-      expect(run.failureMessage).contains('This test will fail');
-      expect(endTime - startTime).at.most(4000);
-    }
+      expect(endTime - startTime).gte(4000);
+    });
   });
 
-  it('should not bail out current process when disableBail is true', async () => {
-    const testFiles = ['tests/bail.spec.js'];
-    const startTime = Date.now();
+  describe('Running on a bogus project', () => {
+    beforeEach(async () => {
+      sandbox = new TempTestDirectorySandbox('bogus');
+      await sandbox.init();
+      options.tap = tapRunnerOptions({
+        testFiles: 'readme.md', // WAT??? -> Not even a .js file
+      });
+      sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
+      await sut.init();
+    });
 
-    // Act
-    const run = await sut.mutantRun(factory.mutantRunOptions({ testFilter: testFiles, disableBail: true }));
-    const endTime = Date.now();
+    it('should report an error on dry run', async () => {
+      // Act
+      const run = await sut.dryRun(factory.dryRunOptions());
 
-    // Assert
-    assertions.expectKilled(run);
-    expect(endTime - startTime).gte(4000);
+      // Assert
+      assertions.expectErrored(run);
+      expect(run.errorMessage).contains('Error running file "readme.md". Tap process exited with code 1');
+    });
+  });
+
+  describe.only('Running on a typescript project', () => {
+    beforeEach(async () => {
+      sandbox = new TempTestDirectorySandbox('ts-example');
+      await sandbox.init();
+      options.tap = tapRunnerOptions({
+        nodeArgs: ['--loader', 'ts-node/esm'],
+      });
+      sut = testInjector.injector.injectFunction(createTapTestRunnerFactory('__stryker2__'));
+      await sut.init();
+    });
+
+    it('should be able to run with a --loader', async () => {
+      // Act
+      const run = await sut.dryRun(factory.dryRunOptions());
+
+      // Assert
+      assertions.expectCompleted(run);
+    });
   });
 });

--- a/packages/tap-runner/test/integration/testy-looking-files.spec.ts
+++ b/packages/tap-runner/test/integration/testy-looking-files.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { expect } from 'chai';
 
 import { findTestyLookingFiles } from '../../src/tap-helper.js';
-import { defaultTestFilesGlob } from '../helpers/tap-test-runner-constants.js';
+import { tapRunnerOptions } from '../helpers/factory.js';
 
 describe('Running in an testy-looking-files project', () => {
   beforeEach(async () => {
@@ -13,7 +13,7 @@ describe('Running in an testy-looking-files project', () => {
 
   it('should find all testy looking files', async () => {
     // Act
-    const files = await findTestyLookingFiles(defaultTestFilesGlob);
+    const files = await findTestyLookingFiles(tapRunnerOptions().testFiles);
 
     // Assert
     const expectedFiles = [

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -57,30 +57,4 @@ describe(TapTestRunner.name, () => {
       expect(sut.capabilities()).deep.eq(expectedCapabilities);
     });
   });
-
-  describe('mutantRun', () => {
-    it('should wait for process to exit before returning result', async () => {
-      // Added this test because it was possible that two process were trying to use the same mutated files resulting in a locked file error.
-      // For more info see: https://github.com/stryker-mutator/stryker-js/issues/4122
-
-      const runPromise = sut.mutantRun(factory.mutantRunOptions({ testFilter: ['test.js'] }));
-      let processFinished = false;
-
-      // End the tapParser manually so the process is not killed
-      tapParser.end('');
-
-      childProcessMock.on('exit', () => {
-        processFinished = true;
-      });
-
-      // Wait a second before emitting the exit event
-      setTimeout(() => {
-        childProcessMock.emit('exit', 0);
-      }, 1000);
-
-      // Should wait for the process to finish before resolving
-      await runPromise;
-      expect(processFinished).to.be.true;
-    });
-  });
 });

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -9,7 +9,7 @@ import fs from 'fs/promises';
 import sinon from 'sinon';
 
 import { TestRunnerCapabilities } from '@stryker-mutator/api/test-runner';
-import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
 import * as tap from 'tap-parser';

--- a/packages/tap-runner/testResources/bogus/readme.md
+++ b/packages/tap-runner/testResources/bogus/readme.md
@@ -1,0 +1,1 @@
+This is not a test file!

--- a/packages/tap-runner/testResources/ts-example/src/formatter.ts
+++ b/packages/tap-runner/testResources/ts-example/src/formatter.ts
@@ -1,0 +1,3 @@
+export function concat(text1: string, text2: string) {
+  return text1 + text2;
+}

--- a/packages/tap-runner/testResources/ts-example/src/math.ts
+++ b/packages/tap-runner/testResources/ts-example/src/math.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/packages/tap-runner/testResources/ts-example/tests/formatter.spec.ts
+++ b/packages/tap-runner/testResources/ts-example/tests/formatter.spec.ts
@@ -1,0 +1,7 @@
+import tap from 'tap';
+import { concat } from '../src/formatter.js';
+
+tap.test('Concat two strings', ({ equal, end }) => {
+  equal(concat('3', 'hours'), '3hours', 'Adding 10 and 5 equal to 15')
+  end();
+});

--- a/packages/tap-runner/testResources/ts-example/tests/math.spec.ts
+++ b/packages/tap-runner/testResources/ts-example/tests/math.spec.ts
@@ -1,0 +1,9 @@
+import tap from 'tap';
+import { add } from '../src/math.js';
+
+tap.test('Adding two numbers', ({ equal, end }) => {
+  equal(add(5, 10), 15, 'Adding 10 and 5 equal to 15')
+  equal(add(100, 200), 300, 'Adding 100 and 200 equal to 300')
+  end();
+});
+

--- a/packages/tap-runner/testResources/ts-example/tsconfig.json
+++ b/packages/tap-runner/testResources/ts-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "outDir": "dist",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "ts-node": {
+    "transpileOnly": true
+  }
+}


### PR DESCRIPTION
Add support for the `tap.nodeArgs` config option. Here you can specify additional node arguments to be passed to every test runner.

With this, it is now possible to JIT compile typescript code using:

```json
{
  "tap": {
    "nodeArgs": ["--loader", "ts-node/esm"]
  }
}
```

Or (when using commonjs)

```json
{
  "tap": {
    "nodeArgs": ["-r", "ts-node/register"]
  }
}
```

Also add a test for typescript using the tap runner.

Closes #4222