### PR TITLE
feat(vitest): support `bail`

### DIFF
--- a/e2e/test/disable-bail/.mocharc.json
+++ b/e2e/test/disable-bail/.mocharc.json
@@ -1,3 +1,4 @@
 {
-  "require": ["test/chai-setup.js"]
+  "require": ["test/chai-setup.js"],
+  "spec": "test/math.spec.js"
 }

--- a/e2e/test/disable-bail/package.json
+++ b/e2e/test/disable-bail/package.json
@@ -9,6 +9,8 @@
     "test:jasmine": "jasmine",
     "test:karma": "karma start",
     "test:jest": "jest",
+    "test:tap": "tap test/*.tap.js",
+    "test:vitest": "vitest run",
     "test": "mocha --no-config --no-timeout verify/verify.js"
   },
   "keywords": [],

--- a/e2e/test/disable-bail/stryker.conf.json
+++ b/e2e/test/disable-bail/stryker.conf.json
@@ -5,5 +5,8 @@
   "disableBail": true,
   "karma": {
     "configFile": "karma.conf.js"
+  },
+  "tap": {
+    "testFiles": "test/*.tap.js"
   }
 }

--- a/e2e/test/disable-bail/test/math1.tap.js
+++ b/e2e/test/disable-bail/test/math1.tap.js
@@ -1,0 +1,12 @@
+const { test } = require('tap');
+const { add } = require('../src/math');
+
+test(add.name, (t) => {
+  // Both kill the same mutant
+  t.test('should result in 42 for 40 and 2', (t) => {
+    t.equal(add(40, 2), 42);
+    t.end();
+  });
+
+  t.end();
+});

--- a/e2e/test/disable-bail/test/math2.tap.js
+++ b/e2e/test/disable-bail/test/math2.tap.js
@@ -1,0 +1,12 @@
+const { test } = require('tap');
+const { add } = require('../src/math');
+
+test(add.name, (t) => {
+  // Both kill the same mutant
+  t.test('should result in 42 for 41 and 1', (t) => {
+    t.equal(add(41, 1), 42);
+    t.end();
+  });
+
+  t.end();
+});

--- a/e2e/test/disable-bail/vitest.config.js
+++ b/e2e/test/disable-bail/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  }
+})

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -27,7 +27,7 @@ export function convertTestToTestResult(test: Test): TestResult {
     id: toTestId(test),
     name: collectTestName(test),
     timeSpentMs: test.result?.duration ?? 0,
-    fileName: test.file?.filepath,
+    fileName: test.file?.filepath && path.resolve(test.file.filepath),
     startPosition: test.meta,
   };
   if (status === TestStatus.Failed) {

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -48,6 +48,7 @@ export class VitestTestRunner implements TestRunner {
       coverage: { enabled: false },
       singleThread: true,
       watch: false,
+      bail: this.options.disableBail ? 0 : 1,
       onConsoleLog: () => false,
     });
 
@@ -105,8 +106,11 @@ export class VitestTestRunner implements TestRunner {
       });
       await this.ctx.start();
     }
-    const tests = this.ctx.state.getFiles().flatMap((file) => collectTestsFromSuite(file));
-    const testResults: TestResult[] = tests.map((test) => convertTestToTestResult(test));
+    const tests = this.ctx.state
+      .getFiles()
+      .flatMap((file) => collectTestsFromSuite(file))
+      .filter((test) => test.result); // if no result: it was skipped because of bail
+    const testResults = tests.map((test) => convertTestToTestResult(test));
     return { tests: testResults, status: DryRunStatus.Complete };
   }
 

--- a/packages/vitest-runner/testResources/simple-project/tests/add.spec.ts
+++ b/packages/vitest-runner/testResources/simple-project/tests/add.spec.ts
@@ -7,4 +7,9 @@ describe(add.name, () => {
 
     expect(actual).toBe(7);
   });
+  it('should be able to add a negative number', () => {
+    const actual = add(2, -5);
+
+    expect(actual).toBe(-3);
+  });
 });


### PR DESCRIPTION
Support `bail` in the vitest test runner. Also, support `disableBail` stryker option for reporting all killed tests.

Add e2e tests for `disableBail` in both vitest and tap.

Closes #4236