### PR TITLE
fix(vitest): explicitly error when browser-mode is enabled

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -50,7 +50,7 @@
         "ts-loader": "9.4.3",
         "ts-node": "10.9.1",
         "typescript": "5.0.4",
-        "vitest": "0.31.1",
+        "vitest": "0.31.2",
         "webpack": "5.84.1",
         "webpack-cli": "5.1.1"
       }
@@ -3729,13 +3729,13 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
-      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.2.tgz",
+      "integrity": "sha512-AOuh2NLN9zJ0SkvsItRkS/W39akYpUvo5LOnay3zEhGSnRgivPu2D3S8QlMij1hFMQcX+dlMilPgJatUHiGQ4A==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "chai": "^4.3.7"
       },
       "funding": {
@@ -3743,12 +3743,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
-      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.2.tgz",
+      "integrity": "sha512-k2mWrzZD1xsWfzwEXeVr2XF4v8ELpFOKLxRbcnzZclHelOLn27nXvnw1A4JwJtmca64C3/6lo4WHZDlq3TefLQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.31.1",
+        "@vitest/utils": "0.31.2",
         "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
@@ -3785,9 +3785,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
-      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.2.tgz",
+      "integrity": "sha512-NXRlbP3sM5+KELb8oXVHf7UWD+liBnSsS+4JlDVPD5+KPquZmgNR0xPLW5VEb5HoQZQpKTAFhtGf1AczRCbAhg==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.0",
@@ -3840,9 +3840,9 @@
       "dev": true
     },
     "node_modules/@vitest/spy": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
-      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.2.tgz",
+      "integrity": "sha512-81zcAkCCgAc1gA7UvLOWCvkIwrgzaqHBdv9sskOt2xh1+l+RMX9G7sVYj3AOsib3UDR0MCSXit49xKILTMnikw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.0"
@@ -3852,9 +3852,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.2.tgz",
+      "integrity": "sha512-B2AoocMpIiBezediqFzSqvuXI7AZlmlPkh3oj20Jh3bL35c8YYWk9KfOLkEjsLCrOHOUFXoYFc+ACiELCIJVRw==",
       "dev": true,
       "dependencies": {
         "concordance": "^5.0.4",
@@ -15785,9 +15785,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -16484,9 +16484,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
-      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.2.tgz",
+      "integrity": "sha512-NvoO7+zSvxROC4JY8cyp/cO7DHAX3dwMOHQVDdNtCZ4Zq8wInnR/bJ/lfsXqE6wrUgtYCE5/84qHS+A7vllI3A==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -16507,19 +16507,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
-      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.2.tgz",
+      "integrity": "sha512-O0qKHDbI+zXxwq1WOeqFjxP5v1mDqqM6gllPuOUJkK2YFyQ2nEo8CELR4Mg68ryTSSh527ysBmEN69bDvL2LkQ==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.31.1",
-        "@vitest/runner": "0.31.1",
-        "@vitest/snapshot": "0.31.1",
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/expect": "0.31.2",
+        "@vitest/runner": "0.31.2",
+        "@vitest/snapshot": "0.31.2",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -16535,7 +16535,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.31.1",
+        "vite-node": "0.31.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -19878,23 +19878,23 @@
       "dev": true
     },
     "@vitest/expect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
-      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.2.tgz",
+      "integrity": "sha512-AOuh2NLN9zJ0SkvsItRkS/W39akYpUvo5LOnay3zEhGSnRgivPu2D3S8QlMij1hFMQcX+dlMilPgJatUHiGQ4A==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "chai": "^4.3.7"
       }
     },
     "@vitest/runner": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
-      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.2.tgz",
+      "integrity": "sha512-k2mWrzZD1xsWfzwEXeVr2XF4v8ELpFOKLxRbcnzZclHelOLn27nXvnw1A4JwJtmca64C3/6lo4WHZDlq3TefLQ==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "0.31.1",
+        "@vitest/utils": "0.31.2",
         "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
@@ -19918,9 +19918,9 @@
       }
     },
     "@vitest/snapshot": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
-      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.2.tgz",
+      "integrity": "sha512-NXRlbP3sM5+KELb8oXVHf7UWD+liBnSsS+4JlDVPD5+KPquZmgNR0xPLW5VEb5HoQZQpKTAFhtGf1AczRCbAhg==",
       "dev": true,
       "requires": {
         "magic-string": "^0.30.0",
@@ -19960,18 +19960,18 @@
       }
     },
     "@vitest/spy": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
-      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.2.tgz",
+      "integrity": "sha512-81zcAkCCgAc1gA7UvLOWCvkIwrgzaqHBdv9sskOt2xh1+l+RMX9G7sVYj3AOsib3UDR0MCSXit49xKILTMnikw==",
       "dev": true,
       "requires": {
         "tinyspy": "^2.1.0"
       }
     },
     "@vitest/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.2.tgz",
+      "integrity": "sha512-B2AoocMpIiBezediqFzSqvuXI7AZlmlPkh3oj20Jh3bL35c8YYWk9KfOLkEjsLCrOHOUFXoYFc+ACiELCIJVRw==",
       "dev": true,
       "requires": {
         "concordance": "^5.0.4",
@@ -28857,9 +28857,9 @@
       "dev": true
     },
     "tinyspy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true
     },
     "tmp": {
@@ -29321,9 +29321,9 @@
       }
     },
     "vite-node": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
-      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.2.tgz",
+      "integrity": "sha512-NvoO7+zSvxROC4JY8cyp/cO7DHAX3dwMOHQVDdNtCZ4Zq8wInnR/bJ/lfsXqE6wrUgtYCE5/84qHS+A7vllI3A==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -29335,19 +29335,19 @@
       }
     },
     "vitest": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
-      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.2.tgz",
+      "integrity": "sha512-O0qKHDbI+zXxwq1WOeqFjxP5v1mDqqM6gllPuOUJkK2YFyQ2nEo8CELR4Mg68ryTSSh527ysBmEN69bDvL2LkQ==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.31.1",
-        "@vitest/runner": "0.31.1",
-        "@vitest/snapshot": "0.31.1",
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/expect": "0.31.2",
+        "@vitest/runner": "0.31.2",
+        "@vitest/snapshot": "0.31.2",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -29363,7 +29363,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.31.1",
+        "vite-node": "0.31.2",
         "why-is-node-running": "^2.2.2"
       }
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "29.0.5",
     "ts-loader": "9.4.3",
     "ts-node": "10.9.1",
-    "vitest": "0.31.1",
+    "vitest": "0.31.2",
     "typescript": "5.0.4",
     "webpack": "5.84.1",
     "webpack-cli": "5.1.1"

--- a/e2e/test/vitest-old-version/package-lock.json
+++ b/e2e/test/vitest-old-version/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "devDependencies": {
-        "vitest": "0.30.0"
+        "vitest": "0.31.2"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -420,9 +420,9 @@
       "peer": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "node_modules/@types/chai-subset": {
@@ -435,52 +435,64 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.1.tgz",
-      "integrity": "sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.30.0.tgz",
-      "integrity": "sha512-b/jLWBqi6WQHfezWm8VjgXdIyfejAurtxqdyCdDqoToCim5W/nDxKjFAADitEHPz80oz+IP+c+wmkGKBucSpiw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.2.tgz",
+      "integrity": "sha512-AOuh2NLN9zJ0SkvsItRkS/W39akYpUvo5LOnay3zEhGSnRgivPu2D3S8QlMij1hFMQcX+dlMilPgJatUHiGQ4A==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.30.0",
-        "@vitest/utils": "0.30.0",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "chai": "^4.3.7"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.30.0.tgz",
-      "integrity": "sha512-Xh4xkdRcymdeRNrSwjhgarCTSgnQu2J59wsFI6i4UhKrL5whzo5+vWyq7iWK1ht3fppPeNAtvkbqUDf+OJSCbQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.2.tgz",
+      "integrity": "sha512-k2mWrzZD1xsWfzwEXeVr2XF4v8ELpFOKLxRbcnzZclHelOLn27nXvnw1A4JwJtmca64C3/6lo4WHZDlq3TefLQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.30.0",
+        "@vitest/utils": "0.31.2",
         "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.30.0.tgz",
-      "integrity": "sha512-e4eSGCy36Bw3/Tkir9qYJDlFsUz3NALFPNJSxzlY8CFl901TV9iZdKgpqXpyG1sAhLO0tPHThBAMHRi8hRA8cg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.2.tgz",
+      "integrity": "sha512-NXRlbP3sM5+KELb8oXVHf7UWD+liBnSsS+4JlDVPD5+KPquZmgNR0xPLW5VEb5HoQZQpKTAFhtGf1AczRCbAhg==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
         "pretty-format": "^27.5.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.30.0.tgz",
-      "integrity": "sha512-olTWyG5gVWdfhCrdgxWQb2K3JYtj1/ZwInFFOb4GZ2HFI91PUWHWHhLRPORxwRwVvoXD1MS1162vPJZuHlKJkg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.2.tgz",
+      "integrity": "sha512-81zcAkCCgAc1gA7UvLOWCvkIwrgzaqHBdv9sskOt2xh1+l+RMX9G7sVYj3AOsib3UDR0MCSXit49xKILTMnikw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui": {
@@ -499,14 +511,17 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.30.0.tgz",
-      "integrity": "sha512-qFZgoOKQ+rJV9xG4BBxgOSilnLQ2gkfG4I+z1wBuuQ3AD33zQrnB88kMFfzsot1E1AbF3dNK1e4CU7q3ojahRA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.2.tgz",
+      "integrity": "sha512-B2AoocMpIiBezediqFzSqvuXI7AZlmlPkh3oj20Jh3bL35c8YYWk9KfOLkEjsLCrOHOUFXoYFc+ACiELCIJVRw==",
       "dev": true,
       "dependencies": {
         "concordance": "^5.0.4",
         "loupe": "^2.3.6",
         "pretty-format": "^27.5.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -723,9 +738,9 @@
       }
     },
     "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -957,9 +972,9 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -1065,9 +1080,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "dev": true,
       "funding": [
         {
@@ -1147,9 +1162,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.22.0.tgz",
-      "integrity": "sha512-imsigcWor5Y/dC0rz2q0bBt9PabcL3TORry2hAa6O6BuMvY71bqHyfReAz5qyAqiQATD1m70qdntqBfBQjVWpQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.0.tgz",
+      "integrity": "sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1224,15 +1239,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -1276,24 +1282,24 @@
       }
     },
     "node_modules/tinybench": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
-      "integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+      "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
       "dev": true
     },
     "node_modules/tinypool": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
-      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
+      "integrity": "sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -1340,9 +1346,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
@@ -1388,9 +1394,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.30.0.tgz",
-      "integrity": "sha512-23X5Ggylx0kU/bMf8MCcEEl55d/gsTtU81mMZjm7Z0FSpgKZexUqmX3mJtgglP9SySQQs9ydYg/GEahi/cKHaA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.2.tgz",
+      "integrity": "sha512-NvoO7+zSvxROC4JY8cyp/cO7DHAX3dwMOHQVDdNtCZ4Zq8wInnR/bJ/lfsXqE6wrUgtYCE5/84qHS+A7vllI3A==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -1407,23 +1413,23 @@
         "node": ">=v14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antfu"
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.30.0.tgz",
-      "integrity": "sha512-2WW4WeTHtrLFeoiuotWvEW6khozx1NvMGYoGsNz2btdddEbqvEdPJIouIdoiC5i61Rl1ctZvm9cn2R9TcPQlzw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.2.tgz",
+      "integrity": "sha512-O0qKHDbI+zXxwq1WOeqFjxP5v1mDqqM6gllPuOUJkK2YFyQ2nEo8CELR4Mg68ryTSSh527ysBmEN69bDvL2LkQ==",
       "dev": true,
       "dependencies": {
-        "@types/chai": "^4.3.4",
+        "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.30.0",
-        "@vitest/runner": "0.30.0",
-        "@vitest/snapshot": "0.30.0",
-        "@vitest/spy": "0.30.0",
-        "@vitest/utils": "0.30.0",
+        "@vitest/expect": "0.31.2",
+        "@vitest/runner": "0.31.2",
+        "@vitest/snapshot": "0.31.2",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -1434,13 +1440,12 @@
         "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
-        "source-map": "^0.6.1",
         "std-env": "^3.3.2",
         "strip-literal": "^1.0.1",
-        "tinybench": "^2.4.0",
-        "tinypool": "^0.4.0",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.30.0",
+        "vite-node": "0.31.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -1450,7 +1455,7 @@
         "node": ">=v14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antfu"
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",

--- a/e2e/test/vitest-old-version/package.json
+++ b/e2e/test/vitest-old-version/package.json
@@ -20,6 +20,6 @@
     "@stryker-mutator/util": "../../../packages/util"
   },
   "devDependencies": {
-    "vitest": "0.30.0"
+    "vitest": "0.31.2"
   }
 }

--- a/packages/vitest-runner/.vscode/launch.json
+++ b/packages/vitest-runner/.vscode/launch.json
@@ -30,6 +30,7 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
+      "outputCapture": "std",
       "args": [
         "--no-timeout",
         "dist/test/integration/**/*.js"    

--- a/packages/vitest-runner/package-lock.json
+++ b/packages/vitest-runner/package-lock.json
@@ -14,14 +14,14 @@
       "devDependencies": {
         "@types/node": "18.16.16",
         "ts-node": "10.9.1",
-        "vitest": "0.31.1"
+        "vitest": "0.31.2"
       },
       "engines": {
         "node": ">=14.18.0"
       },
       "peerDependencies": {
         "@stryker-mutator/core": "~6.4.2",
-        "vitest": ">=0.30.0"
+        "vitest": ">=0.31.2"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -459,13 +459,13 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
-      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.2.tgz",
+      "integrity": "sha512-AOuh2NLN9zJ0SkvsItRkS/W39akYpUvo5LOnay3zEhGSnRgivPu2D3S8QlMij1hFMQcX+dlMilPgJatUHiGQ4A==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "chai": "^4.3.7"
       },
       "funding": {
@@ -473,12 +473,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
-      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.2.tgz",
+      "integrity": "sha512-k2mWrzZD1xsWfzwEXeVr2XF4v8ELpFOKLxRbcnzZclHelOLn27nXvnw1A4JwJtmca64C3/6lo4WHZDlq3TefLQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.31.1",
+        "@vitest/utils": "0.31.2",
         "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
-      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.2.tgz",
+      "integrity": "sha512-NXRlbP3sM5+KELb8oXVHf7UWD+liBnSsS+4JlDVPD5+KPquZmgNR0xPLW5VEb5HoQZQpKTAFhtGf1AczRCbAhg==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.0",
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
-      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.2.tgz",
+      "integrity": "sha512-81zcAkCCgAc1gA7UvLOWCvkIwrgzaqHBdv9sskOt2xh1+l+RMX9G7sVYj3AOsib3UDR0MCSXit49xKILTMnikw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.0"
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.2.tgz",
+      "integrity": "sha512-B2AoocMpIiBezediqFzSqvuXI7AZlmlPkh3oj20Jh3bL35c8YYWk9KfOLkEjsLCrOHOUFXoYFc+ACiELCIJVRw==",
       "dev": true,
       "dependencies": {
         "concordance": "^5.0.4",
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "dev": true,
       "funding": [
         {
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -1164,9 +1164,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
-      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.2.tgz",
+      "integrity": "sha512-NvoO7+zSvxROC4JY8cyp/cO7DHAX3dwMOHQVDdNtCZ4Zq8wInnR/bJ/lfsXqE6wrUgtYCE5/84qHS+A7vllI3A==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -1235,19 +1235,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
-      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.2.tgz",
+      "integrity": "sha512-O0qKHDbI+zXxwq1WOeqFjxP5v1mDqqM6gllPuOUJkK2YFyQ2nEo8CELR4Mg68ryTSSh527ysBmEN69bDvL2LkQ==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.31.1",
-        "@vitest/runner": "0.31.1",
-        "@vitest/snapshot": "0.31.1",
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/expect": "0.31.2",
+        "@vitest/runner": "0.31.2",
+        "@vitest/snapshot": "0.31.2",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -1263,7 +1263,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.31.1",
+        "vite-node": "0.31.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -1597,32 +1597,32 @@
       "dev": true
     },
     "@vitest/expect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
-      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.2.tgz",
+      "integrity": "sha512-AOuh2NLN9zJ0SkvsItRkS/W39akYpUvo5LOnay3zEhGSnRgivPu2D3S8QlMij1hFMQcX+dlMilPgJatUHiGQ4A==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "chai": "^4.3.7"
       }
     },
     "@vitest/runner": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
-      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.2.tgz",
+      "integrity": "sha512-k2mWrzZD1xsWfzwEXeVr2XF4v8ELpFOKLxRbcnzZclHelOLn27nXvnw1A4JwJtmca64C3/6lo4WHZDlq3TefLQ==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "0.31.1",
+        "@vitest/utils": "0.31.2",
         "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
       }
     },
     "@vitest/snapshot": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
-      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.2.tgz",
+      "integrity": "sha512-NXRlbP3sM5+KELb8oXVHf7UWD+liBnSsS+4JlDVPD5+KPquZmgNR0xPLW5VEb5HoQZQpKTAFhtGf1AczRCbAhg==",
       "dev": true,
       "requires": {
         "magic-string": "^0.30.0",
@@ -1631,18 +1631,18 @@
       }
     },
     "@vitest/spy": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
-      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.2.tgz",
+      "integrity": "sha512-81zcAkCCgAc1gA7UvLOWCvkIwrgzaqHBdv9sskOt2xh1+l+RMX9G7sVYj3AOsib3UDR0MCSXit49xKILTMnikw==",
       "dev": true,
       "requires": {
         "tinyspy": "^2.1.0"
       }
     },
     "@vitest/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.2.tgz",
+      "integrity": "sha512-B2AoocMpIiBezediqFzSqvuXI7AZlmlPkh3oj20Jh3bL35c8YYWk9KfOLkEjsLCrOHOUFXoYFc+ACiELCIJVRw==",
       "dev": true,
       "requires": {
         "concordance": "^5.0.4",
@@ -1896,9 +1896,9 @@
       }
     },
     "mlly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.2",
@@ -1958,9 +1958,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",
@@ -2055,9 +2055,9 @@
       "dev": true
     },
     "tinyspy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true
     },
     "ts-node": {
@@ -2105,9 +2105,9 @@
       "dev": true
     },
     "vite": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.17.5",
@@ -2117,9 +2117,9 @@
       }
     },
     "vite-node": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
-      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.2.tgz",
+      "integrity": "sha512-NvoO7+zSvxROC4JY8cyp/cO7DHAX3dwMOHQVDdNtCZ4Zq8wInnR/bJ/lfsXqE6wrUgtYCE5/84qHS+A7vllI3A==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -2131,19 +2131,19 @@
       }
     },
     "vitest": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
-      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.2.tgz",
+      "integrity": "sha512-O0qKHDbI+zXxwq1WOeqFjxP5v1mDqqM6gllPuOUJkK2YFyQ2nEo8CELR4Mg68ryTSSh527ysBmEN69bDvL2LkQ==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.31.1",
-        "@vitest/runner": "0.31.1",
-        "@vitest/snapshot": "0.31.1",
-        "@vitest/spy": "0.31.1",
-        "@vitest/utils": "0.31.1",
+        "@vitest/expect": "0.31.2",
+        "@vitest/runner": "0.31.2",
+        "@vitest/snapshot": "0.31.2",
+        "@vitest/spy": "0.31.2",
+        "@vitest/utils": "0.31.2",
         "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
@@ -2159,7 +2159,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.31.1",
+        "vite-node": "0.31.2",
         "why-is-node-running": "^2.2.2"
       }
     },

--- a/packages/vitest-runner/package.json
+++ b/packages/vitest-runner/package.json
@@ -45,11 +45,11 @@
     "@stryker-mutator/test-helpers": "6.4.2",
     "@types/node": "18.16.16",
     "ts-node": "10.9.1",
-    "vitest": "0.31.1"
+    "vitest": "0.31.2"
   },
   "peerDependencies": {
     "@stryker-mutator/core": "~6.4.2",
-    "vitest": ">=0.30.0"
+    "vitest": ">=0.31.2"
   },
   "dependencies": {
     "@stryker-mutator/api": "6.4.2",

--- a/packages/vitest-runner/schema/vitest-runner-options.json
+++ b/packages/vitest-runner/schema/vitest-runner-options.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
+  "title": "StrykerVitestRunnerOptions",
   "additionalProperties": false,
   "properties": {
     "vitest": {

--- a/packages/vitest-runner/src/file-communicator.ts
+++ b/packages/vitest-runner/src/file-communicator.ts
@@ -7,22 +7,14 @@ import { normalizeFileName } from '@stryker-mutator/util';
 import { collectTestName, toTestId } from './vitest-helpers.js';
 
 export class FileCommunicator {
-  private readonly communicationDir = path.resolve(`.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`);
-
-  public readonly files = Object.freeze({
-    // Replace function is to have a valid windows path
-    coverageDir: normalizeFileName(path.resolve(this.communicationDir, 'coverage')),
-    hitCountDir: normalizeFileName(path.resolve(this.communicationDir, 'hitCount')),
-    vitestSetup: normalizeFileName(path.resolve(this.communicationDir, 'vitest.setup.js')),
-  });
+  public readonly vitestSetup = normalizeFileName(path.resolve(`.'vitest.${process.env.STRYKER_MUTATOR_WORKER}.setup.js`));
 
   constructor(private readonly globalNamespace: string) {}
 
   public async setDryRun(): Promise<void> {
-    await this.cleanCommunicationDirectories();
     await fs.writeFile(
       // Write hit count, hit limit, isDryRun, global namespace, etc. Altogether in 1 file
-      this.files.vitestSetup,
+      this.vitestSetup,
       this.setupFileTemplate(`
       ns.activeMutant = undefined;
       ${collectTestName.toString()}
@@ -37,17 +29,14 @@ export class FileCommunicator {
       });
   
       afterAll(async (suite) => {
-        await fs.writeFile(path.resolve('${
-          this.files.coverageDir
-        }', String(suite.projectName)), JSON.stringify(ns.mutantCoverage ?? { perTest: {}, static: {}}));
+        suite.meta.mutantCoverage = ns.mutantCoverage;
       });`)
     );
   }
 
   public async setMutantRun(options: MutantRunOptions): Promise<void> {
-    await this.cleanCommunicationDirectories();
     await fs.writeFile(
-      this.files.vitestSetup,
+      this.vitestSetup,
       this.setupFileTemplate(`
       ns.hitLimit = ${options.hitLimit};
       beforeAll(() => {
@@ -63,7 +52,7 @@ export class FileCommunicator {
             });`
       }
       afterAll(async (suite) => {
-        await fs.writeFile(path.resolve('${this.files.hitCountDir}', String(suite.projectName)), ns.hitCount.toString());
+        suite.meta.hitCount = ns.hitCount;
       });`)
     );
   }
@@ -71,8 +60,6 @@ export class FileCommunicator {
   private setupFileTemplate(body: string) {
     return `
     import path from 'path';
-    import fs from 'fs/promises';
-    import { normalizeFileName } from '@stryker-mutator/util';
 
     import { beforeEach, afterAll, beforeAll, afterEach } from 'vitest';
 
@@ -80,13 +67,7 @@ export class FileCommunicator {
     ${body}`;
   }
 
-  private async cleanCommunicationDirectories() {
-    await this.dispose();
-    await fs.mkdir(this.files.coverageDir, { recursive: true });
-    await fs.mkdir(this.files.hitCountDir, { recursive: true });
-  }
-
   public async dispose(): Promise<void> {
-    await fs.rm(this.communicationDir, { recursive: true, force: true });
+    await fs.rm(this.vitestSetup, { force: true });
   }
 }

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import { BaseTestResult, TestResult, TestStatus } from '@stryker-mutator/api/test-runner';
-import { normalizeFileName } from '@stryker-mutator/util';
 import type { RunMode, Suite, TaskState, Test, ResolvedConfig } from 'vitest';
 
 function convertTaskStateToTestStatus(taskState: TaskState | undefined, testMode: RunMode): TestStatus {
@@ -28,7 +27,6 @@ export function convertTestToTestResult(test: Test): TestResult {
     name: collectTestName(test),
     timeSpentMs: test.result?.duration ?? 0,
     fileName: test.file?.filepath && path.resolve(test.file.filepath),
-    startPosition: test.meta,
   };
   if (status === TestStatus.Failed) {
     return {
@@ -94,6 +92,6 @@ export function collectTestName({ name, suite }: { name: string; suite?: Suite }
 }
 
 export function toTestId(test: Test): string {
-  return `${normalizeFileName(path.relative(process.cwd(), test.file?.filepath ?? 'unknown.js'))}#${collectTestName(test)}`;
+  return `${path.relative(process.cwd(), test.file?.filepath ?? 'unknown.js').replace(/\\/g, '/')}#${collectTestName(test)}`;
 }
 // Stryker restore all

--- a/packages/vitest-runner/src/vitest-runner-options-with-stryker-options.ts
+++ b/packages/vitest-runner/src/vitest-runner-options-with-stryker-options.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core';
 
-import { VitestRunnerOptions } from '../src-generated/vitest-runner-options.js';
+import { StrykerVitestRunnerOptions } from '../src-generated/vitest-runner-options.js';
 
-export interface VitestRunnerOptionsWithStrykerOptions extends VitestRunnerOptions, StrykerOptions {}
+export interface VitestRunnerOptionsWithStrykerOptions extends StrykerVitestRunnerOptions, StrykerOptions {}

--- a/packages/vitest-runner/src/vitest-wrapper.ts
+++ b/packages/vitest-runner/src/vitest-wrapper.ts
@@ -1,0 +1,6 @@
+import { createVitest } from 'vitest/node';
+
+export type * from 'vitest/node';
+export const vitestWrapper = {
+  createVitest: createVitest,
+};

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -49,9 +49,19 @@ describe('VitestRunner integration', () => {
         assertions.expectCompleted(runResult);
         assertions.expectTestResults(runResult, [
           { id: test1, fileName: path.resolve('tests/add.spec.ts'), name: 'add should be able to add two numbers', status: TestStatus.Success },
-          { id: test2, fileName: path.resolve('tests/add.spec.ts'), name: 'add should be able to add a negative number', status: TestStatus.Success },
+          {
+            id: test2,
+            fileName: path.resolve('tests/add.spec.ts'),
+            name: 'add should be able to add a negative number',
+            status: TestStatus.Success,
+          },
           { id: test3, fileName: path.resolve('tests/math.spec.ts'), name: 'math should be able negate a number', status: TestStatus.Success },
-          { id: test4, fileName: path.resolve('tests/math.spec.ts'), name: 'math should be able to add one to a number', status: TestStatus.Success },
+          {
+            id: test4,
+            fileName: path.resolve('tests/math.spec.ts'),
+            name: 'math should be able to add one to a number',
+            status: TestStatus.Success,
+          },
           {
             id: test5,
             fileName: path.resolve('tests/math.spec.ts'),
@@ -246,26 +256,6 @@ describe('VitestRunner integration', () => {
 
         assertions.expectKilled(runResult);
         expect(runResult.nrOfTests).eq(1);
-      });
-
-      it('mutant run with 2 filters should run 2 tests', async () => {
-        // Arrange
-        await sut.init();
-        const mutantRunOptions = factory.mutantRunOptions({
-          mutantActivation: 'runtime',
-          activeMutant: factory.mutant({ id: '2' }),
-          sandboxFileName,
-          testFilter: [test1, test4],
-        });
-
-        // Act
-        const runResult = await sut.mutantRun(mutantRunOptions);
-
-        // Assert
-        assertions.expectKilled(runResult);
-        expect(runResult.nrOfTests).eq(2);
-        expect(runResult.killedBy).deep.eq([test1]);
-        expect(runResult.failureMessage).contains('expected -3 to be 7');
       });
     });
   });

--- a/packages/vitest-runner/test/unit/file-communication.spec.ts
+++ b/packages/vitest-runner/test/unit/file-communication.spec.ts
@@ -2,44 +2,33 @@ import fs from 'fs/promises';
 import { syncBuiltinESMExports } from 'module';
 import path from 'path';
 
-import { factory } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import sinon from 'sinon';
-import { normalizeFileName } from '@stryker-mutator/util';
+import { expect } from 'chai';
+import { normalizeFileName, normalizeWhitespaces } from '@stryker-mutator/util';
+import { factory } from '@stryker-mutator/test-helpers';
 
 import { FileCommunicator } from '../../src/file-communicator.js';
 
 describe(FileCommunicator.name, () => {
   let sut: FileCommunicator;
   let writeFileStub: sinon.SinonStubbedMember<typeof fs.writeFile>;
-  let mkdirStub: sinon.SinonStubbedMember<typeof fs.mkdir>;
-  let rmStub: sinon.SinonStubbedMember<typeof fs.rm>;
 
   beforeEach(() => {
     sut = new FileCommunicator('__stryker__');
     writeFileStub = sinon.stub(fs, 'writeFile');
-    mkdirStub = sinon.stub(fs, 'mkdir');
-    rmStub = sinon.stub(fs, 'rm');
     syncBuiltinESMExports();
   });
 
-  const communicationDir = path.resolve(`.vitest-runner-${process.env.STRYKER_MUTATOR_WORKER}`);
+  const setupFile = normalizeFileName(path.resolve(`.'vitest.${process.env.STRYKER_MUTATOR_WORKER}.setup.js`));
 
   function assertVitestSetupContains(containsText: string) {
-    sinon.assert.calledOnceWithExactly(writeFileStub, sut.files.vitestSetup, sinon.match(containsText));
+    sinon.assert.calledOnceWithExactly(writeFileStub, sut.vitestSetup, sinon.match.string);
+    const file = writeFileStub.firstCall.args[1] as string;
+    expect(normalizeWhitespaces(file)).to.contain(normalizeWhitespaces(containsText));
   }
 
-  describe('files' satisfies keyof FileCommunicator, () => {
-    it('should have the correct values', () => {
-      expect(sut.files).to.deep.equal({
-        coverageDir: normalizeFileName(path.resolve(communicationDir, 'coverage')),
-        hitCountDir: normalizeFileName(path.resolve(communicationDir, 'hitCount')),
-        vitestSetup: normalizeFileName(path.resolve(communicationDir, 'vitest.setup.js')),
-      } satisfies typeof sut.files);
-    });
-    it('should be frozen', () => {
-      expect(sut.files).frozen;
-    });
+  it('should have make the setupFile worker dependent', () => {
+    expect(sut.vitestSetup).eq(setupFile);
   });
 
   describe(FileCommunicator.prototype.setDryRun.name, () => {
@@ -52,19 +41,13 @@ describe(FileCommunicator.name, () => {
       assertVitestSetupContains('globalThis.__stryker__');
     });
 
-    it('should write to coverage file', async () => {
+    it('should report mutant coverage in afterAll', async () => {
       await sut.setDryRun();
       assertVitestSetupContains(
-        `fs.writeFile(path.resolve('${sut.files.coverageDir}', String(suite.projectName)), JSON.stringify(ns.mutantCoverage ?? { perTest: {}, static: {}}))`
+        `afterAll(async (suite) => {
+          suite.meta.mutantCoverage = ns.mutantCoverage;
+        })`
       );
-    });
-
-    it('should clean the communication directory', async () => {
-      await sut.setDryRun();
-      sinon.assert.calledOnceWithExactly(rmStub, communicationDir, { recursive: true, force: true });
-      sinon.assert.calledWithExactly(mkdirStub, sut.files.coverageDir, { recursive: true });
-      sinon.assert.calledWithExactly(mkdirStub, sut.files.hitCountDir, { recursive: true });
-      sinon.assert.callOrder(rmStub, mkdirStub, mkdirStub);
     });
   });
 
@@ -75,32 +58,26 @@ describe(FileCommunicator.name, () => {
     });
 
     it('should set active mutant without before if mutant is static', async () => {
-      const id = '12345';
-      await sut.setMutantRun(factory.mutantRunOptions({ mutantActivation: 'static', activeMutant: factory.mutant({ id }) }));
+      await sut.setMutantRun(factory.mutantRunOptions({ mutantActivation: 'static', activeMutant: factory.mutant({ id: '12345' }) }));
       const data = writeFileStub.firstCall.args[1] as string;
-      const regex = /beforeEach\((.*)\);/gs;
-      const beforeEachData = regex.exec(data);
-      expect(beforeEachData).to.be.null;
-      expect(data).to.contain(`ns.activeMutant = '${id}'`);
+      expect(/beforeEach\((.*)\);/gs.exec(data)).to.be.null;
+      assertVitestSetupContains("ns.activeMutant = '12345'");
     });
 
     it('should set active mutant in before each if mutant is runtime', async () => {
-      const id = '12345';
-      await sut.setMutantRun(factory.mutantRunOptions({ mutantActivation: 'runtime', activeMutant: factory.mutant({ id }) }));
-      const data = writeFileStub.firstCall.args[1] as string;
-      const regex = /beforeEach\((.*)\);/gs;
-      const beforeEachData = regex.exec(data);
-
-      expect(beforeEachData).to.be.not.null;
-      expect(beforeEachData![1]).to.contain(`ns.activeMutant = '${id}'`);
+      await sut.setMutantRun(factory.mutantRunOptions({ mutantActivation: 'runtime', activeMutant: factory.mutant({ id: '12345' }) }));
+      assertVitestSetupContains(`beforeEach(() => {
+        ns.activeMutant = '12345';
+      })`);
     });
 
-    it('should clean the communication directory', async () => {
+    it('should report the hitCount in afterAll', async () => {
       await sut.setMutantRun(factory.mutantRunOptions());
-      sinon.assert.calledOnceWithExactly(rmStub, communicationDir, { recursive: true, force: true });
-      sinon.assert.calledWithExactly(mkdirStub, sut.files.coverageDir, { recursive: true });
-      sinon.assert.calledWithExactly(mkdirStub, sut.files.hitCountDir, { recursive: true });
-      sinon.assert.callOrder(rmStub, mkdirStub, mkdirStub);
+      assertVitestSetupContains(
+        `afterAll(async (suite) => {
+          suite.meta.hitCount = ns.hitCount;
+        })`
+      );
     });
   });
 });

--- a/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
@@ -18,10 +18,12 @@ describe('vitest-helpers', () => {
           tasks: [],
           id: '1',
           name: 'suite',
+          meta: {},
           mode: 'run',
         },
         id: '1',
         name: 'test1',
+        meta: {},
         mode: 'run',
         context: {} as any,
         file: {
@@ -32,6 +34,7 @@ describe('vitest-helpers', () => {
           id: '1',
           mode: 'run',
           tasks: [],
+          meta: {},
         },
       };
       const result = toTestId(test);
@@ -57,8 +60,10 @@ describe('vitest-helpers', () => {
           id: '1',
           name: 'suite',
           mode: 'run',
+          meta: {},
         },
         id: '1',
+        meta: {},
         name: 'test1',
         mode: 'run',
         context: {} as any,
@@ -69,6 +74,7 @@ describe('vitest-helpers', () => {
           id: '1',
           mode: 'run',
           tasks: [],
+          meta: {},
         },
         result: {
           state: 'skip',
@@ -78,7 +84,7 @@ describe('vitest-helpers', () => {
       expect(result.status).to.be.equal(TestStatus.Skipped);
     });
 
-    it('should have status skipped if taskstate is todo', () => {
+    it('should have status skipped if task state is todo', () => {
       const test: Test = {
         type: 'test',
         suite: {
@@ -87,13 +93,16 @@ describe('vitest-helpers', () => {
           id: '1',
           name: 'suite',
           mode: 'run',
+          meta: {},
         },
+        meta: {},
         id: '1',
         name: 'test1',
         mode: 'run',
         context: {} as any,
         file: {
           name: 'file.js',
+          meta: {},
           filepath: 'file.js',
           type: 'suite',
           id: '1',
@@ -110,12 +119,14 @@ describe('vitest-helpers', () => {
 
     it('should have status Failed if result is undefined', () => {
       const test: Test = {
+        meta: {},
         type: 'test',
         suite: {
           type: 'suite',
           tasks: [],
           id: '1',
           name: 'suite',
+          meta: {},
           mode: 'run',
         },
         id: '1',
@@ -126,6 +137,7 @@ describe('vitest-helpers', () => {
           name: 'file.js',
           filepath: 'file.js',
           type: 'suite',
+          meta: {},
           id: '1',
           mode: 'run',
           tasks: [],
@@ -143,6 +155,7 @@ describe('vitest-helpers', () => {
         tasks: [],
         id: '1',
         name: 'suite',
+        meta: {},
         mode: 'run',
       };
       const result = collectTestsFromSuite(suite);
@@ -151,6 +164,7 @@ describe('vitest-helpers', () => {
     it('should return 1 test for a suite with 1 test', () => {
       const suite: Suite = {
         type: 'suite',
+        meta: {},
         id: '1',
         name: 'suite',
         mode: 'run',
@@ -162,6 +176,7 @@ describe('vitest-helpers', () => {
             mode: 'run',
             context: {} as any,
             suite: {} as any,
+            meta: {},
           },
         ],
       };
@@ -175,6 +190,7 @@ describe('vitest-helpers', () => {
         id: '1',
         name: 'suite',
         mode: 'run',
+        meta: {},
         tasks: [
           {
             type: 'test',
@@ -183,6 +199,7 @@ describe('vitest-helpers', () => {
             mode: 'run',
             context: {} as any,
             suite: {} as any,
+            meta: {},
           },
           {
             type: 'test',
@@ -191,6 +208,7 @@ describe('vitest-helpers', () => {
             mode: 'run',
             context: {} as any,
             suite: {} as any,
+            meta: {},
           },
         ],
       };
@@ -203,6 +221,7 @@ describe('vitest-helpers', () => {
         type: 'suite',
         id: '1',
         name: 'suite1',
+        meta: {},
         mode: 'run',
         tasks: [
           {
@@ -218,6 +237,7 @@ describe('vitest-helpers', () => {
                 mode: 'run',
                 context: {} as any,
                 suite: {} as any,
+                meta: {},
               },
               {
                 type: 'test',
@@ -226,8 +246,10 @@ describe('vitest-helpers', () => {
                 mode: 'run',
                 context: {} as any,
                 suite: {} as any,
+                meta: {},
               },
             ],
+            meta: {},
           },
         ],
       };

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -1,19 +1,41 @@
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { testInjector } from '@stryker-mutator/test-helpers';
 import { TestRunnerCapabilities } from '@stryker-mutator/api/test-runner';
+import { Vitest } from 'vitest/node';
 
 import { VitestTestRunner } from '../../src/vitest-test-runner.js';
+import { VitestRunnerOptionsWithStrykerOptions } from '../../src/vitest-runner-options-with-stryker-options.js';
+import { vitestWrapper } from '../../src/vitest-wrapper.js';
+import { createVitestMock } from '../util/factories.js';
 
 describe(VitestTestRunner.name, () => {
   let sut: VitestTestRunner;
+  let createVitestStub: sinon.SinonStubbedMember<typeof vitestWrapper.createVitest>;
+  let options: VitestRunnerOptionsWithStrykerOptions;
+  let vitestStub: sinon.SinonStubbedInstance<Vitest>;
 
   beforeEach(() => {
     sut = testInjector.injector.provideValue('globalNamespace', '__stryker2__' as const).injectClass(VitestTestRunner);
+    createVitestStub = sinon.stub(vitestWrapper, 'createVitest');
+    options = testInjector.options as VitestRunnerOptionsWithStrykerOptions;
+    options.vitest = {};
+    vitestStub = createVitestMock();
+    createVitestStub.resolves(vitestStub);
   });
 
   it('should not have reload capabilities', () => {
     // The files under test are cached between runs
     const expectedCapabilities: TestRunnerCapabilities = { reloadEnvironment: true };
     expect(sut.capabilities()).deep.eq(expectedCapabilities);
+  });
+
+  describe('browser mode', () => {
+    it('should throw a not supported error', async () => {
+      vitestStub.config.browser.enabled = true;
+      await expect(sut.init()).rejectedWith(
+        'Browser mode is currently not supported by the `@stryker-mutator/vitest-runner`. Please disable `browser.enabled` in your `vitest.config.js`.'
+      );
+    });
   });
 });

--- a/packages/vitest-runner/test/util/factories.ts
+++ b/packages/vitest-runner/test/util/factories.ts
@@ -1,0 +1,17 @@
+import sinon from 'sinon';
+import { Vitest } from 'vitest/node';
+
+type ResolvedConfig = Vitest['config'];
+type ResolvedBrowserOptions = ResolvedConfig['browser'];
+
+export function createVitestMock(): sinon.SinonStubbedInstance<Vitest> {
+  return {
+    config: {
+      browser: {
+        enabled: false,
+        headless: false,
+      } as ResolvedBrowserOptions,
+    } as ResolvedConfig,
+    start: sinon.stub(),
+  } as sinon.SinonStubbedInstance<Vitest>;
+}

--- a/packages/vitest-runner/testResources/simple-project/tests/add.spec.ts
+++ b/packages/vitest-runner/testResources/simple-project/tests/add.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { add } from '../math';
+import { add } from '../math.js';
 
 describe(add.name, () => {
   it('should be able to add two numbers', () => {

--- a/packages/vitest-runner/testResources/simple-project/vitest.browser.config.js
+++ b/packages/vitest-runner/testResources/simple-project/vitest.browser.config.js
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    browser: {
+      name: 'chromium',
+      headless: true,
+      provider: 'playwright',
+      enabled: true
+    },
     include: ['tests/*.ts'],
     setupFiles: ['vitest.setup.ts'],
   },

--- a/packages/vitest-runner/testResources/simple-project/vitest.setup.ts
+++ b/packages/vitest-runner/testResources/simple-project/vitest.setup.ts
@@ -1,5 +1,5 @@
 import { beforeAll } from 'vitest';
-import * as math from './math';
+import * as math from './math.js';
 
 beforeAll(() => {
   globalThis.math = math;


### PR DESCRIPTION
- Clearly state that the `@stryker-mutator/vitest-runner` doesn't support browser mode yet.
- Opt for [task metadata](https://vitest.dev/advanced/metadata.html) instead of file communication.
- Set minimal support `vitest` version to `0.31.2`, because of the task metadata support.

Fixes #4218 
