### PR TITLE
feat(type-checking): disable type check by default

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -426,16 +426,16 @@
       "description": "Set to 'true' to disable type checking, or 'false' to enable it. For more control, configure a pattern that matches the files of which type checking has to be disabled. This is needed because Stryker will create (typescript) type errors when inserting the mutants in your code. Stryker disables type checking by inserting `// @ts-nocheck` atop those files and removing other `// @ts-xxx` directives (so they won't interfere with `@ts-nocheck`). The default setting allows these directives to be stripped from all JavaScript and friend files in `lib`, `src` and `test` directories.",
       "oneOf": [
         {
-          "enum": [
-            false,
-            true
-          ]
+          "type": "boolean"
         },
         {
           "type": "string"
         }
       ],
-      "default": "{test,src,lib}/**/*.{js,ts,jsx,tsx,html,vue}"
+      "examples": [
+        "{test,src,lib}/**/*.{js,ts,jsx,tsx,html,vue,cts,mts}"
+      ],
+      "default": true
     },
     "symlinkNodeModules": {
       "description": "The 'symlinkNodeModules' value indicates whether Stryker should create a symbolic link to your current node_modules directory in the sandbox directories. This makes running your tests by Stryker behave more like your would run the tests yourself in your project directory. Only disable this setting if you really know what you are doing.",

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -55,7 +55,7 @@ describe(OptionsValidator.name, () => {
           baseUrl: 'https://dashboard.stryker-mutator.io/api/reports',
           reportType: ReportType.Full,
         },
-        disableTypeChecks: '{test,src,lib}/**/*.{js,ts,jsx,tsx,html,vue}',
+        disableTypeChecks: true,
         dryRunOnly: false,
         dryRunTimeoutMinutes: 5,
         eventReporter: {

--- a/packages/core/test/unit/process/3-dry-run-executor.spec.ts
+++ b/packages/core/test/unit/process/3-dry-run-executor.spec.ts
@@ -233,6 +233,7 @@ describe(DryRunExecutor.name, () => {
       });
 
       it('should remap test locations when type checking was disabled for a test file', async () => {
+        testInjector.options.disableTypeChecks = '{src,test}/**/*.js';
         runResult.tests.push(
           factory.successTestResult({ fileName: '.stryker-tmp/sandbox-123/test/foo.spec.js', startPosition: { line: 3, column: 1 } }),
           factory.successTestResult({ fileName: '.stryker-tmp/sandbox-123/testResources/foo.spec.js', startPosition: { line: 5, column: 1 } })

--- a/stryker.parent.conf.json
+++ b/stryker.parent.conf.json
@@ -16,6 +16,7 @@
   "checkers": ["typescript"],
   "dashboard": {},
   "buildCommand": "tsc -b",
+  "disableTypeChecks": "{test,src,lib}/**/*.{js,ts,jsx,tsx,html,vue,cts,mts}",
   "mochaOptions": {
     "spec": ["dist/test/unit/**/*.js"]
   }


### PR DESCRIPTION
Change the default of [`disableTypeChecks`](https://stryker-mutator.io/docs/stryker-js/configuration/#disabletypechecks-boolean--string) to `true`.

Closes #4204