### PR TITLE
fix(core): improve no-mutate warning

### DIFF
--- a/packages/core/src/fs/project-reader.ts
+++ b/packages/core/src/fs/project-reader.ts
@@ -52,7 +52,7 @@ export class ProjectReader {
     const inputFileNames = await this.resolveInputFileNames();
     const fileDescriptions = this.resolveFileDescriptions(inputFileNames);
     const project = new Project(this.fs, fileDescriptions, await this.readIncrementalReport());
-    project.logFiles(this.log, this.ignoreRules, this.force);
+    project.logFiles(this.log, this.ignoreRules, this.force, this.mutatePatterns);
     return project;
   }
 

--- a/packages/core/src/fs/project.ts
+++ b/packages/core/src/fs/project.ts
@@ -29,7 +29,7 @@ export class Project {
     return this.files.size === 0;
   }
 
-  public logFiles(log: Logger, ignoreRules: readonly string[], force: boolean): void {
+  public logFiles(log: Logger, ignoreRules: readonly string[], force: boolean, mutatePatterns: readonly string[]): void {
     if (this.isEmpty) {
       log.warn(
         normalizeWhitespaces(`No files found in directory ${process.cwd()} using ignore rules: ${JSON.stringify(ignoreRules)}. 
@@ -48,10 +48,15 @@ export class Project {
 
         log.info(`Found ${this.filesToMutate.size} of ${this.files.size} file(s) to be mutated${incrementalInfo}.`);
       } else {
-        log.warn(
-          normalizeWhitespaces(`No files marked to be mutated, Stryker will perform a dry-run without actually mutating anything.
-        You can configure the \`mutate\` property in your config file (or use \`--mutate\` via command line).`)
-        );
+        const msg =
+          normalizeWhitespaces(`Warning: No files found for mutation with the given glob expressions. As a result, a dry-run will be performed without actually modifying anything. 
+          If you intended to mutate files, please check and adjust the configuration.
+          Current glob pattern(s) used:
+          ${mutatePatterns.map((pattern) => `"${pattern}"`).join(', ')}.
+          To enable file mutation, consider configuring the \`${propertyPath<StrykerOptions>()(
+            'mutate'
+          )}\` property in your configuration file or using the --mutate option via the command line.`);
+        log.warn(msg);
       }
       if (log.isDebugEnabled()) {
         log.debug(`All input files: ${JSON.stringify([...this.files.keys()], null, 2)}`);

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { MutateDescription, MutationRange } from '@stryker-mutator/api/core';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
-import { I, normalizeFileName } from '@stryker-mutator/util';
+import { I, normalizeFileName, normalizeWhitespaces } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -234,7 +234,13 @@ describe(ProjectReader.name, () => {
 
         // Assert
         expect(testInjector.logger.warn).calledWith(
-          'No files marked to be mutated, Stryker will perform a dry-run without actually mutating anything. You can configure the `mutate` property in your config file (or use `--mutate` via command line).'
+          normalizeWhitespaces(`Warning: No files found for mutation with the given glob expressions.
+            As a result, a dry-run will be performed without actually modifying anything. 
+            If you intended to mutate files, please check and adjust the configuration. 
+            Current glob pattern(s) used: "{src,lib}/**/!(*.+(s|S)pec|*.+(t|T)est).+(cjs|mjs|js|ts|jsx|tsx|html|vue)", 
+            "!{src,lib}/**/__tests__/**/*.+(cjs|mjs|js|ts|jsx|tsx|html|vue)".
+            To enable file mutation, consider configuring the \`mutate\` 
+            property in your configuration file or using the --mutate option via the command line.`)
         );
       });
     });


### PR DESCRIPTION
Improve the warning shown when no files are marked for mutation.

```diff
- No files marked to be mutated, Stryker will perform a dry-run without actually mutating anything. You can configure the `mutate` property in your config file (or use `--mutate` via command line).
+Warning: No files found for mutation with the given glob expressions. As a result, a dry-run will be performed without actually modifying anything. If you intended to mutate files, please check and adjust the configuration. Current glob pattern(s) used: "{src,lib}/**/!(*.+(s|S)pec|*.+(t|T)est).+(cjs|mjs|js|ts|jsx|tsx|html|vue)", "!{src,lib}/**/__tests__/**/*.+(cjs|mjs|js|ts|jsx|tsx|html|vue)". To enable file mutation, consider configuring the `mutate` property in your configuration file or using the --mutate option via the command line.
```

Fixes #2958