### PR TITLE
fix(config): regression in import options

### DIFF
--- a/e2e/test/mono-schema/package.json
+++ b/e2e/test/mono-schema/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mono-schema",
   "description": "A test for the 'mono-schema'. A json schema that got merged from all the objects and put into @stryker-mutator/core/schema",
+  "type": "module",
   "scripts": {
     "test": "mocha --no-config --no-package --timeout 0 verify/verify.js"
   }

--- a/e2e/test/mono-schema/test/invalid.js
+++ b/e2e/test/mono-schema/test/invalid.js
@@ -1,0 +1,7 @@
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  allowConsoleColors: true,
+  checkers: 'typescript',
+  testRunner: { name: 'mocha' },
+};
+export default config;

--- a/e2e/test/mono-schema/test/tsconfig.json
+++ b/e2e/test/mono-schema/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  }
+}

--- a/e2e/test/mono-schema/test/valid.js
+++ b/e2e/test/mono-schema/test/valid.js
@@ -1,0 +1,27 @@
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  checkers: ['typescript'],
+  testRunner: 'mocha',
+  jest: {
+    config: {},
+  },
+  jasmineConfigFile: 'A file',
+  karma: {
+    ngConfig: {
+      testArguments: { test: 'test' },
+    },
+  },
+  cucumber: {
+    features: ['my-feature.feature'],
+    profile: 'stryker',
+    tags: ['@tag', '@tag2'],
+  },
+  vitest: {
+    configFile: 'vitest.config.js',
+  },
+  tap: {
+    testFiles: ['{**/@(test|tests|__test__|__tests__)/**,**/*.@(test|tests|spec)}.@(cjs|mjs|js|jsx|ts|tsx)'],
+    nodeArgs: ['--loader', 'ts-node/esm'],
+  },
+};
+export default config;

--- a/e2e/test/mono-schema/verify/package.json
+++ b/e2e/test/mono-schema/verify/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/e2e/test/mono-schema/verify/verify.js
+++ b/e2e/test/mono-schema/verify/verify.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
-import { URL } from 'url';
+import { URL, fileURLToPath } from 'url';
+import path from 'path';
 
+import ts from 'typescript';
 import { expect } from 'chai';
 import ajvModule from 'ajv';
 import Axios from 'axios';
@@ -125,3 +127,43 @@ describe('The Stryker meta schema', () => {
     return a.instancePath.localeCompare(b.instancePath);
   }
 });
+
+describe('PartialStrykerOptions', () => {
+  ['Node', 'Node16'].forEach((moduleResolution) => {
+    describe(`with --moduleResolution ${moduleResolution}`, () => {
+      it('should validate a valid schema', async () => {
+        const diagnostics = tsc('--moduleResolution', moduleResolution, 'valid.js');
+        expect(diagnostics, String(diagnostics[0]?.messageText)).empty;
+      });
+      it('should invalidate an invalid schema', async () => {
+        const diagnostics = tsc('--moduleResolution', moduleResolution, 'invalid.js');
+        expect(diagnostics).not.empty;
+        // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+        expect(diagnostics.map(({ messageText }) => messageText).sort()).deep.eq([
+          "Type 'string' is not assignable to type '(string | undefined)[]'.",
+          "Type '{ name: string; }' is not assignable to type 'string'.",
+        ]);
+      });
+    });
+  });
+});
+
+/** @param  {...string} args */
+function tsc(...args) {
+  try {
+    process.chdir(fileURLToPath(new URL('../test', import.meta.url)));
+    const tsconfigFile = ts.findConfigFile('tsconfig.json', ts.sys.fileExists);
+    const { config } = ts.readConfigFile(tsconfigFile, ts.sys.readFile);
+    const { fileNames, options } = ts.parseCommandLine(args, (file) => {
+      return ts.sys.readFile(file);
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const program = ts.createProgram(fileNames, { ...config.compilerOptions, ...options });
+    const emitResult = program.emit();
+    const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+    console.log(allDiagnostics);
+    return allDiagnostics;
+  } finally {
+    process.chdir(path.dirname(fileURLToPath(import.meta.url)));
+  }
+}

--- a/e2e/test/mono-schema/verify/verify.js
+++ b/e2e/test/mono-schema/verify/verify.js
@@ -161,7 +161,6 @@ function tsc(...args) {
     const program = ts.createProgram(fileNames, { ...config.compilerOptions, ...options });
     const emitResult = program.emit();
     const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
-    console.log(allDiagnostics);
     return allDiagnostics;
   } finally {
     process.chdir(path.dirname(fileURLToPath(import.meta.url)));

--- a/packages/api/core.d.ts
+++ b/packages/api/core.d.ts
@@ -1,0 +1,3 @@
+// This file is here to make `--moduleResolution node` work with:
+// /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+export type * from './dist/src/core/index.js';


### PR DESCRIPTION
Fix regression in `import('@stryker-mutator/api/core').PartialStrykerOptions` when using module resolution node.
Also, add an e2e test for it.

Fixes #4273
