### PR TITLE
feat(init): use registry.npmjs.com for queries

### DIFF
--- a/packages/core/src/initializer/index.ts
+++ b/packages/core/src/initializer/index.ts
@@ -16,15 +16,13 @@ import { StrykerInquirer } from './stryker-inquirer.js';
 import { createInitializers } from './custom-initializers/index.js';
 import { GitignoreWriter } from './gitignore-writer.js';
 
-const BASE_NPM_SEARCH = 'https://api.npms.io';
-const BASE_NPM_PACKAGE = 'https://www.unpkg.com';
+const NPM_REGISTRY = 'https://registry.npmjs.com';
 
 export function initializerFactory(): StrykerInitializer {
   LogConfigurator.configureMainProcess(LogLevel.Information);
   return provideLogger(createInjector())
     .provideValue(initializerTokens.out, console.log)
-    .provideValue(initializerTokens.restClientNpmSearch, new RestClient('npmSearch', BASE_NPM_SEARCH))
-    .provideValue(initializerTokens.restClientNpm, new RestClient('npm', BASE_NPM_PACKAGE))
+    .provideValue(initializerTokens.restClientNpm, new RestClient('npm', NPM_REGISTRY))
     .provideClass(initializerTokens.npmClient, NpmClient)
     .provideClass(initializerTokens.configWriter, StrykerConfigWriter)
     .provideClass(initializerTokens.gitignoreWriter, GitignoreWriter)

--- a/packages/core/src/initializer/initializer-tokens.ts
+++ b/packages/core/src/initializer/initializer-tokens.ts
@@ -1,4 +1,3 @@
-export const restClientNpmSearch = 'restClientNpmSearch';
 export const restClientNpm = 'restClientNpm';
 export const npmClient = 'npmClient';
 export const customInitializers = 'strykerPresets';

--- a/packages/core/src/initializer/npm-client.ts
+++ b/packages/core/src/initializer/npm-client.ts
@@ -3,20 +3,14 @@ import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { errorToString } from '@stryker-mutator/util';
 import type { IRestResponse, RestClient } from 'typed-rest-client/RestClient.js';
 
-import { PackageInfo } from './package-info.js';
+import { PackageInfo, PackageSummary } from './package-info.js';
 import { PromptOption } from './prompt-option.js';
 
 import { initializerTokens } from './index.js';
 
-interface NpmSearchResult {
+export interface NpmSearchResult {
   total: number;
-  results: Array<{ package: PackageInfo }>;
-}
-
-export interface NpmPackage {
-  name: string;
-  homepage?: string;
-  initStrykerConfig?: Record<string, unknown>;
+  objects: Array<{ package: PackageSummary }>;
 }
 
 const getName = (packageName: string) => {
@@ -24,7 +18,7 @@ const getName = (packageName: string) => {
 };
 
 const mapSearchResultToPromptOption = (searchResults: NpmSearchResult): PromptOption[] =>
-  searchResults.results.map((result) => ({
+  searchResults.objects.map((result) => ({
     name: getName(result.package.name),
     pkg: result.package,
   }));
@@ -40,40 +34,43 @@ const handleResult =
   };
 
 export class NpmClient {
-  public static inject = tokens(commonTokens.logger, initializerTokens.restClientNpmSearch, initializerTokens.restClientNpm);
-  constructor(private readonly log: Logger, private readonly searchClient: RestClient, private readonly packageClient: RestClient) {}
+  public static inject = tokens(commonTokens.logger, initializerTokens.restClientNpm);
+  constructor(private readonly log: Logger, private readonly innerNpmClient: RestClient) {}
 
   public getTestRunnerOptions(): Promise<PromptOption[]> {
-    return this.search('/v2/search?q=keywords:@stryker-mutator/test-runner-plugin').then(mapSearchResultToPromptOption);
+    return this.search(`/-/v1/search?text=keywords:${encodeURIComponent('@stryker-mutator/test-runner-plugin')}`).then(mapSearchResultToPromptOption);
   }
 
   public getTestReporterOptions(): Promise<PromptOption[]> {
-    return this.search('/v2/search?q=keywords:@stryker-mutator/reporter-plugin').then(mapSearchResultToPromptOption);
+    return this.search(`/-/v1/search?text=keywords:${encodeURIComponent('@stryker-mutator/reporter-plugin')}`).then(mapSearchResultToPromptOption);
   }
 
-  public getAdditionalConfig(pkgInfo: PackageInfo): Promise<NpmPackage> {
-    const path = `/${pkgInfo.name}@${pkgInfo.version}/package.json`;
-    return this.packageClient
-      .get<NpmPackage>(path)
+  public getAdditionalConfig(pkgInfo: PackageSummary): Promise<PackageInfo> {
+    const path = `/${encodeURIComponent(pkgInfo.name)}@${pkgInfo.version}`;
+    return this.innerNpmClient
+      .get<PackageInfo>(path)
       .then(handleResult(path))
       .catch((err) => {
         this.log.warn(
           `Could not fetch additional initialization config for dependency ${pkgInfo.name}. You might need to configure it manually`,
           err
         );
-        return { name: pkgInfo.name };
+        return pkgInfo;
       });
   }
 
   private search(path: string): Promise<NpmSearchResult> {
     this.log.debug(`Searching: ${path}`);
-    return this.searchClient
+    return this.innerNpmClient
       .get<NpmSearchResult>(path)
       .then(handleResult(path))
       .catch((err) => {
-        this.log.error(`Unable to reach npms.io (for query ${path}). Please check your internet connection.`, errorToString(err));
+        this.log.error(
+          `Unable to reach 'https://registry.npmjs.com' (for query ${path}). Please check your internet connection.`,
+          errorToString(err)
+        );
         const result: NpmSearchResult = {
-          results: [],
+          objects: [],
           total: 0,
         };
         return result;

--- a/packages/core/src/initializer/package-info.ts
+++ b/packages/core/src/initializer/package-info.ts
@@ -1,4 +1,9 @@
-export interface PackageInfo {
+export interface PackageInfo extends PackageSummary {
+  homepage?: string;
+  initStrykerConfig?: Record<string, unknown>;
+}
+
+export interface PackageSummary {
   name: string;
   keywords: string[];
   version: string;

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -5,8 +5,8 @@ import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { Logger } from '@stryker-mutator/api/logging';
 import { notEmpty } from '@stryker-mutator/util';
 
-import { NpmClient, NpmPackage } from './npm-client.js';
-import { PackageInfo } from './package-info.js';
+import { NpmClient } from './npm-client.js';
+import { PackageInfo, PackageSummary } from './package-info.js';
 import { CustomInitializer } from './custom-initializers/custom-initializer.js';
 import { PromptOption } from './prompt-option.js';
 import { StrykerConfigWriter } from './stryker-config-writer.js';
@@ -218,7 +218,7 @@ export class StrykerInitializer {
     }
   }
 
-  private async fetchAdditionalConfig(dependencies: PackageInfo[]): Promise<NpmPackage[]> {
+  private async fetchAdditionalConfig(dependencies: PackageSummary[]): Promise<PackageInfo[]> {
     return await Promise.all(dependencies.map((dep) => this.client.getAdditionalConfig(dep)));
   }
 }


### PR DESCRIPTION
Use https://registry.npmjs.com as a backend for any queries during init. This solves the caching problem and adds `vitest` and `tap` as test runners.

- https://registry.npmjs.com/-/v1/search?text=keywords:%40stryker-mutator%2Ftest-runner-plugin for test runner plugins
- https://registry.npmjs.com/%40stryker-mutator%2Fkarma-runner/latest to retrieve package.json

Closes #4288

![image](https://github.com/stryker-mutator/stryker-js/assets/1828233/a1d89d62-5e7b-43df-bd63-c3bd57fb1e2a)
