### PR TITLE
feat(vitest-runner): add `"dir"` config option

### DIFF
--- a/docs/vitest-runner.md
+++ b/docs/vitest-runner.md
@@ -41,6 +41,8 @@ Specify a ['vitest.config.js' file](https://vitest.dev/config/) to be loaded. By
 
 ### `vitest.dir` [`string` | `undefined`]
 
+_Since v7.1_
+
 Default: `undefined`
 
 Configure the `--dir <path>` command line option. See https://vitest.dev/guide/cli.html#options.

--- a/docs/vitest-runner.md
+++ b/docs/vitest-runner.md
@@ -27,7 +27,8 @@ You can configure the `@stryker-mutator/vitest-runner` using the `stryker.conf.j
 {
   "testRunner": "vitest",
   "vitest": {
-    "configFile": "vitest.config.js"
+    "configFile": "vitest.config.js",
+    "dir": "packages"
   }
 }
 ```
@@ -37,6 +38,12 @@ You can configure the `@stryker-mutator/vitest-runner` using the `stryker.conf.j
 Default: `undefined`
 
 Specify a ['vitest.config.js' file](https://vitest.dev/config/) to be loaded. By default vitest will look for a `vitest.config.js` (or `.ts`) file in the root of your project.
+
+### `vitest.dir` [`string` | `undefined`]
+
+Default: `undefined`
+
+Configure the `--dir <path>` command line option. See https://vitest.dev/guide/cli.html#options.
 
 ## Non overridable options
 

--- a/packages/vitest-runner/schema/vitest-runner-options.json
+++ b/packages/vitest-runner/schema/vitest-runner-options.json
@@ -11,6 +11,10 @@
       "type": "object",
       "default": {},
       "properties": {
+        "dir": {
+          "description": "Configure the `--dir <path>` command line option",
+          "type": "string"
+        },
         "configFile": {
           "description": "Path to the config file. Default resolving to `vitest.config.*`, `vite.config.*`",
           "type": "string"

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -45,6 +45,7 @@ export class VitestTestRunner implements TestRunner {
       coverage: { enabled: false },
       singleThread: true,
       watch: false,
+      dir: this.options.vitest.dir,
       bail: this.options.disableBail ? 0 : 1,
       onConsoleLog: () => false,
     });

--- a/packages/vitest-runner/test/integration/timeout-on-infinite-loop.it.spec.ts
+++ b/packages/vitest-runner/test/integration/timeout-on-infinite-loop.it.spec.ts
@@ -2,6 +2,7 @@ import { testInjector, factory, assertions, TempTestDirectorySandbox } from '@st
 import { expect } from 'chai';
 
 import { createVitestTestRunnerFactory, VitestTestRunner } from '../../src/vitest-test-runner.js';
+import { VitestRunnerOptionsWithStrykerOptions } from '../../src/vitest-runner-options-with-stryker-options.js';
 
 describe('Infinite loop', () => {
   let sut: VitestTestRunner;
@@ -10,6 +11,7 @@ describe('Infinite loop', () => {
   beforeEach(async () => {
     sandbox = new TempTestDirectorySandbox('infinite-loop');
     await sandbox.init();
+    (testInjector.options as VitestRunnerOptionsWithStrykerOptions).vitest = {};
     sut = testInjector.injector.injectFunction(createVitestTestRunnerFactory('__stryker2__'));
   });
   afterEach(async () => {

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -356,4 +356,26 @@ describe('VitestRunner integration', () => {
       assertions.expectSurvived(runResult);
     });
   });
+
+  // See https://github.com/stryker-mutator/stryker-js/issues/4257
+  describe('using a project using "--dir <path>"', () => {
+    beforeEach(async () => {
+      sandbox = new TempTestDirectorySandbox('deep-project');
+      await sandbox.init();
+    });
+
+    it('should be able to report an ErrorResult', async () => {
+      options.vitest.dir = 'packages';
+      await sut.init();
+      const runResult = await sut.dryRun();
+      assertions.expectCompleted(runResult);
+      expect(runResult.tests).lengthOf(1);
+      assertions.expectTestResults(runResult, [
+        {
+          id: 'packages/app/src/math.spec.js#math should be 5 for add(2, 3)',
+          status: TestStatus.Success,
+        },
+      ]);
+    });
+  });
 });

--- a/packages/vitest-runner/testResources/deep-project/package.json
+++ b/packages/vitest-runner/testResources/deep-project/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "test": "vitest run --dir packages"
+  }
+}

--- a/packages/vitest-runner/testResources/deep-project/packages/app/src/math.js
+++ b/packages/vitest-runner/testResources/deep-project/packages/app/src/math.js
@@ -1,0 +1,3 @@
+export function add(num1, num2) {
+  return num1 + num2;
+}

--- a/packages/vitest-runner/testResources/deep-project/packages/app/src/math.spec.js
+++ b/packages/vitest-runner/testResources/deep-project/packages/app/src/math.spec.js
@@ -1,0 +1,8 @@
+import {  add } from './math.js';
+import { expect, test, describe } from 'vitest';
+
+describe('math', () => {
+  test('should be 5 for add(2, 3)', function () {
+    expect(add(2, 3)).toBe(5);
+  });
+});

--- a/packages/vitest-runner/testResources/deep-project/resources/some-other.spec.js
+++ b/packages/vitest-runner/testResources/deep-project/resources/some-other.spec.js
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('this test should not run', function () {
+  expect(false).toBe(true);
+});

--- a/packages/vitest-runner/testResources/deep-project/vitest.config.ts
+++ b/packages/vitest-runner/testResources/deep-project/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+  },
+})


### PR DESCRIPTION
Add `"dir"` config option, which allows users to configure a `--dir <path>`.

Closes #4257
