### PR TITLE
Implementation of additional configs for clear-text reporter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Choose whether or not to clean the temp dir (which is ".stryker-tmp" inside the 
 
 ### `clearTextReporter` [`ClearTextOptions`]
 
-Default: `{ "allowColor": true, "allowEmojis": false, "logTests": true, "maxTestsToLog": 3 }`<br />
+Default: `{ "allowColor": true, "allowEmojis": false, "logTests": true, "maxTestsToLog": 3, "reportAllTests": true, "reportAllMutants": true, "reportScoreTable": true }`<br />
 
 Config file: 
 ```json
@@ -85,7 +85,10 @@ Config file:
     "allowColor": true,
     "allowEmojis": false,
     "logTests": true,
-    "maxTestsToLog": 3
+    "maxTestsToLog": 3,
+    "reportAllTests": true,
+    "reportAllMutants": true,
+    "reportScoreTable": true
   }
 }
 ```
@@ -439,6 +442,9 @@ The `clear-text` reporter supports three additional config options:
 - `allowColor` to use cyan and yellow in printing source file names and positions. This defaults to `true`, so specify as `clearTextReporter: { allowColor: false },` to disable if you must.
 - `logTests` to log the names of unit tests that were run to allow mutants. By default, only the first three are logged. The config for your config file is: `clearTextReporter: { logTests: true },`
 - `maxTestsToLog` to show more tests that were executed to kill a mutant when `logTests` is true. The config for your config file is: `clearTextReporter: { logTests: true, maxTestsToLog: 7 },`
+- `reportAllTests` to log all tests. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportAllTests: false },` to disable if you must.
+- `reportAllMutants` to log all mutants. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportAllMutants: false },` to disable if you must.
+- `reportScoreTable` to log score table. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportScoreTable: false },` to disable if you must.
 
 The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.\*](#dashboard-dashboardoptions) configuration options.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,9 +442,9 @@ The `clear-text` reporter supports three additional config options:
 - `allowColor` to use cyan and yellow in printing source file names and positions. This defaults to `true`, so specify as `clearTextReporter: { allowColor: false },` to disable if you must.
 - `logTests` to log the names of unit tests that were run to allow mutants. By default, only the first three are logged. The config for your config file is: `clearTextReporter: { logTests: true },`
 - `maxTestsToLog` to show more tests that were executed to kill a mutant when `logTests` is true. The config for your config file is: `clearTextReporter: { logTests: true, maxTestsToLog: 7 },`
-- `reportAllTests` to log all tests. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportAllTests: false },` to disable if you must.
-- `reportAllMutants` to log all mutants. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportAllMutants: false },` to disable if you must.
-- `reportScoreTable` to log score table. By default, only the first three are logged. This defaults to `true`, so specify as `clearTextReporter: { reportScoreTable: false },` to disable if you must.
+- `reportAllTests` to log all tests. This defaults to `true`, so specify as `clearTextReporter: { reportAllTests: false },` to disable if you must.
+- `reportAllMutants` to log all mutants. This defaults to `true`, so specify as `clearTextReporter: { reportAllMutants: false },` to disable if you must.
+- `reportScoreTable` to log score table. This defaults to `true`, so specify as `clearTextReporter: { reportScoreTable: false },` to disable if you must.
 
 The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.\*](#dashboard-dashboardoptions) configuration options.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Choose whether or not to clean the temp dir (which is ".stryker-tmp" inside the 
 
 ### `clearTextReporter` [`ClearTextOptions`]
 
-Default: `{ "allowColor": true, "allowEmojis": false, "logTests": true, "maxTestsToLog": 3, "reportAllTests": true, "reportAllMutants": true, "reportScoreTable": true }`<br />
+Default: `{ "allowColor": true, "allowEmojis": false, "logTests": true, "maxTestsToLog": 3, "reportTests": true, "reportMutants": true, "reportScoreTable": true }`<br />
 
 Config file: 
 ```json
@@ -86,8 +86,8 @@ Config file:
     "allowEmojis": false,
     "logTests": true,
     "maxTestsToLog": 3,
-    "reportAllTests": true,
-    "reportAllMutants": true,
+    "reportTests": true,
+    "reportMutants": true,
     "reportScoreTable": true
   }
 }
@@ -442,9 +442,9 @@ The `clear-text` reporter supports three additional config options:
 - `allowColor` to use cyan and yellow in printing source file names and positions. This defaults to `true`, so specify as `clearTextReporter: { allowColor: false },` to disable if you must.
 - `logTests` to log the names of unit tests that were run to allow mutants. By default, only the first three are logged. The config for your config file is: `clearTextReporter: { logTests: true },`
 - `maxTestsToLog` to show more tests that were executed to kill a mutant when `logTests` is true. The config for your config file is: `clearTextReporter: { logTests: true, maxTestsToLog: 7 },`
-- `reportAllTests` to log all tests. This defaults to `true`, so specify as `clearTextReporter: { reportAllTests: false },` to disable if you must.
-- `reportAllMutants` to log all mutants. This defaults to `true`, so specify as `clearTextReporter: { reportAllMutants: false },` to disable if you must.
-- `reportScoreTable` to log score table. This defaults to `true`, so specify as `clearTextReporter: { reportScoreTable: false },` to disable if you must.
+- `reportTests` to log tests. When set to `true` this reporter will report a list of all tests with the amounts of mutants they killed (if any).
+- `reportMutants` to log mutants. When set to `true` this reporter will report each `Survived` and `NoCoverage` mutant to the stdout, as well as log other mutant states on debug log level.
+- `reportScoreTable` to log the score table. When set to `true` this reporter will end with a summary table with a row per mutated file.
 
 The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.\*](#dashboard-dashboardoptions) configuration options.
 

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -82,6 +82,21 @@
           "type": "integer",
           "minimum": 0,
           "default": 3
+        },
+        "reportAllTests": {
+          "description": "Indicates whether or not to log all tests.",
+          "type": "boolean",
+          "default": true
+        },
+        "reportAllMutants": {
+          "description": "Indicates whether or not to log all mutants.",
+          "type": "boolean",
+          "default": true
+        },
+        "reportScoreTable": {
+          "description": "Indicates whether or not to log score table.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -83,12 +83,12 @@
           "minimum": 0,
           "default": 3
         },
-        "reportAllTests": {
+        "reportTests": {
           "description": "Indicates whether or not to log all tests.",
           "type": "boolean",
           "default": true
         },
-        "reportAllMutants": {
+        "reportMutants": {
           "description": "Indicates whether or not to log all mutants.",
           "type": "boolean",
           "default": true

--- a/packages/core/src/reporters/clear-text-reporter.ts
+++ b/packages/core/src/reporters/clear-text-reporter.ts
@@ -39,18 +39,18 @@ export class ClearTextReporter implements Reporter {
   public onMutationTestReportReady(_report: schema.MutationTestResult, metrics: MutationTestMetricsResult): void {
     this.writeLine();
 
-    if (this.options.clearTextReporter.reportAllTests) {
-      this.reportAllTests(metrics);
+    if (this.options.clearTextReporter.reportTests) {
+      this.reportTests(metrics);
     }
-    if (this.options.clearTextReporter.reportAllMutants) {
-      this.reportAllMutants(metrics);
+    if (this.options.clearTextReporter.reportMutants) {
+      this.reportMutants(metrics);
     }
     if (this.options.clearTextReporter.reportScoreTable) {
       this.writeLine(new ClearTextScoreTable(metrics.systemUnderTestMetrics, this.options).draw());
     }
   }
 
-  private reportAllTests(metrics: MutationTestMetricsResult) {
+  private reportTests(metrics: MutationTestMetricsResult) {
     function indent(depth: number) {
       return new Array(depth).fill('  ').join('');
     }
@@ -87,7 +87,7 @@ export class ClearTextReporter implements Reporter {
     }
   }
 
-  private reportAllMutants({ systemUnderTestMetrics }: MutationTestMetricsResult): void {
+  private reportMutants({ systemUnderTestMetrics }: MutationTestMetricsResult): void {
     this.writeLine();
     let totalTests = 0;
 

--- a/packages/core/src/reporters/clear-text-reporter.ts
+++ b/packages/core/src/reporters/clear-text-reporter.ts
@@ -38,9 +38,16 @@ export class ClearTextReporter implements Reporter {
 
   public onMutationTestReportReady(_report: schema.MutationTestResult, metrics: MutationTestMetricsResult): void {
     this.writeLine();
-    this.reportAllTests(metrics);
-    this.reportAllMutants(metrics);
-    this.writeLine(new ClearTextScoreTable(metrics.systemUnderTestMetrics, this.options).draw());
+
+    if (this.options.clearTextReporter.reportAllTests) {
+      this.reportAllTests(metrics);
+    }
+    if (this.options.clearTextReporter.reportAllMutants) {
+      this.reportAllMutants(metrics);
+    }
+    if (this.options.clearTextReporter.reportScoreTable) {
+      this.writeLine(new ClearTextScoreTable(metrics.systemUnderTestMetrics, this.options).draw());
+    }
   }
 
   private reportAllTests(metrics: MutationTestMetricsResult) {

--- a/packages/core/test/helpers/producers.ts
+++ b/packages/core/test/helpers/producers.ts
@@ -46,6 +46,9 @@ export const createClearTextReporterOptions = factoryMethod<ClearTextReporterOpt
   allowEmojis: false,
   logTests: true,
   maxTestsToLog: 3,
+  reportAllTests: true,
+  reportAllMutants: true,
+  reportScoreTable: true,
 }));
 
 export type ConcurrencyTokenProviderMock = sinon.SinonStubbedInstance<I<ConcurrencyTokenProvider>> & {

--- a/packages/core/test/helpers/producers.ts
+++ b/packages/core/test/helpers/producers.ts
@@ -46,8 +46,8 @@ export const createClearTextReporterOptions = factoryMethod<ClearTextReporterOpt
   allowEmojis: false,
   logTests: true,
   maxTestsToLog: 3,
-  reportAllTests: true,
-  reportAllMutants: true,
+  reportTests: true,
+  reportMutants: true,
   reportScoreTable: true,
 }));
 

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -46,6 +46,9 @@ describe(OptionsValidator.name, () => {
           allowEmojis: false,
           logTests: true,
           maxTestsToLog: 3,
+          reportAllTests: true,
+          reportAllMutants: true,
+          reportScoreTable: true,
         },
         commandRunner: {
           command: 'npm test',

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -46,8 +46,8 @@ describe(OptionsValidator.name, () => {
           allowEmojis: false,
           logTests: true,
           maxTestsToLog: 3,
-          reportAllTests: true,
-          reportAllMutants: true,
+          reportTests: true,
+          reportMutants: true,
           reportScoreTable: true,
         },
         commandRunner: {

--- a/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
@@ -57,6 +57,32 @@ describe(ClearTextReporter.name, () => {
       ]);
     });
 
+    it('should not report the clear text table when reportScoreTable is not true', () => {
+      testInjector.options.clearTextReporter.reportScoreTable = false;
+
+      act({
+        files: {
+          'src/file.js': {
+            language: 'js',
+            mutants: [
+              {
+                id: '1',
+                location: { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } },
+                mutatorName: 'Block',
+                replacement: '{}',
+                status: MutantStatus.Killed,
+              },
+            ],
+            source: 'console.log("hello world!")',
+          },
+        },
+        schemaVersion: '1.0',
+        thresholds: factory.mutationScoreThresholds({}),
+      });
+
+      expect(stdoutStub).not.calledWithMatch(sinon.match('File      | % score | # killed | # timeout | # survived | # no cov | # errors |'));
+    });
+
     it('should show emojis in table with enableConsoleEmojis flag', () => {
       testInjector.options.clearTextReporter.allowEmojis = true;
 
@@ -246,6 +272,13 @@ describe(ClearTextReporter.name, () => {
         expect(stdoutStub).calledWithMatch(sinon.match('[Survived] Math'));
       });
 
+      it('should not report a Survived mutant to stdout when reportAllMutants is not true', async () => {
+        testInjector.options.clearTextReporter.reportAllMutants = false;
+        mutant.status = MutantStatus.Survived;
+        act(report);
+        expect(stdoutStub).not.calledWithMatch(sinon.match('[Survived] Math'));
+      });
+
       it('should report a Timeout mutant to stdout', async () => {
         mutant.status = MutantStatus.Timeout;
         act(report);
@@ -351,6 +384,31 @@ describe(ClearTextReporter.name, () => {
         expect(stdoutStub).calledWithMatch(sinon.match('  ✓ foo should bar (killed 1)'));
         expect(stdoutStub).calledWithMatch(sinon.match('  ~ baz should qux (covered 1)'));
         expect(stdoutStub).calledWithMatch(sinon.match('  ✘ quux should corge (covered 0)'));
+      });
+
+      it('should not report a list of tests if file names are unknown when reportAllTests is not true', () => {
+        testInjector.options.clearTextReporter.reportAllTests = false;
+        const report = factory.mutationTestReportSchemaMutationTestResult({
+          files: {
+            'foo.js': factory.mutationTestReportSchemaFileResult({
+              mutants: [
+                factory.mutationTestReportSchemaMutantResult({ killedBy: ['0'] }),
+                factory.mutationTestReportSchemaMutantResult({ coveredBy: ['1'] }),
+              ],
+            }),
+          },
+          testFiles: {
+            '': factory.mutationTestReportSchemaTestFile({
+              tests: [
+                factory.mutationTestReportSchemaTestDefinition({ id: '0', name: 'foo should bar' }),
+                factory.mutationTestReportSchemaTestDefinition({ id: '1', name: 'baz should qux' }),
+                factory.mutationTestReportSchemaTestDefinition({ id: '2', name: 'quux should corge' }),
+              ],
+            }),
+          },
+        });
+        act(report);
+        expect(stdoutStub).not.calledWithMatch(sinon.match('All tests'));
       });
 
       it('should report in the correct colors', () => {

--- a/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
@@ -279,6 +279,13 @@ describe(ClearTextReporter.name, () => {
         expect(stdoutStub).not.calledWithMatch(sinon.match('[Survived] Math'));
       });
 
+      it('should not report a NoCoverage mutant to stdout when reportMutants is not true', async () => {
+        testInjector.options.clearTextReporter.reportMutants = false;
+        mutant.status = MutantStatus.NoCoverage;
+        act(report);
+        expect(stdoutStub).not.calledWithMatch(sinon.match('[NoCoverage] Math'));
+      });
+
       it('should report a Timeout mutant to stdout', async () => {
         mutant.status = MutantStatus.Timeout;
         act(report);

--- a/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/clear-text-reporter.spec.ts
@@ -272,8 +272,8 @@ describe(ClearTextReporter.name, () => {
         expect(stdoutStub).calledWithMatch(sinon.match('[Survived] Math'));
       });
 
-      it('should not report a Survived mutant to stdout when reportAllMutants is not true', async () => {
-        testInjector.options.clearTextReporter.reportAllMutants = false;
+      it('should not report a Survived mutant to stdout when reportMutants is not true', async () => {
+        testInjector.options.clearTextReporter.reportMutants = false;
         mutant.status = MutantStatus.Survived;
         act(report);
         expect(stdoutStub).not.calledWithMatch(sinon.match('[Survived] Math'));
@@ -386,8 +386,8 @@ describe(ClearTextReporter.name, () => {
         expect(stdoutStub).calledWithMatch(sinon.match('  ✘ quux should corge (covered 0)'));
       });
 
-      it('should not report a list of tests if file names are unknown when reportAllTests is not true', () => {
-        testInjector.options.clearTextReporter.reportAllTests = false;
+      it('should not report a list of tests if file names are unknown when reportTests is not true', () => {
+        testInjector.options.clearTextReporter.reportTests = false;
         const report = factory.mutationTestReportSchemaMutationTestResult({
           files: {
             'foo.js': factory.mutationTestReportSchemaFileResult({


### PR DESCRIPTION
Related issue: [here](https://github.com/stryker-mutator/stryker-js/issues/4209)

Implementation of additional configuration options for the clear-text reporter. These additions include the ability to enable/disable the three sections within the clear-text reporter that get printed: All tests, survived mutants, and score table.

Fixes #4209