### PR TITLE
build: enable npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write # to enable use of OIDC for npm provenance
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
     - uses: actions/checkout@v3
     - name: Set NPM Env

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,3 +19,5 @@ jobs:
       run: npm run build
     - name: Release
       run: npx lerna publish from-git --yes --pre-dist-tag next --no-verify-access
+      env:
+        NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
A few months ago, npm introduced something called [npm provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/). Basically, it's a way to verify that a certain package was built on a certain commit with certain build steps, and not just a pinky-promise that some evildoer didn't publish it locally with some naughty code. All it takes is adding the option to the publish step, and npm/GH Actions will take care of the rest.

Right now, it doesn't do much other than showing a check on the npm page, and you can still publish new versions without provenance (it just won't show the check), but hopefully this will improve in the future.