### PR TITLE
bug(tap-runnner): time spent not shown when tap result has no time spent

### DIFF
--- a/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
+++ b/packages/tap-runner/test/integration/tap-test-runner.it.spec.ts
@@ -261,12 +261,21 @@ describe('tap-runner integration', () => {
       await sut.init();
     });
 
-    it('should be able to run', async function () {
+    it('should be able to run', async () => {
       // Act
       const run = await sut.dryRun(factory.dryRunOptions());
 
       // Assert
       assertions.expectCompleted(run);
+    });
+
+    it('should return a valid timeSpentMs', async () => {
+      // Act
+      const run = await sut.dryRun(factory.dryRunOptions());
+
+      // Assert
+      assertions.expectCompleted(run);
+      expect(run.tests[0].timeSpentMs).to.be.greaterThan(0);
     });
   });
 });


### PR DESCRIPTION
Added custom time calculation for a test run which is used when the tap result does not include the time spent.

Fixes #4331