### PR TITLE
feat(vitest-runner): Support JSDOM

### DIFF
--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -166,7 +166,9 @@ export class VitestTestRunner implements TestRunner {
 
   private async readMutantCoverage(): Promise<MutantCoverage> {
     // Read coverage from all projects
-    const coverages: MutantCoverage[] = [...new Map(this.ctx!.state.getFiles().map((file) => [file.name, file] as const)).entries()]
+    const coverages: MutantCoverage[] = [
+      ...new Map(this.ctx!.state.getFiles().map((file) => [`${file.projectName}-${file.name}`, file] as const)).entries(),
+    ]
       .map(([, file]) => (file.meta as { mutantCoverage?: MutantCoverage }).mutantCoverage)
       .filter(notEmpty);
 

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -43,7 +43,8 @@ export class VitestTestRunner implements TestRunner {
       config: this.options.vitest?.configFile,
       threads: true,
       coverage: { enabled: false },
-      singleThread: true,
+      singleThread: false,
+      maxConcurrency: 1,
       watch: false,
       dir: this.options.vitest.dir,
       bail: this.options.disableBail ? 0 : 1,
@@ -165,7 +166,7 @@ export class VitestTestRunner implements TestRunner {
 
   private async readMutantCoverage(): Promise<MutantCoverage> {
     // Read coverage from all projects
-    const coverages: MutantCoverage[] = [...new Map(this.ctx!.state.getFiles().map((file) => [file.projectName, file] as const)).entries()]
+    const coverages: MutantCoverage[] = [...new Map(this.ctx!.state.getFiles().map((file) => [file.name, file] as const)).entries()]
       .map(([, file]) => (file.meta as { mutantCoverage?: MutantCoverage }).mutantCoverage)
       .filter(notEmpty);
 


### PR DESCRIPTION
JSDOM is not supported in vitest when using `singleThread = true` because it relies on being isolated.

With `singleThread = false` and `maxConcurrency = 1` this should be fixed. Concurrency should be set to 1 to prevent proces starvation.
Also fixed bug in the method readMutantCoverage `file.projectName` was undefined in the cases i tested so now its using `file.name`

Fixes #4336 