### PR TITLE
fix: don't publish test and tsbuildinfo

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,8 +9,10 @@
     "directory": "packages/api"
   },
   "files": [
-    "dist",
-    "./core.d.ts",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
+    "core.d.ts",
     "src-generated",
     "src"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "files": [
     "bin",
-    "dist",
+    "dist/src",
     "schema",
     "src"
   ],

--- a/packages/cucumber-runner/package.json
+++ b/packages/cucumber-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the cucumber test runner in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/instrumenter/package.json
+++ b/packages/instrumenter/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "type": "module",
   "files": [
-    "dist",
+    "dist/src",
     "src"
   ],
   "exports": {

--- a/packages/jasmine-runner/package.json
+++ b/packages/jasmine-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the Jasmine (NodeJS) test runner in Stryker, the mutation testing framework for JavaScript and friends",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the jest test runner and framework in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/karma-runner/package.json
+++ b/packages/karma-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the karma test runner in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src",
     "stryker-karma.conf.cjs"

--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the mocha test runner in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/tap-runner/package.json
+++ b/packages/tap-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the TAP (test anything protocol) test runner in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/typescript-checker/package.json
+++ b/packages/typescript-checker/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A typescript type checker plugin to be used in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -3,7 +3,7 @@
   "version": "7.2.0",
   "description": "Contains utilities for Stryker, the mutation testing framework for JavaScript and friends",
   "files": [
-    "dist",
+    "dist/src",
     "src"
   ],
   "exports": {

--- a/packages/vitest-runner/package.json
+++ b/packages/vitest-runner/package.json
@@ -3,7 +3,9 @@
   "version": "7.2.0",
   "description": "A plugin to use the vitest test runner and framework in Stryker, the JavaScript mutation testing framework",
   "files": [
-    "dist",
+    "dist/schema",
+    "dist/src-generated",
+    "dist/src",
     "src-generated",
     "src"
   ],


### PR DESCRIPTION
Fix the problems reported in previous pull request https://github.com/stryker-mutator/stryker-js/pull/4405#issuecomment-1743831971: don't publish `dist/test/`, `dist/tsconfig.src.tsbuildinfo` and `dist/tsconfig.test.tsbuildinfo`.

---

- `api`: [diff between 7.1.1 and 7.2.0](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fapi%2F-%2Fapi-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fapi%2F-%2Fapi-7.2.0.tgz) / [files in 7.2.0](https://www.npmjs.com/package/@stryker-mutator/api/v/7.2.0?activeTab=code)
- `core`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcore%2F-%2Fcore-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcore%2F-%2Fcore-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/core/v/7.2.0?activeTab=code)
- `cucumber-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcucumber-runner%2F-%2Fcucumber-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcucumber-runner%2F-%2Fcucumber-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/cucumber-runner/v/7.2.0?activeTab=code)
- `cucumber-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcucumber-runner%2F-%2Fcucumber-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fcucumber-runner%2F-%2Fcucumber-runner-7.2.0.tgz) / [code](https://www.npmjs.com/package/@stryker-mutator/cucumber-runner/v/7.2.0?activeTab=code)
- `grunt-stryker`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2Fgrunt-stryker%2F-%2Fgrunt-stryker-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2Fgrunt-stryker%2F-%2Fgrunt-stryker-7.2.0.tgz) / [files](https://www.npmjs.com/package/grunt-stryker/v/7.2.0?activeTab=code)
- `instrumenter`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Finstrumenter%2F-%2Finstrumenter-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Finstrumenter%2F-%2Finstrumenter-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/instrumenter/v/7.2.0?activeTab=code)
- `jasmine-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fjasmine-runner%2F-%2Fjasmine-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fjasmine-runner%2F-%2Fjasmine-runner-7.2.0.tgz) / [diff](https://www.npmjs.com/package/@stryker-mutator/jasmine-runner/v/7.2.0?activeTab=code)
- `jest-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fjest-runner%2F-%2Fjest-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fjest-runner%2F-%2Fjest-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/jest-runner/v/7.2.0?activeTab=code)
- `karma-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fkarma-runner%2F-%2Fkarma-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fkarma-runner%2F-%2Fkarma-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/karma-runner/v/7.2.0?activeTab=code)
- `mocha-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fmocha-runner%2F-%2Fmocha-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fmocha-runner%2F-%2Fmocha-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/mocha-runner/v/7.2.0?activeTab=code)
- `tap-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Ftap-runner%2F-%2Ftap-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Ftap-runner%2F-%2Ftap-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/tap-runner/v/7.2.0?activeTab=code)
- `test-helpers`: private
- `typescript-checker`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Ftypescript-checker%2F-%2Ftypescript-checker-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Ftypescript-checker%2F-%2Ftypescript-checker-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/typescript-checker/v/7.2.0?activeTab=code)
- `util`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Futil%2F-%2Futil-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Futil%2F-%2Futil-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/util/v/7.2.0?activeTab=code)
- `vitest-runner`: [diff](https://diff.ecosyste.ms/diff?url_1=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fvitest-runner%2F-%2Fvitest-runner-7.1.1.tgz&url_2=https%3A%2F%2Fregistry.npmjs.org%2F%40stryker-mutator%2Fvitest-runner%2F-%2Fvitest-runner-7.2.0.tgz) / [files](https://www.npmjs.com/package/@stryker-mutator/vitest-runner/v/7.2.0?activeTab=code)