### PR TITLE
fix(core): short circuit test executor when no tests and allowEmpty

### DIFF
--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -75,7 +75,7 @@ export class MutationTestExecutor {
     if (this.dryRunResult.tests.length === 0 && this.options.allowEmpty) {
       this.logDone();
       return [];
-  }
+    }
 
     const mutantTestPlans = await this.planner.makePlan(this.mutants);
     const { earlyResult$, runMutant$ } = this.executeEarlyResult(from(mutantTestPlans));

--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -2,7 +2,7 @@ import { from, partition, merge, Observable, lastValueFrom, EMPTY, concat, buffe
 import { toArray, map, shareReplay, tap } from 'rxjs/operators';
 import { tokens, commonTokens } from '@stryker-mutator/api/plugin';
 import { MutantResult, MutantStatus, Mutant, StrykerOptions, PlanKind, MutantTestPlan, MutantRunPlan } from '@stryker-mutator/api/core';
-import { TestRunner } from '@stryker-mutator/api/test-runner';
+import { TestRunner, CompleteDryRunResult } from '@stryker-mutator/api/test-runner';
 import { Logger } from '@stryker-mutator/api/logging';
 import { I } from '@stryker-mutator/util';
 import { CheckStatus } from '@stryker-mutator/api/check';
@@ -22,6 +22,7 @@ export interface MutationTestContext extends DryRunContext {
   [coreTokens.timeOverheadMS]: number;
   [coreTokens.mutationTestReportHelper]: MutationTestReportHelper;
   [coreTokens.mutantTestPlanner]: MutantTestPlanner;
+  [coreTokens.dryRunResult]: I<CompleteDryRunResult>;
 }
 
 const CHECK_BUFFER_MS = 10_000;
@@ -48,6 +49,7 @@ export class MutationTestExecutor {
     commonTokens.options,
     coreTokens.timer,
     coreTokens.concurrencyTokenProvider,
+    coreTokens.dryRunResult,
   );
 
   constructor(
@@ -61,6 +63,7 @@ export class MutationTestExecutor {
     private readonly options: StrykerOptions,
     private readonly timer: I<Timer>,
     private readonly concurrencyTokenProvider: I<ConcurrencyTokenProvider>,
+    private readonly dryRunResult: CompleteDryRunResult,
   ) {}
 
   public async execute(): Promise<MutantResult[]> {
@@ -68,6 +71,11 @@ export class MutationTestExecutor {
       this.log.info('The dry-run has been completed successfully. No mutations have been executed.');
       return [];
     }
+
+    if (this.dryRunResult.tests.length === 0 && this.options.allowEmpty) {
+      this.logDone();
+      return [];
+  }
 
     const mutantTestPlans = await this.planner.makePlan(this.mutants);
     const { earlyResult$, runMutant$ } = this.executeEarlyResult(from(mutantTestPlans));

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -423,4 +423,22 @@ describe(MutationTestExecutor.name, () => {
     expect(checker.check).not.called;
     expect(actualResults).empty;
   });
+
+  it('should not short circuit if no tests found and allowEmpty is disabled', async () => {
+    // Arrange
+    testInjector.options.allowEmpty = false;
+    arrangeScenario({ dryRunTestResult: [] });
+    const plan1 = mutantRunPlan({ id: '1' });
+    const plan2 = mutantRunPlan({ id: '2' });
+    mutantTestPlans.push(plan1, plan2);
+
+    // Act
+    const actualResults = await sut.execute();
+
+    // Assert
+    expect(mutantTestPlannerMock.makePlan).called;
+    expect(testRunner.mutantRun).calledWithExactly(plan1.runOptions);
+    expect(testRunner.mutantRun).calledWithExactly(plan2.runOptions);
+    expect(actualResults).deep.eq([plan1.mutant, plan2.mutant]);;
+  });
 });

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -100,7 +100,12 @@ describe(MutationTestExecutor.name, () => {
     mutationTestReportHelperMock.reportAll.returnsArg(0);
   }
 
-  function arrangeScenario(overrides?: { mutantRunPlan?: MutantRunPlan; checkResult?: CheckResult; mutantRunResult?: MutantRunResult; dryRunTestResult?: TestResult[] }) {
+  function arrangeScenario(overrides?: {
+    mutantRunPlan?: MutantRunPlan;
+    checkResult?: CheckResult;
+    mutantRunResult?: MutantRunResult;
+    dryRunTestResult?: TestResult[];
+  }) {
     checker.check.resolves([[overrides?.mutantRunPlan ?? mutantRunPlan(), overrides?.checkResult ?? factory.checkResult()]]);
     testRunner.mutantRun.resolves(overrides?.mutantRunResult ?? factory.survivedMutantRunResult());
     completeDryRunResult.tests = overrides?.dryRunTestResult ?? [factory.testResult()];
@@ -439,6 +444,6 @@ describe(MutationTestExecutor.name, () => {
     expect(mutantTestPlannerMock.makePlan).called;
     expect(testRunner.mutantRun).calledWithExactly(plan1.runOptions);
     expect(testRunner.mutantRun).calledWithExactly(plan2.runOptions);
-    expect(actualResults).deep.eq([plan1.mutant, plan2.mutant]);;
+    expect(actualResults).deep.eq([plan1.mutant, plan2.mutant]);
   });
 });


### PR DESCRIPTION
This should fix #4475 by short circuiting the test executor when no tests found and `allowEmpty=true` (same behaviour as `dryRunOnly`):
- prevent thresholds evaluation 
- avoid unnecessary run of the mutation executor (save some processing time)