### PR TITLE
docs(core): recommended to use Typescript instead of "recommended to use Stryker"

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -70,4 +70,4 @@ async function main() {
 }
 ```
 
-Stryker is written in TypeScript, so it is recommended to use Stryker as well to get the best developer experience.
+Stryker is written in TypeScript, so it is recommended to use Typescript as well to get the best developer experience.


### PR DESCRIPTION
The `README.md` in stryker core said
`Stryker is written in TypeScript, so it is recommended to use Stryker as well to get the best developer experience.`
This should be
`Stryker is written in TypeScript, so it is recommended to use Typescript as well to get the best developer experience.`