### PR TITLE
refactor(ignore): rename `PluginKind.Ignorer` to `PluginKind.Ignore`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,7 +301,7 @@ When using the command line, the list can only contain a comma separated list of
 - `--ignorePatterns ".idea",".angular","/src/assets/*.png","/src/assets/*.jpg"`
 - `--ignorePatterns "/src/**/*.css"`
 - `--ignorePatterns` with `"!"` (= undo) for example:
-  - `--ignorePatterns "src/**","!str/app/important/*.ts"` (for details on usage of glob patterns like `!`, `*`, `**` see [above](#usage-of-globbing-expressions-on-options) )
+  - `--ignorePatterns "src/**","!str/app/important/*.ts"` (for details on usage of glob patterns like `!`, `*`, `**` see [above](#usage-of-globbing-expressions-on-options))
   - or in the config file: `"ignorePatterns": ["src/**","!str/app/important/*.ts"]` This would ignore everything in and below `src` - directory **except** the typescript files in `src/app/important` directory, but the `--mutate` might be the better option in that case, see [below](#mutate-string)
   - Keep in mind that you should **not accidentally ignore any other configuration** files your test runner might need for running the tests in the sandbox directory.
 
@@ -313,11 +313,11 @@ Default: `[]`<br />
 Command line: _none_<br />
 Config file: `"ignorers": ["console.debug"]`<br />
 
-Specify which ignorer plugins to use. With an ignorer plugin you can ignore mutants inside common code patterns that you don't want to test for some reason. For example, you can use this to ignore all `console.debug()` statements from being mutated. 
+Specify which ignore-plugins to use. With an ignore-plugin you can ignore mutants inside common code patterns that you don't want to test for some reason. For example, you can use this to ignore all `console.debug()` statements from being mutated. 
 
-You only specify the name of the plugin here. The plugin's implementation must be loaded using a separate file, which must be listed in your [plugins array](#plugins-string).
+You only specify the name of the plugins here. The plugin's implementation must be loaded using a separate file, which must be listed in your [plugins array](#plugins-string).
 
-See [using an ignore plugin](./disable-mutants.md#using-an-ignorer-plugin) for more information.
+See [using an ignore-plugin](./disable-mutants.md#using-an-ignore-plugin) for more information.
 
 ### `ignoreStatic` [`boolean`]
 
@@ -365,10 +365,10 @@ Default: `false`<br />
 Command line: `--inPlace`<br />
 Config file: `"inPlace": true`<br />
 
-Determines whether or not Stryker should mutate your files in place.
+Determines whether Stryker should mutate your files in place.
 Note: mutating your files in place is generally not needed for mutation testing, unless you have a dependency in your project that is really dependent on the file locations (like "app-root-path" for example).
 
-When `true`, Stryker will override your files, but it will keep a copy of the originals in the temp directory (using `tempDirName`) and it will place the originals back after it is done. Also with `true` the [`ignorePatterns`](#ignorepatterns-string) has no effect any more.
+When `true`, Stryker will override your files, but it will keep a copy of the originals in the temp directory (using `tempDirName`) and it will place the originals back after it is done. Also, with `true` the [`ignorePatterns`](#ignorepatterns-string) has no effect anymore.
 
 When `false` (default) Stryker will work in the copy of your code inside the temp directory.
 
@@ -424,7 +424,7 @@ The default will try to guess your production code files based on sane defaults.
 - Include all js-like files inside the `src` or `lib` dir
   - Except files inside `__tests__` directories and file names ending with `test` or `spec`.
 
-If the defaults are not sufficient for you, for example in a angular project you might want to **exclude** not only the `*.spec.ts` files but other files too, just like the default already does.
+If the defaults are not sufficient for you, for example in an angular project you might want to **exclude** not only the `*.spec.ts` files but other files too, just like the default already does.
 
 It is possible to specify exactly which code blocks to mutate by means of a _mutation range_. This can be done postfixing your file with `:startLine[:startColumn]-endLine[:endColumn]`. Some examples:
 
@@ -472,25 +472,18 @@ Default: `['clear-text', 'progress', 'html']`<br />
 Command line: `--reporters clear-text,progress,dots,dashboard,html,json`<br />
 Config file: `"reporters": ["clear-text", "progress", "dots", "dashboard", "html", "json"]`
 
-With `reporters`, you can set the reporters for Stryker to use.
-These reporters can be used out of the box: `html`, `json`, `progress`, `clear-text`, `dots`, `dashboard` and `event-recorder`.
+Set the reporters for Stryker to use. These reporters can be used out of the box: `html`, `json`, `progress`, `clear-text`, `dots`, `dashboard` and `event-recorder`.
 By default, `clear-text`, `progress`, `html` are active if no reporters are configured. See [reporter plugins](./plugins.md#reporters)
 for a full description of each reporter.
 
-The `html` reporter allows you to specify an output folder. This defaults to `reports/mutation/html`. The config for your config file is: `htmlReporter: { fileName: 'mypath/reports/stryker.html' }` (since Stryker v6).
+You can also add your custom reporter using a [reporter plugin](./plugins.md/#reporters)
 
-The `json` reporter allows specifying an output file name (may also contain a path). The config for your config file is: `jsonReporter: { fileName: 'mypath/reports/mutation.json' }`
+To configure specific reporters, see their configuration:
 
-The `clear-text` reporter supports three additional config options:
-
-- `allowColor` to use cyan and yellow in printing source file names and positions. This defaults to `true`, so specify as `clearTextReporter: { allowColor: false },` to disable if you must.
-- `logTests` to log the names of unit tests that were run to allow mutants. By default, only the first three are logged. The config for your config file is: `clearTextReporter: { logTests: true },`
-- `maxTestsToLog` to show more tests that were executed to kill a mutant when `logTests` is true. The config for your config file is: `clearTextReporter: { logTests: true, maxTestsToLog: 7 },`
-- `reportTests` to log tests. When set to `true` this reporter will report a list of all tests with the amounts of mutants they killed (if any).
-- `reportMutants` to log mutants. When set to `true` this reporter will report each `Survived` and `NoCoverage` mutant to the stdout, as well as log other mutant states on debug log level.
-- `reportScoreTable` to log the score table. When set to `true` this reporter will end with a summary table with a row per mutated file.
-
-The `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a mutation score badge to your readme, as well as hosting your html report on the dashboard. It uses the [dashboard.\*](#dashboard-dashboardoptions) configuration options.
+- [clearTextReporter](#cleartextreporter-cleartextoptions)
+- [dashboard](#dashboard-dashboardoptions)
+- [htmlReporter](#htmlreporter-object)
+- [jsonReporter](#jsonreporter-object)
 
 ### `symlinkNodeModules` [`boolean`]
 

--- a/docs/disable-mutants.md
+++ b/docs/disable-mutants.md
@@ -51,7 +51,7 @@ StrykerJS supports three ways to ignore mutants.
    If you are not interested in a specific mutator.
 2. [Using a `// Stryker disable` comment](#using-a--stryker-disable-comment).  
    Suitable for the one-off ignoring of mutants.
-3. [Using an `Ignorer` plugin](#using-an-ignorer-plugin).  
+3. [Using an ignore-plugin](#using-an-ignore-plugin).  
    If you want to ignore the same pattern multiple times (and in multiple files).
 
 Disabled mutants will remain in your report but will get the `ignored` status. Mutants with this status in your report don't influence your mutation score but are still visible if you want to look for them.
@@ -162,7 +162,7 @@ function max(a, b) {
 }
 ```
 
-Turn off all mutators for an entire file, but restore the EqualityOperator for 1 line:
+Turn off all mutators for an entire file, but restore the `EqualityOperator` for 1 line:
 
 ```js
 // Stryker disable all
@@ -178,9 +178,9 @@ The syntax looks like this:
 // Stryker [disable|restore] [next-line] *mutatorList*[: custom reason]
 ```
 
-The comment always starts with `// Stryker`, followed by either `disable` or `restore`. Next, you can specify whether or not this comment targets the `next-line` or all lines from this point on (by not using `next-line`). As for the mutator list, this is either a comma-separated list of mutators or `all` to signal this comment targets all mutators. Last is an optional custom reason text behind the `:` colon.
+The comment always starts with `// Stryker`, followed by either `disable` or `restore`. Next, you can specify whether this comment targets the `next-line` or all lines from this point on (by not using `next-line`). As for the mutator list, this is either a comma-separated list of mutators or `all` to signal this comment targets all mutators. Last is an optional custom reason text behind the `:` colon.
 
-## Using an ignorer plugin
+## Using an ignore-plugin
 
 _Available since Stryker 7.3_
 
@@ -199,9 +199,9 @@ function subtract(a, b) {
 }
 ```
 
-In the code above, you might want to ignore all mutants in `console.debug` statements in this code. This is where an Ignorer can help.
+In the code above, you might want to ignore all mutants in `console.debug` statements in this code. This is where an ignore-plugin can help.
 
-To declare a ignorer plugin, first install `@stryker-mutator/api` as a dev dependency:
+To declare an ignore-plugin, first install `@stryker-mutator/api` as a dev dependency:
 
 ```
 npm i -D @stryker-mutator/api
@@ -213,9 +213,9 @@ Now add a "stryker-console-ignorer.js" to your project:
 // stryker-console-ignorer.js
 import { PluginKind, declareValuePlugin } from '@stryker-mutator/api/plugin';
 
-export const strykerPlugins = [declareValuePlugin(PluginKind.Ignorer, 'console.debug', {
+export const strykerPlugins = [declareValuePlugin(PluginKind.Ignore, 'console.debug', {
   shouldIgnore(path) {
-    // Define the conditions for which you want to ignore mutants using visitor
+    // Define the conditions for which you want to ignore mutants
     if (
       path.isExpressionStatement() &&
       path.node.expression.type === 'CallExpression' &&
@@ -232,13 +232,9 @@ export const strykerPlugins = [declareValuePlugin(PluginKind.Ignorer, 'console.d
 })];
 ```
 
-:::info
+In the above example, you declare an ignore-plugin with the name `'console.debug'` and an `Ignorer`. An `Ignorer` is an object with a `shouldIgnore(path)` method. Stryker will execute this method on each node of the abstract syntax tree (AST). To ignore mutants in the current node and child nodes, return a non-empty ignore reason as a string here. The `path` parameter is a babel `NodePath` object, [see 'visiting' in the babel handbook](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#user-content-visiting) for more information on the `NodePath` API.
 
-In the above example, you declare an `Ignorer` plugin. An `Ignorer` is an object with a `shouldIgnore(path)` method. Stryker will execute this method on each node of the abstract syntax tree (AST). To ignore the current node, return a non-empty ignore reason as a string here. The `path` parameter is a babel `NodePath` object, [see 'visiting' in the babel handbook for more information](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#user-content-visiting)
-
-:::
-
-You configure this plugin in your stryker.config.json file:
+You configure this plugin in your 'stryker.config.json' file:
 
 ```json
 {
@@ -249,11 +245,11 @@ You configure this plugin in your stryker.config.json file:
 
 After rerunning Stryker, your report will look like this.
 
-![Ignorer plugin report](disable-mutants-ignorer.png))
+![Ignore-plugin report](./images/disable-mutants-ignorer.png)
 
 :::tip
 
-If you want some TypeScript type-safety on the `path` being passed into your ignorer plugin, you will need to install the babel types yourself: `npm i -D @types/babel__core` and add this TypeScript file somewhere in your project:
+If you want TypeScript type-safety on the `path` being passed into your ignore-plugin, you will need to install the babel types yourself: `npm i -D @types/babel__core` and add this TypeScript file somewhere in your project:
 
 ```ts
 /// <reference types="@stryker-mutator/api/ignore" />
@@ -263,5 +259,7 @@ declare module '@stryker-mutator/api/ignore' {
   export interface NodePath extends babel.NodePath {}
 }
 ```
+
+If you want to write the plugin itself as TypeScript as well, you will need to transpile it to JavaScript yourself. Either by doing it before you run Stryker, or using a just-in-time compiler like `ts-node`.
 
 :::

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -49,7 +49,7 @@ A checker plugin can _check_ a mutant before it is mutation tested. The check ca
 
 ## Ignorers
 
-With an ignorer plugin, you can ignore all mutants in a specific a code pattern. See [using an ignore plugin](./disable-mutants.md#using-an-ignorer-plugin) for more information.
+With an ignore-plugin, you can ignore all mutants in a specific a code pattern. See [using an ignore-plugin](./disable-mutants.md#using-an-ignorer-plugin) for more information.
 
 ## &lt;Your plugin here&gt;
 

--- a/e2e/test/ignore-project/stryker-plugins/ignorers/console-ignorer.js
+++ b/e2e/test/ignore-project/stryker-plugins/ignorers/console-ignorer.js
@@ -2,7 +2,7 @@
 import { PluginKind, declareValuePlugin } from '@stryker-mutator/api/plugin';
 
 export const strykerPlugins = [
-  declareValuePlugin(PluginKind.Ignorer, 'ConsoleIgnorer', {
+  declareValuePlugin(PluginKind.Ignore, 'ConsoleIgnorer', {
     shouldIgnore(path) {
       if (
         path.isExpressionStatement() &&

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -533,7 +533,7 @@
       "default": false
     },
     "ignorers": {
-      "description": "Enable ignorer plugins here. An ignorer plugin will be invoked on each AST node visitation and can decide to ignore the node or not. This can be useful for example to ignore all mutants in a console.log() statement.",
+      "description": "Specify which ignore-plugins to use. With an ignore-plugin you can ignore mutants inside common code patterns that you don't want to test for some reason. For example, you can use this to ignore all `console.debug()` statements from being mutated.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/api/src/plugin/plugin-kind.ts
+++ b/packages/api/src/plugin/plugin-kind.ts
@@ -5,5 +5,5 @@ export enum PluginKind {
   Checker = 'Checker',
   TestRunner = 'TestRunner',
   Reporter = 'Reporter',
-  Ignorer = 'Ignorer',
+  Ignore = 'Ignore',
 }

--- a/packages/api/src/plugin/plugins.ts
+++ b/packages/api/src/plugin/plugins.ts
@@ -112,7 +112,7 @@ export interface PluginInterfaces {
   [PluginKind.Reporter]: Reporter;
   [PluginKind.TestRunner]: TestRunner;
   [PluginKind.Checker]: Checker;
-  [PluginKind.Ignorer]: Ignorer;
+  [PluginKind.Ignore]: Ignorer;
 }
 
 /**

--- a/packages/core/src/process/2-mutant-instrumenter-executor.ts
+++ b/packages/core/src/process/2-mutant-instrumenter-executor.ts
@@ -48,7 +48,7 @@ export class MutantInstrumenterExecutor {
     const instrumenter = this.injector.injectFunction(createInstrumenter);
 
     // Instrument files in-memory
-    const ignorers = this.options.ignorers.map((name) => this.pluginCreator.create(PluginKind.Ignorer, name));
+    const ignorers = this.options.ignorers.map((name) => this.pluginCreator.create(PluginKind.Ignore, name));
     const instrumentResult = await instrumenter.instrument(await this.readFilesToMutate(), { ignorers, ...this.options.mutator });
 
     // Preprocess the project

--- a/packages/core/test/integration/di/plugins.it.spec.ts
+++ b/packages/core/test/integration/di/plugins.it.spec.ts
@@ -18,7 +18,7 @@ describe('Plugins integration', () => {
     });
 
     it('should be able to load a "ValuePlugin"', async () => {
-      const plugin = pluginCreator.create(PluginKind.Ignorer, 'console.debug');
+      const plugin = pluginCreator.create(PluginKind.Ignore, 'console.debug');
       expect(plugin).ok;
       expect(plugin.shouldIgnore).a('function');
     });

--- a/packages/core/test/unit/process/2-mutant-instrumenter-executor.spec.ts
+++ b/packages/core/test/unit/process/2-mutant-instrumenter-executor.spec.ts
@@ -87,7 +87,7 @@ describe(MutantInstrumenterExecutor.name, () => {
       [{ name: 'foo.js', content: 'console.log("bar")', mutate: true }],
       expectedInstrumenterOptions,
     );
-    sinon.assert.calledOnceWithExactly(pluginCreatorMock.create, PluginKind.Ignorer, 'notIgnorer');
+    sinon.assert.calledOnceWithExactly(pluginCreatorMock.create, PluginKind.Ignore, 'notIgnorer');
   });
 
   it('result in the new injector', async () => {

--- a/packages/core/testResources/plugins/custom-plugins.js
+++ b/packages/core/testResources/plugins/custom-plugins.js
@@ -24,7 +24,7 @@ class MyReporter {
 /** 
  * @param {Injector} _injector
  * @returns {TestRunner} 
- */1
+ */
 function createLazyTestRunner(_injector) {
   return {
     capabilities() {
@@ -50,7 +50,7 @@ createLazyTestRunner.inject = [commonTokens.injector];
 export const strykerPlugins = [
   declareClassPlugin(PluginKind.Reporter, 'console', MyReporter),
   declareFactoryPlugin(PluginKind.TestRunner, 'lazy', createLazyTestRunner),
-  declareValuePlugin(PluginKind.Ignorer, 'console.debug', {
+  declareValuePlugin(PluginKind.Ignore, 'console.debug', {
     shouldIgnore(path) {
       if (
         path.isExpresssionStatement() &&

--- a/packages/instrumenter/src/transformers/ignorer-bookkeeper.ts
+++ b/packages/instrumenter/src/transformers/ignorer-bookkeeper.ts
@@ -8,7 +8,7 @@ declare module '@stryker-mutator/api/ignore' {
 }
 
 /**
- * Responsible for keeping track of the active ignore message and node using the configured ignorer plugins.
+ * Responsible for keeping track of the active ignore message and node using the configured ignore-plugins.
  */
 export class IgnorerBookkeeper {
   private readonly ignorers;


### PR DESCRIPTION
Small refactor in the naming of things
- `PluginKind.Ignorer` -> `PluginKind.Ignore`
- "ignorer plugin" -> "ignore-plugin"

Keep the name of "ignorers", because "ignore" itself has no plural. Also keep the name of the interface "Ignorer", because it is an ignorer object.