### PR TITLE
doc(troubleshooting): fix broken code block

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -350,11 +350,11 @@ To keep using `module-alias`, there are 2 workarounds:
 
 1. Mark the `node_modules` folder as part of your sandbox:
 
-  ```diff
-  {
-  +  "ignorePatterns": ["!node_modules"],
-  +  "symlinkNodeModules": false
-  }
-  ```
+```diff
+{
++  "ignorePatterns": ["!node_modules"],
++  "symlinkNodeModules": false
+}
+```
 
 2. Let StrykerJS mutate your files in place: `npx stryker run --inPlace`


### PR DESCRIPTION
Troubleshooting section introduced in ce3e5cd has a broken code block likely due to the indentation (markdown parsing issue) 😞 

<img width="839" alt="Screenshot 2023-10-23 at 18 36 25" src="https://github.com/stryker-mutator/stryker-js/assets/324670/1b99e6a3-10d4-49f4-a261-cb5c38a16cea">

This PR removes the indentation from the code block. 

~❕ _The fix has not been tested, the assumption is that the codeblock will render the same as other non-indented `diff` codeblocks._~

Manually tested using `stryker-mutator.github.io` repo.

<img width="853" alt="Screenshot 2023-10-23 at 18 53 03" src="https://github.com/stryker-mutator/stryker-js/assets/324670/b34b5d90-851f-4af3-85dd-6a1e07e255f3">

