### PR TITLE
feat(core): Add .next, .nuxt and .svelte-kit to ignorePattern

### DIFF
--- a/packages/core/src/fs/project-reader.ts
+++ b/packages/core/src/fs/project-reader.ts
@@ -16,7 +16,7 @@ import { coreTokens } from '../di/index.js';
 import { Project } from './project.js';
 import { FileSystem } from './file-system.js';
 
-const ALWAYS_IGNORE = Object.freeze(['node_modules', '.git', '*.tsbuildinfo', '/stryker.log']);
+const ALWAYS_IGNORE = Object.freeze(['node_modules', '.git', '*.tsbuildinfo', '/stryker.log', '.next', '.nuxt', '.svelte-kit']);
 
 export const IGNORE_PATTERN_CHARACTER = '!';
 /**

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -24,7 +24,7 @@ describe(ProjectReader.name, () => {
       const sut = createSut();
       await sut.read();
       expect(testInjector.logger.warn).calledWith(
-        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".stryker-tmp","reports/stryker-incremental.json","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
+        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".next",".nuxt",".svelte-kit",".stryker-tmp","reports/stryker-incremental.json","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
       );
     });
     it('should discover files recursively using readdir', async () => {


### PR DESCRIPTION
Added .next, .nuxt and .svelte-kit to the `ALWAYS_IGNORE` so it gets included in the ignorePattern
Closes #4571