### PR TITLE
feat(typescript-checker): support prerelease TypeScript versions

### DIFF
--- a/packages/typescript-checker/src/tsconfig-helpers.ts
+++ b/packages/typescript-checker/src/tsconfig-helpers.ts
@@ -28,7 +28,7 @@ const LOW_EMIT_OPTIONS_FOR_PROJECT_REFERENCES: Readonly<Partial<ts.CompilerOptio
 });
 
 export function guardTSVersion(version = ts.version): void {
-  if (!semver.satisfies(version, '>=3.6')) {
+  if (!semver.satisfies(version, '>=3.6', { includePrerelease: true })) {
     throw new Error(`@stryker-mutator/typescript-checker only supports typescript@3.6 or higher. Found typescript@${version}`);
   }
 }

--- a/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
+++ b/packages/typescript-checker/test/unit/typescript-helpers.spec.ts
@@ -200,11 +200,19 @@ describe('typescript-helpers', () => {
         '@stryker-mutator/typescript-checker only supports typescript@3.6 or higher. Found typescript@3.5.0',
       );
     });
+    it('should throw if typescript@3.5.0-beta', () => {
+      expect(guardTSVersion.bind(undefined, '3.5.0-beta')).throws(
+        '@stryker-mutator/typescript-checker only supports typescript@3.6 or higher. Found typescript@3.5.0-beta',
+      );
+    });
     it('should not throw if typescript@3.6.0', () => {
       expect(guardTSVersion.bind(undefined, '3.6.0')).not.throws();
     });
     it('should not throw if typescript@4.0.0', () => {
       expect(guardTSVersion.bind(undefined, '4.0.0')).not.throws();
+    });
+    it('should not throw if typescript@5.4.0-beta', () => {
+      expect(guardTSVersion.bind(undefined, '5.4.0-beta')).not.throws();
     });
   });
 


### PR DESCRIPTION
Stryker fails at launch when using `v5.4.0-beta` of TypeScript, displaying:
> `Error: @stryker-mutator/typescript-checker only supports typescript@3.6 or higher. Found typescript@5.4.0-beta`

This PR allows prerelease versions of TypeScript.