### PR TITLE
fix(instrumenter): don't place mutants inside delete expressions

### DIFF
--- a/packages/instrumenter/src/mutant-placers/expression-mutant-placer.ts
+++ b/packages/instrumenter/src/mutant-placers/expression-mutant-placer.ts
@@ -1,7 +1,5 @@
 import babel, { type NodePath } from '@babel/core';
 
-import { satisfies } from 'semver';
-
 import { mutantTestExpression, mutationCoverageSequenceExpression } from '../util/syntax-helpers.js';
 
 import { MutantPlacer } from './mutant-placer.js';

--- a/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
+++ b/packages/instrumenter/test/unit/mutant-placers/expression-mutant-placer.spec.ts
@@ -35,6 +35,20 @@ describe('expressionMutantPlacer', () => {
       expect(expressionMutantPlacer.canPlace(templateLiteral)).false;
     });
 
+    it('should be false when the parent is a delete unary expression', () => {
+      const memberExpression = findNodePath(parseJS('delete myVariable?.[indexer];'), (p) => p.isOptionalMemberExpression());
+      expect(expressionMutantPlacer.canPlace(memberExpression)).false;
+    });
+
+    it('should be true when the parent is a non-delete unary expression', () => {
+      const memberExpression = findNodePath(parseJS('void myVariable[indexer];'), (p) => p.isMemberExpression());
+      const memberExpression2 = findNodePath(parseJS('typeof myVariable[indexer];'), (p) => p.isMemberExpression());
+      const memberExpression3 = findNodePath(parseJS('throw myVariable[indexer];'), (p) => p.isMemberExpression());
+      expect(expressionMutantPlacer.canPlace(memberExpression)).true;
+      expect(expressionMutantPlacer.canPlace(memberExpression2)).true;
+      expect(expressionMutantPlacer.canPlace(memberExpression3)).true;
+    });
+
     describe('object literals', () => {
       it('should be false when the expression is a key', () => {
         // A stringLiteral is considered an expression, while it is not save to place a mutant there!

--- a/packages/instrumenter/testResources/instrumenter/optional-chains.ts
+++ b/packages/instrumenter/testResources/instrumenter/optional-chains.ts
@@ -12,3 +12,7 @@ input?.id!.toString();
 bar?.baz[0]
 
 state.stats[organization?.organization_id] = action.payload.stats;
+
+// https://github.com/stryker-mutator/stryker-js/issues/4741
+delete myVariable?.[indexer]; 
+void foo?.();

--- a/packages/instrumenter/testResources/instrumenter/optional-chains.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/optional-chains.ts.out.snap
@@ -53,5 +53,9 @@ const directiveRanges = stryMutAct_9fa48(\\"6\\") ? comments.map(tryParseTSDirec
 const qux = quux(stryMutAct_9fa48(\\"7\\") ? corge.cov() : (stryCov_9fa48(\\"7\\"), corge?.cov()));
 stryMutAct_9fa48(\\"8\\") ? input.id!.toString() : (stryCov_9fa48(\\"8\\"), input?.id!.toString());
 stryMutAct_9fa48(\\"9\\") ? bar.baz[0] : (stryCov_9fa48(\\"9\\"), bar?.baz[0]);
-state.stats[stryMutAct_9fa48(\\"10\\") ? organization.organization_id : (stryCov_9fa48(\\"10\\"), organization?.organization_id)] = action.payload.stats;"
+state.stats[stryMutAct_9fa48(\\"10\\") ? organization.organization_id : (stryCov_9fa48(\\"10\\"), organization?.organization_id)] = action.payload.stats;
+
+// https://github.com/stryker-mutator/stryker-js/issues/4741
+stryMutAct_9fa48(\\"11\\") ? delete myVariable[indexer] : (stryCov_9fa48(\\"11\\"), delete myVariable?.[indexer]);
+void (stryMutAct_9fa48(\\"12\\") ? foo() : (stryCov_9fa48(\\"12\\"), foo?.()));"
 `;


### PR DESCRIPTION
Don't place mutants inside a delete expression.

Before:

```js
delete stryMutAct_9fa48(\\"11\\") ? myVariable[indexer] : (stryCov_9fa48(\\"11\\"), myVariable?.[indexer]);
```

After:

```js
stryMutAct_9fa48(\\"11\\") ? delete myVariable[indexer] : (stryCov_9fa48(\\"11\\"), delete myVariable?.[indexer]);
```

Fixes #4741