### PR TITLE
fix(instrumenter): support typescript constructors with code before `super()`

### DIFF
--- a/packages/instrumenter/src/transformers/babel-transformer.ts
+++ b/packages/instrumenter/src/transformers/babel-transformer.ts
@@ -144,10 +144,7 @@ export const transformBabel: AstTransformer<ScriptFormat> = (
    */
   function collectMutants(path: NodePath) {
     return [...mutate(path)]
-      .map((mutable) => {
-        const mutant = mutantCollector.collect(originFileName, path.node, mutable, offset);
-        return mutant;
-      })
+      .map((mutable) => mutantCollector.collect(originFileName, path.node, mutable, offset))
       .filter((mutant) => !mutant.ignoreReason);
   }
 

--- a/packages/instrumenter/test/unit/mutators/block-statement-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/block-statement-mutator.spec.ts
@@ -49,7 +49,7 @@ describe(sut.name, () => {
       expectJSMutation(sut, 'class Foo { constructor() { bar(); } }', 'class Foo { constructor() {} }');
     });
 
-    it('should mutate a constructor with (typescript) parameter properties', () => {
+    it('should mutate a constructor with (typescript) parameter properties without a `super()` call', () => {
       expectJSMutation(sut, 'class Foo { constructor(private baz: string) { bar(); } }', 'class Foo { constructor(private baz: string) {} }');
     });
 
@@ -59,16 +59,26 @@ describe(sut.name, () => {
 
     /**
      * @see https://github.com/stryker-mutator/stryker-js/issues/2314
+     * @see https://github.com/stryker-mutator/stryker-js/issues/4744
      */
     it('should not mutate a constructor containing a super call and has (typescript) parameter properties', () => {
       expectJSMutation(sut, 'class Foo extends Bar { constructor(private baz: string) { super(); } }');
+      expectJSMutation(
+        sut,
+        'class Foo extends Bar { constructor(private baz: string) { const errorBody: Body = { message: `msg: ${baz}` }; super(errorBody);  } }',
+      );
     });
 
     /**
      * @see https://github.com/stryker-mutator/stryker-js/issues/2474
+     * @see https://github.com/stryker-mutator/stryker-js/issues/4744
      */
     it('should not mutate a constructor containing a super call and contains initialized properties', () => {
       expectJSMutation(sut, 'class Foo extends Bar { private baz = "qux"; constructor() { super(); } }');
+      expectJSMutation(
+        sut,
+        'class Foo extends Bar { private baz = "qux"; constructor() { const errorBody: Body = { message: `msg: ${baz}` }; super(errorBody);  } }',
+      );
     });
   });
 });

--- a/packages/instrumenter/testResources/instrumenter/super-call.ts
+++ b/packages/instrumenter/testResources/instrumenter/super-call.ts
@@ -3,3 +3,15 @@ export class InjectionError extends TypedInjectError {
     super(`Could not ${describeInjectAction(path[0])} ${path.map(name).join(' -> ')}. Cause: ${cause.message}`);
   }
 }
+
+// See https://github.com/stryker-mutator/stryker-js/issues/4744
+export class UniqueKeyFailedError<T> extends UnprocessableEntityException {
+  constructor(public readonly fields: ReadonlyArray<keyof T & string>) {
+    const errorBody: UnprocessableEntityBody<T> = {
+      status: 'uniqueness_failed',
+      fields,
+    };
+    super(errorBody);
+    console.log(`${this.message} created`);
+  }
+}

--- a/packages/instrumenter/testResources/instrumenter/super-call.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/super-call.ts.out.snap
@@ -51,5 +51,17 @@ export class InjectionError extends TypedInjectError {
   constructor(public readonly path: InjectionTarget[], public readonly cause: Error) {
     super(stryMutAct_9fa48(\\"0\\") ? \`\` : (stryCov_9fa48(\\"0\\"), \`Could not \${describeInjectAction(path[0])} \${path.map(name).join(stryMutAct_9fa48(\\"1\\") ? \\"\\" : (stryCov_9fa48(\\"1\\"), ' -> '))}. Cause: \${cause.message}\`));
   }
+}
+
+// See https://github.com/stryker-mutator/stryker-js/issues/4744
+export class UniqueKeyFailedError<T> extends UnprocessableEntityException {
+  constructor(public readonly fields: ReadonlyArray<keyof T & string>) {
+    const errorBody: UnprocessableEntityBody<T> = stryMutAct_9fa48(\\"2\\") ? {} : (stryCov_9fa48(\\"2\\"), {
+      status: stryMutAct_9fa48(\\"3\\") ? \\"\\" : (stryCov_9fa48(\\"3\\"), 'uniqueness_failed'),
+      fields
+    });
+    super(errorBody);
+    console.log(stryMutAct_9fa48(\\"4\\") ? \`\` : (stryCov_9fa48(\\"4\\"), \`\${this.message} created\`));
+  }
 }"
 `;


### PR DESCRIPTION
Support constructors in TypeScript that have some code before the `super()` call and have constructor properties or initialized class properties. In such cases, the block statement mutator is not applied.

For more info, see #4744
Fixes #4744
