### PR TITLE
docs: Make link clickable

### DIFF
--- a/packages/core/src/mutants/mutant-test-planner.ts
+++ b/packages/core/src/mutants/mutant-test-planner.ts
@@ -192,7 +192,7 @@ export class MutantTestPlanner {
             staticRunPlans.length / runPlans.length,
           )}% of total) that are estimated to take ${percentage(
             relativeTimeForStaticMutants,
-          )}% of the time running the tests!\n  You might want to enable "ignoreStatic" to ignore these static mutants for your next run. \n  For more information about static mutants visit: https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants.\n  (disable "${optionsPath(
+          )}% of the time running the tests!\n  You might want to enable "ignoreStatic" to ignore these static mutants for your next run. \n  For more information about static mutants visit: https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants\n  (disable "${optionsPath(
             'warnings',
             'slow',
           )}" to ignore this warning)`,


### PR DESCRIPTION
In a terminal on Windows the "." becomes part of the URL, so when you click it you will end up on a 404 page. That's why I suggest removing the "." at the end.

**Screenshot:**

![image](https://github.com/stryker-mutator/stryker-js/assets/469989/ca43dd96-bf8e-41e9-91b5-3866d6e4e4fa)
