### PR TITLE
fix(mocha-runner): compatibility with Mocha v10.5.1 and up

### DIFF
--- a/packages/mocha-runner/src/lib-wrapper.ts
+++ b/packages/mocha-runner/src/lib-wrapper.ts
@@ -13,7 +13,7 @@ const mochaRoot = path.dirname(require.resolve('mocha/package.json'));
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const runHelpers = require(`${mochaRoot}/lib/cli/run-helpers`);
 
-let collectFiles: ((options: MochaOptions) => string[]) | undefined;
+let collectFiles: ((options: MochaOptions) => string[] | { files: string[]; unmatchedFiles: string[] }) | undefined;
 
 /*
  * If read, object containing parsed arguments

--- a/packages/mocha-runner/src/mocha-adapter.ts
+++ b/packages/mocha-runner/src/mocha-adapter.ts
@@ -31,7 +31,11 @@ export class MochaAdapter {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       (process as any).exit = () => {};
       const files = LibWrapper.collectFiles!(options);
-      return files;
+      if (Array.isArray(files)) {
+        return files;
+      } else {
+        return files.files;
+      }
     } finally {
       process.exit = originalProcessExit;
     }


### PR DESCRIPTION
Fixes #4883

Update the `mocha-adapter.ts` of the mocha-runner to be compatible with v10.5.1 of Mocha. To preserve compatibility with earlier versions of Mocha, a runtime check for the return value of the affected Mocha API is added.