### PR TITLE
docs: update link to peerDependencies in cucumber-runner

### DIFF
--- a/docs/cucumber-runner.md
+++ b/docs/cucumber-runner.md
@@ -25,7 +25,7 @@ As such, you should make sure you have the correct versions of its dependencies 
 - `@cucumber/cucumber`
 - `@stryker-mutator/core`
 
-You can find the [`peerDependencies` in @stryker-mutator/cucumber-runner's package.json file](https://github.com/stryker-mutator/stryker-js/blob/master/packages/cucumber-runner/package.json#L36).
+You can find the [`peerDependencies` in @stryker-mutator/cucumber-runner's package.json file](https://github.com/stryker-mutator/stryker-js/blob/HEAD/packages/cucumber-runner/package.json#L53-L56).
 
 ## Configuring
 


### PR DESCRIPTION
Update link to _peerDependencies in @stryker-mutator/cucumber-runner's package.json file_ in [_Cucumber Runner_](https://stryker-mutator.io/docs/stryker-js/cucumber-runner/#peer-dependencies) page.