### PR TITLE
refactor(logging): remove dependency on `get-port`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12746,18 +12746,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-stream": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
@@ -26825,7 +26813,6 @@
         "emoji-regex": "~10.4.0",
         "execa": "~9.4.0",
         "file-url": "~4.0.0",
-        "get-port": "~7.1.0",
         "lodash.groupby": "~4.6.0",
         "minimatch": "~9.0.5",
         "mutation-testing-elements": "3.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,6 @@
     "emoji-regex": "~10.4.0",
     "execa": "~9.4.0",
     "file-url": "~4.0.0",
-    "get-port": "~7.1.0",
     "lodash.groupby": "~4.6.0",
     "minimatch": "~9.0.5",
     "mutation-testing-elements": "3.3.0",

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,4 @@
 export * from './file-utils.js';
-export * from './net-utils.js';
 export * from './object-utils.js';
 export * from './string-builder.js';
 export * from './string-utils.js';

--- a/packages/core/src/utils/net-utils.ts
+++ b/packages/core/src/utils/net-utils.ts
@@ -1,8 +1,0 @@
-import getPort from 'get-port';
-
-export const netUtils = {
-  /**
-   * A wrapper around `getPort` for testing purposes
-   */
-  getFreePort: getPort,
-};


### PR DESCRIPTION
Remove the dependency on `get-port`. I forgot to remove it in #5111.
