### PR TITLE
feat(temp-dir): allow multiple instances to share the same temp-dir

### DIFF
--- a/packages/core/src/reporters/event-recorder-reporter.ts
+++ b/packages/core/src/reporters/event-recorder-reporter.ts
@@ -21,7 +21,7 @@ export class EventRecorderReporter implements StrictReporter {
     private readonly log: Logger,
     private readonly options: StrykerOptions,
   ) {
-    this.createBaseFolderTask = fileUtils.cleanFolder(this.options.eventReporter.baseDir);
+    this.createBaseFolderTask = fileUtils.cleanDir(this.options.eventReporter.baseDir);
   }
 
   private writeToFile(methodName: keyof Reporter, data: any) {

--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -4,17 +4,16 @@ import fs from 'fs';
 import { isErrnoException } from '@stryker-mutator/util';
 
 export const fileUtils = {
-  deleteDir(dir: string): Promise<void> {
-    return fs.promises.rm(dir, { recursive: true, force: true });
-  },
-
-  async cleanFolder(folderName: string): Promise<string | undefined> {
+  /**
+   * Cleans the dir by creating it.
+   */
+  async cleanDir(dirName: string): Promise<string | undefined> {
     try {
-      await fs.promises.lstat(folderName);
-      await this.deleteDir(folderName);
-      return fs.promises.mkdir(folderName, { recursive: true });
+      await fs.promises.lstat(dirName);
+      await fs.promises.rm(dirName, { recursive: true, force: true });
+      return fs.promises.mkdir(dirName, { recursive: true });
     } catch {
-      return fs.promises.mkdir(folderName, { recursive: true });
+      return fs.promises.mkdir(dirName, { recursive: true });
     }
   },
 

--- a/packages/core/src/utils/object-utils.ts
+++ b/packages/core/src/utils/object-utils.ts
@@ -71,12 +71,4 @@ export const objectUtils = {
       }
     });
   },
-
-  /**
-   * Creates a random integer number.
-   * @returns A random integer.
-   */
-  random(): number {
-    return Math.ceil(Math.random() * 10000000);
-  },
 };

--- a/packages/core/test/integration/utils/file-utils.it.spec.ts
+++ b/packages/core/test/integration/utils/file-utils.it.spec.ts
@@ -13,7 +13,7 @@ describe('fileUtils', () => {
     const to = path.resolve(os.tmpdir(), 'moveDirectoryRecursiveSyncTo');
 
     afterEach(async () => {
-      await Promise.all([fileUtils.deleteDir(from), fileUtils.deleteDir(to)]);
+      await Promise.all([fsPromises.rm(from, { recursive: true, force: true }), fsPromises.rm(to, { recursive: true, force: true })]);
     });
 
     it('should override target files', async () => {

--- a/packages/core/test/unit/reporters/event-recorder-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/event-recorder-reporter.spec.ts
@@ -11,23 +11,23 @@ import { fileUtils } from '../../../src/utils/file-utils.js';
 
 describe(EventRecorderReporter.name, () => {
   let sut: StrictReporter;
-  let cleanFolderStub: sinon.SinonStub;
+  let cleanDirStub: sinon.SinonStub;
   let writeFileStub: sinon.SinonStub;
 
   beforeEach(() => {
-    cleanFolderStub = sinon.stub(fileUtils, 'cleanFolder');
     writeFileStub = sinon.stub(fs.promises, 'writeFile');
+    cleanDirStub = sinon.stub(fileUtils, 'cleanDir');
   });
 
   describe('when constructed with empty options', () => {
     describe('and cleanFolder resolves correctly', () => {
       beforeEach(() => {
-        cleanFolderStub.returns(Promise.resolve());
+        cleanDirStub.returns(Promise.resolve());
         sut = testInjector.injector.injectClass(EventRecorderReporter);
       });
 
       it('should clean the baseFolder', () => {
-        expect(fileUtils.cleanFolder).to.have.been.calledWith('reports/mutation/events');
+        expect(fileUtils.cleanDir).to.have.been.calledWith('reports/mutation/events');
       });
 
       const arrangeActAssertEvent = (eventName: keyof Reporter) => {
@@ -68,7 +68,7 @@ describe(EventRecorderReporter.name, () => {
       let expectedError: Error;
       beforeEach(() => {
         expectedError = new Error('Some error 1');
-        cleanFolderStub.rejects(expectedError);
+        cleanDirStub.rejects(expectedError);
         sut = testInjector.injector.injectClass(EventRecorderReporter);
       });
 

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -25,12 +25,11 @@ describe(Sandbox.name, () => {
   let unexpectedExitHandlerMock: sinon.SinonStubbedInstance<I<UnexpectedExitHandler>>;
   let moveDirectoryRecursiveSyncStub: sinon.SinonStub;
   let fsTestDouble: FileSystemTestDouble;
-  const SANDBOX_WORKING_DIR = path.resolve('.stryker-tmp/sandbox-123');
-  const BACKUP_DIR = 'backup-123';
+  const SANDBOX_WORKING_DIR = '.stryker-tmp/sandbox-123';
 
   beforeEach(() => {
     temporaryDirectoryMock = sinon.createStubInstance(TemporaryDirectory);
-    temporaryDirectoryMock.getRandomDirectory.withArgs('sandbox').returns(SANDBOX_WORKING_DIR).withArgs('backup').returns(BACKUP_DIR);
+    sinon.stub(temporaryDirectoryMock, 'path').value(SANDBOX_WORKING_DIR);
     symlinkJunctionStub = sinon.stub(fileUtils, 'symlinkJunction');
     findNodeModulesListStub = sinon.stub(fileUtils, 'findNodeModulesList');
     moveDirectoryRecursiveSyncStub = sinon.stub(fileUtils, 'moveDirectoryRecursiveSync');
@@ -66,13 +65,6 @@ describe(Sandbox.name, () => {
     describe('with inPlace = false', () => {
       beforeEach(() => {
         testInjector.options.inPlace = false;
-      });
-
-      it('should have created a sandbox folder', async () => {
-        const sut = createSut();
-        await sut.init();
-        expect(temporaryDirectoryMock.getRandomDirectory).calledWith('sandbox');
-        expect(temporaryDirectoryMock.createDirectory).calledWith(SANDBOX_WORKING_DIR);
       });
 
       it('should copy regular input files', async () => {
@@ -113,13 +105,6 @@ describe(Sandbox.name, () => {
         testInjector.options.inPlace = true;
       });
 
-      it('should have created a backup directory', async () => {
-        const sut = createSut();
-        await sut.init();
-        expect(temporaryDirectoryMock.getRandomDirectory).calledWith('backup');
-        expect(temporaryDirectoryMock.createDirectory).calledWith(BACKUP_DIR);
-      });
-
       it('should not override the current file if no changes were detected', async () => {
         fsTestDouble.files[path.resolve('a', 'b.txt')] = 'b content';
         const sut = createSut();
@@ -150,7 +135,7 @@ describe(Sandbox.name, () => {
         fsTestDouble.files[fileName] = originalContent;
         const project = new Project(fsTestDouble, { [fileName]: { mutate: true } });
         project.files.get(fileName)!.setContent(mutatedContent);
-        const expectedBackupFileName = path.join(path.join(BACKUP_DIR, 'a'), 'b.js');
+        const expectedBackupFileName = path.join(path.join(SANDBOX_WORKING_DIR, 'a'), 'b.js');
 
         // Act
         const sut = createSut(project);
@@ -169,7 +154,7 @@ describe(Sandbox.name, () => {
         fsTestDouble.files[fileName] = originalContent;
         const project = new Project(fsTestDouble, { [fileName]: { mutate: true } });
         project.files.get(fileName)!.setContent(mutatedContent);
-        const expectedBackupFileName = path.join(path.join(BACKUP_DIR, 'a'), 'b.js');
+        const expectedBackupFileName = path.join(path.join(SANDBOX_WORKING_DIR, 'a'), 'b.js');
 
         // Act
         const sut = createSut(project);
@@ -280,7 +265,7 @@ describe(Sandbox.name, () => {
       testInjector.options.inPlace = true;
       const sut = createSut();
       sut.dispose();
-      expect(moveDirectoryRecursiveSyncStub).calledWith(BACKUP_DIR, process.cwd());
+      sinon.assert.calledWithExactly(moveDirectoryRecursiveSyncStub, SANDBOX_WORKING_DIR, process.cwd());
     });
 
     it('should recover from the backup dir if stryker exits unexpectedly while inPlace = true', () => {
@@ -288,8 +273,8 @@ describe(Sandbox.name, () => {
       const errorStub = sinon.stub(console, 'error');
       createSut();
       unexpectedExitHandlerMock.registerHandler.callArg(0);
-      expect(moveDirectoryRecursiveSyncStub).calledWith(BACKUP_DIR, process.cwd());
-      expect(errorStub).calledWith(`Detecting unexpected exit, recovering original files from ${BACKUP_DIR}`);
+      expect(moveDirectoryRecursiveSyncStub).calledWith(SANDBOX_WORKING_DIR, process.cwd());
+      expect(errorStub).calledWith(`Detecting unexpected exit, recovering original files from ${SANDBOX_WORKING_DIR}`);
     });
   });
 
@@ -307,25 +292,6 @@ describe(Sandbox.name, () => {
       expect(sut.workingDirectory).eq(process.cwd());
     });
   });
-
-  // describe(Sandbox.prototype.sandboxFileFor.name, () => {
-  //   it('should return the sandbox file if exists', async () => {
-  //     const originalFileName = path.resolve('src/foo.js');
-  //     fsTestDouble.push(new File(originalFileName, ''));
-  //     const sut = createSut();
-  //     await sut.init();
-  //     const actualSandboxFile = sut.sandboxFileFor(originalFileName);
-  //     expect(actualSandboxFile).eq(path.join(SANDBOX_WORKING_DIR, 'src/foo.js'));
-  //   });
-
-  //   it("should throw when the sandbox file doesn't exists", async () => {
-  //     const notExistingFile = 'src/bar.js';
-  //     fsTestDouble.push(new File(path.resolve('src/foo.js'), ''));
-  //     const sut = createSut();
-  //     await sut.init();
-  //     expect(() => sut.sandboxFileFor(notExistingFile)).throws('Cannot find sandbox file for src/bar.js');
-  //   });
-  // });
 
   describe(Sandbox.prototype.originalFileFor.name, () => {
     it('should remap the file to the original', async () => {

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -25,7 +25,7 @@ describe(Sandbox.name, () => {
   let unexpectedExitHandlerMock: sinon.SinonStubbedInstance<I<UnexpectedExitHandler>>;
   let moveDirectoryRecursiveSyncStub: sinon.SinonStub;
   let fsTestDouble: FileSystemTestDouble;
-  const SANDBOX_WORKING_DIR = '.stryker-tmp/sandbox-123';
+  const SANDBOX_WORKING_DIR = path.join('.stryker-tmp', 'sandbox-123');
 
   beforeEach(() => {
     temporaryDirectoryMock = sinon.createStubInstance(TemporaryDirectory);

--- a/packages/core/test/unit/utils/temporary-directory.spec.ts
+++ b/packages/core/test/unit/utils/temporary-directory.spec.ts
@@ -4,80 +4,90 @@ import fs from 'fs';
 import { StrykerOptions } from '@stryker-mutator/api/core';
 import { commonTokens } from '@stryker-mutator/api/plugin';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
-import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { fileUtils } from '../../../src/utils/file-utils.js';
-import { objectUtils } from '../../../src/utils/object-utils.js';
 import { TemporaryDirectory } from '../../../src/utils/temporary-directory.js';
+import { expect } from 'chai';
 
 describe(TemporaryDirectory.name, () => {
-  let randomStub: sinon.SinonStubbedMember<typeof objectUtils.random>;
-  let deleteDirStub: sinon.SinonStub;
+  let mkdtempStub: sinon.SinonStubbedMember<typeof fs.promises.mkdtemp>;
+  let rmStub: sinon.SinonStubbedMember<typeof fs.promises.rm>;
   let mkdirStub: sinon.SinonStubbedMember<(typeof fs.promises)['mkdir']>;
+  let readdirStub: sinon.SinonStubbedMember<typeof fs.promises.readdir>;
+  let rmdirStub: sinon.SinonStubbedMember<typeof fs.promises.rmdir>;
   const tempDirName = '.stryker-tmp';
+  const sandboxPath = path.resolve(tempDirName, 'sandbox-123');
 
   beforeEach(() => {
     mkdirStub = sinon.stub(fs.promises, 'mkdir');
     sinon.stub(fs.promises, 'writeFile');
-    deleteDirStub = sinon.stub(fileUtils, 'deleteDir');
-    randomStub = sinon.stub(objectUtils, 'random');
+    rmStub = sinon.stub(fs.promises, 'rm');
+    mkdtempStub = sinon.stub(fs.promises, 'mkdtemp');
+    readdirStub = sinon.stub(fs.promises, 'readdir');
+    rmdirStub = sinon.stub(fs.promises, 'rmdir');
+    readdirStub.resolves([]);
+    mkdtempStub.resolves(path.resolve(tempDirName, 'sandbox-123'));
   });
 
   function createSut(options?: Partial<StrykerOptions>): TemporaryDirectory {
-    return testInjector.injector
-      .provideValue(commonTokens.logger, factory.logger())
-      .provideValue(commonTokens.options, factory.strykerOptions(options))
-      .injectClass(TemporaryDirectory);
+    return testInjector.injector.provideValue(commonTokens.options, factory.strykerOptions(options)).injectClass(TemporaryDirectory);
   }
 
-  describe(TemporaryDirectory.prototype.getRandomDirectory.name, () => {
-    it('should return a random directory with provided prefix', () => {
+  describe(TemporaryDirectory.prototype.initialize.name, () => {
+    it('should create the .stryker-tmp directory', async () => {
       const sut = createSut();
-      randomStub.returns(126891);
-      expect(sut.getRandomDirectory('stryker-prefix-')).eq(path.resolve(tempDirName, 'stryker-prefix-126891'));
+      await sut.initialize();
+      sinon.assert.calledWithExactly(mkdirStub, path.resolve(tempDirName), { recursive: true });
+    });
+
+    it('should create a sandbox directory', async () => {
+      const sut = createSut();
+      await sut.initialize();
+      sinon.assert.calledWithExactly(mkdtempStub, path.resolve(tempDirName, 'sandbox-'));
+    });
+
+    it('should create a backup directory when `inPlace` is set', async () => {
+      const sut = createSut({ inPlace: true });
+      await sut.initialize();
+      sinon.assert.calledWithExactly(mkdtempStub, path.resolve(tempDirName, 'backup-'));
     });
   });
 
-  describe(TemporaryDirectory.prototype.createDirectory.name, () => {
-    it('should create dir with correct path', async () => {
+  describe('path', () => {
+    it('should return the path when initialized', async () => {
       const sut = createSut();
       await sut.initialize();
-      await sut.createDirectory('some-dir');
-
-      sinon.assert.calledTwice(mkdirStub);
-      sinon.assert.calledWith(mkdirStub, path.resolve(tempDirName, 'some-dir'));
+      expect(sut.path).to.equal(sandboxPath);
     });
-    it('should reject when temp directory is not initialized', async () => {
+
+    it('should throw an error when the path is requested before initialization', () => {
       const sut = createSut();
-      await expect(sut.createDirectory('some-dir')).rejected;
+      expect(() => sut.path).to.throw('initialize() was not called!');
     });
   });
 
   describe('dispose', () => {
     it('should remove the dir if cleanTempDir option is true', async () => {
-      const expectedPath = path.resolve(tempDirName);
-      deleteDirStub.resolves();
+      rmStub.resolves();
       const sut = createSut({ cleanTempDir: true });
       await sut.initialize();
       await sut.dispose();
-      expect(fileUtils.deleteDir).calledWith(expectedPath);
+      sinon.assert.calledWithExactly(rmStub, sandboxPath, { recursive: true, force: true });
     });
 
     it("should remove the dir if cleanTempDir option is 'always'", async () => {
-      const expectedPath = path.resolve(tempDirName);
-      deleteDirStub.resolves();
+      rmStub.resolves();
       const sut = createSut({ cleanTempDir: 'always' });
       await sut.initialize();
       await sut.dispose();
-      expect(fileUtils.deleteDir).calledWith(expectedPath);
+      sinon.assert.calledWithExactly(rmStub, sandboxPath, { recursive: true, force: true });
     });
 
     it('should not remove the dir if cleanTempDir option is enabled', async () => {
       const sut = createSut({ cleanTempDir: false });
       await sut.initialize();
       await sut.dispose();
-      expect(fileUtils.deleteDir).not.called;
+      sinon.assert.notCalled(rmStub);
     });
 
     it('should not remove the dir if `removeDuringDisposal` is set to false', async () => {
@@ -85,20 +95,50 @@ describe(TemporaryDirectory.name, () => {
       await sut.initialize();
       sut.removeDuringDisposal = false;
       await sut.dispose();
-      expect(fileUtils.deleteDir).not.called;
+      sinon.assert.notCalled(rmStub);
     });
 
     it('should remove the dir by default', async () => {
       const sut = createSut();
       await sut.initialize();
-      deleteDirStub.resolves();
+      rmStub.resolves();
       await sut.dispose();
-      expect(fileUtils.deleteDir).calledOnce;
+      sinon.assert.calledOnce(rmStub);
     });
 
-    it('should reject when temp directory is not initialized', async () => {
+    it('should also remove the parent directory if it is empty', async () => {
       const sut = createSut();
-      await expect(sut.dispose()).rejected;
+      await sut.initialize();
+      rmStub.resolves();
+      readdirStub.resolves([]);
+      await sut.dispose();
+      sinon.assert.calledWithExactly(rmdirStub, tempDirName);
+    });
+
+    it('should log any errors on debug when failing to remove the parent directory', async () => {
+      const sut = createSut();
+      await sut.initialize();
+      rmStub.resolves();
+      readdirStub.resolves([]);
+      const expectedError = new Error('foo bar');
+      rmdirStub.rejects(expectedError);
+      await sut.dispose();
+      sinon.assert.calledWithExactly(testInjector.logger.debug, 'Failed to clean temp .stryker-tmp', expectedError);
+    });
+
+    it("should not remove the parent directory if it isn't empty", async () => {
+      const sut = createSut();
+      await sut.initialize();
+      rmStub.resolves();
+      readdirStub.resolves(['sandbox-798'] as unknown as fs.Dirent[]);
+      await sut.dispose();
+      sinon.assert.notCalled(rmdirStub);
+    });
+
+    it('should do nothing when temp directory was not initialized', async () => {
+      const sut = createSut();
+      await sut.dispose();
+      sinon.assert.notCalled(rmStub);
     });
   });
 });


### PR DESCRIPTION
Allow multiple runs of Stryker to share the same temp dir. This means that Stryker will _no longer remove the entire `.stryker-tmp` directory when it ran successfully (since other `sandbox-xxx` directories could be owned by other processes).

Note: this is implemented in preparation for the implementation of the mutation server protocol (#5086)
