### PR TITLE
chore(e2e): enforce `--force` when installing e2e

### DIFF
--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,1 @@
+force=true

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "download-incremental-reports": "./tasks/download-incremental-reports.sh",
     "test:mutation:incremental": "lerna run stryker --stream --concurrency 1 -- --incremental",
     "e2e": "npm run e2e:install && npm run e2e:lint && npm run e2e:run",
-    "e2e:install": "cd e2e && npm ci --force",
+    "e2e:install": "cd e2e && npm ci",
     "e2e:lint": "cd e2e && npm run lint",
     "e2e:run": "cd e2e && npm t",
     "e2e:update-snapshots": "CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm run e2e",


### PR DESCRIPTION
Prevents errors like

```
npm error While resolving: karma-vite@1.0.5
npm error Found: vite@6.3.3
npm error node_modules/vite
npm error   dev vite@"6.3.3" from the root project
npm error   peer vite@"^5.0.3 || ^6.0.0" from @sveltejs/kit@2.20.7
npm error   node_modules/@sveltejs/kit
npm error     dev @sveltejs/kit@"2.20.7" from the root project
npm error     peer @sveltejs/kit@"^2.0.0" from @sveltejs/adapter-auto@6.0.0
npm error     node_modules/@sveltejs/adapter-auto
npm error       dev @sveltejs/adapter-auto@"6.0.0" from the root project
npm error   7 more (@sveltejs/vite-plugin-svelte, ...)
npm error
npm error Could not resolve dependency:
npm error peer vite@"2 || 3 || 4 || 5" from karma-vite@1.0.5
npm error node_modules/karma-vite
npm error   dev karma-vite@"1.0.5" from the root project
npm error
npm error Conflicting peer dependency: vite@5.4.19
npm error node_modules/vite
npm error   peer vite@"2 || 3 || 4 || 5" from karma-vite@1.0.5
npm error   node_modules/karma-vite
npm error     dev karma-vite@"1.0.5" from the root project
npm error
```