### PR TITLE
feat(tap): provide `--test-reporter=tap` as default nodeArg

### DIFF
--- a/docs/tap-runner.md
+++ b/docs/tap-runner.md
@@ -59,10 +59,11 @@ Specify [glob expressions](./config-file.md#glob-patterns) to your test files. B
 | Version | Changes                                                   |
 | ------- | --------------------------------------------------------- |
 | 7.1     | Add `{{hookFile}}` and `{{testFile}}` placeholder support |
+| 9.0     | Changed default to include `--test-reporter=tap`          |
 
 </details>
 
-Default: `["-r", "{{hookFile}}", "{{testFile}}"]`
+Default: `["--test-reporter=tap", "-r", "{{hookFile}}", "{{testFile}}"]`
 
 Specify node arguments to be used when running the tests. You can use the following placeholders:
 

--- a/packages/tap-runner/schema/tap-runner-options.json
+++ b/packages/tap-runner/schema/tap-runner-options.json
@@ -25,7 +25,7 @@
           "items": {
             "type": "string"
           },
-          "default": ["-r", "{{hookFile}}", "{{testFile}}"]
+          "default": ["--test-reporter=tap", "-r", "{{hookFile}}", "{{testFile}}"]
         },
         "forceBail": {
           "description": "Force a running test process to hard-exit after first bail test failure when disableBail is false.",


### PR DESCRIPTION
Provide `--test-reporter=tap` as default in `tap.nodeArgs`, as the default `--test-reporter` changed in node 23 to 'spec', see https://github.com/nodejs/node/issues/58301

Fixes #5287
