### PR TITLE
chore: enable windows latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x, 24.x]
-        os: ['ubuntu-latest', 'windows-2025']
+        os: ['ubuntu-latest', 'windows-latest']
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-2025']
+        os: ['ubuntu-latest', 'windows-latest']
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
Enable windows latest instead of 2025