### PR TITLE
fix(vitest): race condition in init

### DIFF
--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -50,7 +50,7 @@ export class VitestTestRunner implements TestRunner {
   private ctx?: Vitest;
   private readonly options: VitestRunnerOptionsWithStrykerOptions;
   private localSetupFile = path.resolve(
-    `./stryker-setup-${process.env.STRYKER_MUTATOR_WORKER_ID ?? 0}.js`,
+    `./stryker-setup-${process.env.STRYKER_MUTATOR_WORKER ?? 0}.js`,
   );
 
   constructor(


### PR DESCRIPTION
The @stryker-mutator/vitest-runner always tried to copy the init file to '.stryker-tmp\sandbox-OyNlcn\stryker-setup-0.js', disregarding the STRYKER_MUTATOR_WORKER id. When two instances try to do this simultaneously it would fail

Fixes #5379
