### PR TITLE
fix(child-process): support OOM detection on apple silicon

### DIFF
--- a/packages/core/src/utils/string-builder.ts
+++ b/packages/core/src/utils/string-builder.ts
@@ -1,6 +1,7 @@
 import { EOL } from 'os';
 
-const DEFAULT_MAX_SIZE = 2048;
+// 8kB
+const DEFAULT_MAX_SIZE = 8192;
 
 export class StringBuilder {
   private currentLength = 0;

--- a/packages/core/test/unit/utils/string-builder.spec.ts
+++ b/packages/core/test/unit/utils/string-builder.spec.ts
@@ -14,7 +14,7 @@ describe(StringBuilder.name, () => {
       expect(sut.toString()).eq('123');
     });
 
-    const DEFAULT_MAX_CHARACTERS = 2048;
+    const DEFAULT_MAX_CHARACTERS = 8192;
     it(`should append a to maximum of ${DEFAULT_MAX_CHARACTERS} characters by default`, () => {
       const sut = new StringBuilder();
       for (let i = 0; i < DEFAULT_MAX_CHARACTERS; i++) {


### PR DESCRIPTION
Capture 8kB of process output for detecting OOM instead of 2kB.

The out of memory detection works by scanning the process output in case of a crash. Max 2kB of output is scanned. However, when the process crashes on Apple Silicon, the error output contains a stacktrace that pushes the "JavaScript heap out of memory" message over the 2kB.
