### PR TITLE
chore: improve mutation testing download script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         run: npm run download-incremental-reports
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      - name: Run stryker run --incremental --dashboard.version ${{ github.head_ref || github.ref_name }}
-        run: npm run test:mutation:incremental
+      - name: Run stryker run --incremental
+        run: npm run test:mutation:incremental -- --dashboard.version ${{ github.head_ref || github.ref_name }}
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm run download-incremental-reports
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      - name: Run stryker run --incremental
+      - name: Run stryker run --incremental --dashboard.version ${{ github.head_ref || github.ref_name }}
         run: npm run test:mutation:incremental
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,10 +166,11 @@ The possible values are:
 
 ### `dashboard` [`DashboardOptions`]
 
-Default: `{ baseUrl: 'https://dashboard.stryker-mutator.io/api/reports', reportType: 'mutationScore' }`<br />
+Default: `{ baseUrl: 'https://dashboard.stryker-mutator.io/api/reports', reportType: 'full' }`<br />
 Command line:
 
-- `--dashboard.project github.com/my-org/my-project --dashboard.version branch-or-tag`
+- `--dashboard.project github.com/my-org/my-project`
+- `--dashboard.version branch-or-tag`
 - `--dashboard.module my-module`
 - `--dashboard.baseUrl https://dashboard.stryker-mutator.io/api/reports`
 - `--dashboard.reportType full`

--- a/tasks/download-incremental-reports.sh
+++ b/tasks/download-incremental-reports.sh
@@ -2,7 +2,7 @@
 
 for package in api core cucumber-runner instrumenter jasmine-runner jest-runner karma-runner mocha-runner typescript-checker util tap-runner vitest-runner
 do
-    if [ "$BRANCH_NAME" ]
+    if [ "$BRANCH_NAME" ] && [[ "$BRANCH_NAME" != renovate* ]]
     then
         echo "Downloading $package/$BRANCH_NAME..."
         curl -s --dump-header .header.out --create-dirs -o packages/$package/reports/stryker-incremental.json https://dashboard.stryker-mutator.io/api/reports/github.com/stryker-mutator/stryker-js/$BRANCH_NAME?module=$package


### PR DESCRIPTION
- Always download the master incremental reports when renovate bot opens a PR
- Correctly document the default `dashboard.reportType`.
