### PR TITLE
fix(init): stryker init process should complete

### DIFF
--- a/packages/core/src/initializer/index.ts
+++ b/packages/core/src/initializer/index.ts
@@ -1,4 +1,4 @@
-import { createInjector, Injectable, Injector } from 'typed-inject';
+import { Injector } from 'typed-inject';
 import { execaCommand, execaCommandSync } from 'execa';
 import { resolveFromCwd } from '@stryker-mutator/util';
 
@@ -12,9 +12,11 @@ import { StrykerInquirer } from './stryker-inquirer.js';
 import { createInitializers } from './custom-initializers/index.js';
 import { GitignoreWriter } from './gitignore-writer.js';
 import { createNpmRegistryClient, getRegistry } from './npm-registry.js';
-import {  provideLogging, provideLoggingBackend } from '../logging/index.js';
+import { provideLogging, provideLoggingBackend } from '../logging/index.js';
 
-export async function initializerFactory(injector: Injector): Promise<StrykerInitializer> {
+export async function initializerFactory(
+  injector: Injector,
+): Promise<StrykerInitializer> {
   return provideLogging(await provideLoggingBackend(injector))
     .provideValue(initializerTokens.out, console.log)
     .provideValue(coreTokens.execa, execaCommand)

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -61,7 +61,7 @@ export class StrykerCli {
       const port = await server.start();
       console.log(JSON.stringify({ port }));
     },
-  ) { }
+  ) {}
 
   public run(createInjectorImpl = createInjector): void {
     const dashboard: Partial<DashboardOptions> = {};
@@ -120,7 +120,7 @@ export class StrykerCli {
       .option(
         '-b, --buildCommand <command>',
         'Configure a build command to run after mutating the code, but before mutants are tested. This is generally used to transpile your code before testing.' +
-        " Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like `babel/register` or `ts-node`.",
+          " Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like `babel/register` or `ts-node`.",
       )
       .option(
         '--dryRunOnly',
@@ -275,7 +275,7 @@ export class StrykerCli {
           const initializer = await initializerFactory(inj);
           await initializer.initialize();
         } finally {
-          inj.dispose();
+          await inj.dispose();
         }
       },
       run: () => this.runMutationTest(options),

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -170,8 +170,14 @@ describe(StrykerCli.name, () => {
       await tick();
 
       expect(injectorMock.provideClass).to.be.calledTwice;
-      expect(injectorMock.provideClass).to.be.calledWith(coreTokens.loggingSink, LoggingBackend);
-      expect(injectorMock.provideClass).to.be.calledWith(coreTokens.loggingServer, LoggingServer);
+      expect(injectorMock.provideClass).to.be.calledWith(
+        coreTokens.loggingSink,
+        LoggingBackend,
+      );
+      expect(injectorMock.provideClass).to.be.calledWith(
+        coreTokens.loggingServer,
+        LoggingServer,
+      );
     });
 
     it('should dispose of injected classes', async () => {
@@ -183,7 +189,7 @@ describe(StrykerCli.name, () => {
       expect(injectorMock.dispose).to.be.called;
     });
 
-    function actInit(injectorStub: () => Injector<{}>): void {
+    function actInit(injectorStub: () => Injector): void {
       new StrykerCli(
         ['node', 'stryker', 'init'],
         new Command(),


### PR DESCRIPTION
Resolves #5504

The process never completed due to a class that was not properly disposed of.
That caused users to previously have to manually exit the proces with ctrl+c. 