### PR TITLE
chore: improve list and duration formatting using Intl.ListFormat and Intl.NumberFormat

### DIFF
--- a/packages/core/src/config/config-reader.ts
+++ b/packages/core/src/config/config-reader.ts
@@ -159,7 +159,7 @@ export class ConfigReader {
         if (namedExports.length === 0) {
           return "In fact, it didn't export anything.";
         } else {
-          return `Found named export(s): ${namedExports.map((name) => `"${name}"`).join(', ')}.`;
+          return `Found named export(s): ${new Intl.ListFormat('en').format(namedExports.map((name) => `"${name}"`))}.`;
         }
       }
     }

--- a/packages/core/src/config/validation-errors.ts
+++ b/packages/core/src/config/validation-errors.ts
@@ -154,7 +154,7 @@ function describeError(error: ErrorObject): string {
       return `${errorPrefix} has the wrong type. It should be a ${expectedTypeDescription}, but was a ${jsonSchemaType(error.data)}.`;
     }
     case 'enum':
-      return `${errorPrefix} should be one of the allowed values (${error.params.allowedValues.map(stringify).join(', ')}), but was ${stringify(
+      return `${errorPrefix} should be one of the allowed values (${new Intl.ListFormat('en', { type: 'disjunction' }).format((error.params.allowedValues as unknown[]).map(stringify))}), but was ${stringify(
         error.data,
       )}.`;
     case 'minimum':

--- a/packages/core/src/di/plugin-creator.ts
+++ b/packages/core/src/di/plugin-creator.ts
@@ -68,7 +68,7 @@ export class PluginCreator {
         return pluginFound as Plugins[T];
       } else {
         throw new Error(
-          `Cannot find ${kind} plugin "${name}". Did you forget to install it? Loaded ${kind} plugins were: ${plugins.map((p) => p.name).join(', ')}`,
+          `Cannot find ${kind} plugin "${name}". Did you forget to install it? Loaded ${kind} plugins were: ${new Intl.ListFormat('en').format(plugins.map((p) => `"${p.name}"`))}`,
         );
       }
     } else {

--- a/packages/core/src/fs/project.ts
+++ b/packages/core/src/fs/project.ts
@@ -66,7 +66,7 @@ export class Project {
           normalizeWhitespaces(`Warning: No files found for mutation with the given glob expressions. As a result, a dry-run will be performed without actually modifying anything. 
           If you intended to mutate files, please check and adjust the configuration.
           Current glob pattern(s) used:
-          ${mutatePatterns.map((pattern) => `"${pattern}"`).join(', ')}.
+          ${new Intl.ListFormat('en').format(mutatePatterns.map((pattern) => `"${pattern}"`))}.
           To enable file mutation, consider configuring the \`${propertyPath<StrykerOptions>()(
             'mutate',
           )}\` property in your configuration file or using the --mutate option via the command line.`);

--- a/packages/core/src/utils/string-utils.ts
+++ b/packages/core/src/utils/string-utils.ts
@@ -4,13 +4,6 @@ import emojiRegex from 'emoji-regex';
 
 const emojiRe = emojiRegex();
 
-export function wrapInClosure(codeFragment: string): string {
-  return `
-    (function (window) {
-      ${codeFragment}
-    })((Function('return this'))());`;
-}
-
 export function padLeft(input: string): string {
   return input
     .split('\n')

--- a/packages/core/src/utils/timer.ts
+++ b/packages/core/src/utils/timer.ts
@@ -8,9 +8,11 @@ export class Timer {
   }
   public humanReadableElapsed(sinceMarker?: string): string {
     const elapsedSeconds = this.elapsedSeconds(sinceMarker);
-    return (
-      Timer.humanReadableElapsedMinutes(elapsedSeconds) +
-      Timer.humanReadableElapsedSeconds(elapsedSeconds)
+    return new Intl.ListFormat('en').format(
+      [
+        Timer.humanReadableElapsedMinutes(elapsedSeconds),
+        Timer.humanReadableElapsedSeconds(elapsedSeconds),
+      ].filter(Boolean),
     );
   }
 
@@ -47,8 +49,10 @@ export class Timer {
   }
 
   private static formatTime(word: 'minute' | 'second', elapsed: number) {
-    const s = elapsed === 1 ? '' : 's';
-    const blank = word === 'minute' ? ' ' : '';
-    return `${elapsed} ${word}${s}${blank}`;
+    return elapsed.toLocaleString('en', {
+      unit: word,
+      style: 'unit',
+      unitDisplay: 'long',
+    });
   }
 }

--- a/packages/core/test/unit/config/config-reader.spec.ts
+++ b/packages/core/test/unit/config/config-reader.spec.ts
@@ -263,7 +263,7 @@ describe(ConfigReader.name, () => {
       sinon.assert.calledWithMatch(
         testInjector.logger.fatal,
         sinon.match(
-          'Invalid config file. It is missing a default export. Found named export(s): "pi", "foo".',
+          'Invalid config file. It is missing a default export. Found named export(s): "pi" and "foo".',
         ),
       );
     });

--- a/packages/core/test/unit/config/options-validator.spec.ts
+++ b/packages/core/test/unit/config/options-validator.spec.ts
@@ -178,7 +178,7 @@ describe(OptionsValidator.name, () => {
     // @ts-expect-error invalid setting
     testInjector.options.logLevel = 'thisTestPasses';
     actValidationErrors(
-      'Config option "logLevel" should be one of the allowed values ("off", "fatal", "error", "warn", "info", "debug", "trace"), but was "thisTestPasses".',
+      'Config option "logLevel" should be one of the allowed values ("off", "fatal", "error", "warn", "info", "debug", or "trace"), but was "thisTestPasses".',
     );
   });
 
@@ -395,7 +395,7 @@ describe(OptionsValidator.name, () => {
     it('should be invalid for a wrong reportType', () => {
       breakConfig('dashboard', { reportType: 'empty' });
       actValidationErrors(
-        'Config option "dashboard.reportType" should be one of the allowed values ("full", "mutationScore"), but was "empty".',
+        'Config option "dashboard.reportType" should be one of the allowed values ("full" or "mutationScore"), but was "empty".',
       );
     });
   });
@@ -465,7 +465,7 @@ describe(OptionsValidator.name, () => {
   it('should be invalid with invalid coverageAnalysis', () => {
     breakConfig('coverageAnalysis', 'invalid');
     actValidationErrors(
-      'Config option "coverageAnalysis" should be one of the allowed values ("off", "all", "perTest"), but was "invalid".',
+      'Config option "coverageAnalysis" should be one of the allowed values ("off", "all", or "perTest"), but was "invalid".',
     );
   });
 

--- a/packages/core/test/unit/di/plugin-creator.spec.ts
+++ b/packages/core/test/unit/di/plugin-creator.spec.ts
@@ -128,7 +128,7 @@ describe(PluginCreator.name, () => {
       { kind: PluginKind.Reporter, factory: factory.reporter, name: 'bar' },
     ]);
     expect(() => sut.create(PluginKind.Reporter, 'chess')).throws(
-      'Cannot find Reporter plugin "chess". Did you forget to install it? Loaded Reporter plugins were: foo, bar',
+      'Cannot find Reporter plugin "chess". Did you forget to install it? Loaded Reporter plugins were: "foo" and "bar"',
     );
   });
 });

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -320,7 +320,7 @@ describe(ProjectReader.name, () => {
           normalizeWhitespaces(`Warning: No files found for mutation with the given glob expressions.
             As a result, a dry-run will be performed without actually modifying anything. 
             If you intended to mutate files, please check and adjust the configuration. 
-            Current glob pattern(s) used: "{src,lib}/**/!(*.+(s|S)pec|*.+(t|T)est).+(cjs|mjs|js|ts|mts|cts|jsx|tsx|html|vue|svelte)", 
+            Current glob pattern(s) used: "{src,lib}/**/!(*.+(s|S)pec|*.+(t|T)est).+(cjs|mjs|js|ts|mts|cts|jsx|tsx|html|vue|svelte)" and 
             "!{src,lib}/**/__tests__/**/*.+(cjs|mjs|js|ts|mts|cts|jsx|tsx|html|vue|svelte)".
             To enable file mutation, consider configuring the \`mutate\` 
             property in your configuration file or using the --mutate option via the command line.`),

--- a/packages/core/test/unit/utils/timer.spec.ts
+++ b/packages/core/test/unit/utils/timer.spec.ts
@@ -23,10 +23,10 @@ describe(Timer.name, () => {
     };
 
     arrangeActAssert(59999, '59 seconds');
-    arrangeActAssert(119999, '1 minute 59 seconds');
-    arrangeActAssert(120000, '2 minutes 0 seconds');
-    arrangeActAssert(121999, '2 minutes 1 second');
-    arrangeActAssert(61000, '1 minute 1 second');
+    arrangeActAssert(119999, '1 minute and 59 seconds');
+    arrangeActAssert(120000, '2 minutes and 0 seconds');
+    arrangeActAssert(121999, '2 minutes and 1 second');
+    arrangeActAssert(61000, '1 minute and 1 second');
 
     it('should use the since marker when provided', () => {
       clock.tick(1000);

--- a/packages/instrumenter/src/mutant-placers/throw-placement-error.ts
+++ b/packages/instrumenter/src/mutant-placers/throw-placement-error.ts
@@ -16,7 +16,7 @@ export function throwPlacementError(
   fileName: string,
 ): never {
   const location = `${path.relative(process.cwd(), fileName)}:${nodePath.node.loc?.start.line}:${nodePath.node.loc?.start.column}`;
-  const message = `${placer.name} could not place mutants with type(s): "${mutants.map((mutant) => mutant.mutatorName).join(', ')}"`;
+  const message = `${placer.name} could not place mutants with type(s): "${new Intl.ListFormat('en').format(mutants.map((mutant) => mutant.mutatorName))}"`;
   const errorMessage = `${location} ${message}. Either remove this file from the list of files to be mutated, or exclude the mutator (using ${propertyPath<StrykerOptions>()(
     'mutator',
     'excludedMutations',

--- a/packages/karma-runner/src/starters/angular-starter.ts
+++ b/packages/karma-runner/src/starters/angular-starter.ts
@@ -86,7 +86,7 @@ function verifyNgTestArguments(ngTestArguments: string[]) {
   );
   if (prefixedArguments.length > 0) {
     throw new Error(
-      `Don't prefix arguments with dashes ('-'). Stryker will do this automatically. Problematic arguments are ${prefixedArguments.join(', ')}.`,
+      `Don't prefix arguments with dashes ('-'). Stryker will do this automatically. Problematic arguments are ${new Intl.ListFormat('en').format(prefixedArguments)}.`,
     );
   }
 }


### PR DESCRIPTION
Uses [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) to format lists in error messages and logs, enhancing readability by using proper conjunctions. Also employs [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) for consistent number formatting in duration outputs.
