### PR TITLE
chore(renovate): add 3 day wait before suggesting dependency update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:js-lib"],
+  "extends": [
+    "config:js-lib", 
+    "security:minimumReleaseAgeNpm"
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
https://docs.renovatebot.com/key-concepts/minimum-release-age/
https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm

> Wait until the npm package is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in packages, and b) prevents the maintainer and/or NPM from unpublishing a package you already upgraded to, breaking builds.