### PR TITLE
chore(pnpm): add minimum release age of 3 days for packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'packages/*'
   - 'e2e'
   - 'e2e/test/*'
+minimumReleaseAge: 4320 # 3 days, see: https://pnpm.io/settings#minimumreleaseage


### PR DESCRIPTION
in line with #5646, where a minimum release age of 3 days has been instated for renovate.