### PR TITLE
chore(vitest-browser-mode): add configurable browser executable path

### DIFF
--- a/e2e/test/coverage-analysis/vitest.browser.config.js
+++ b/e2e/test/coverage-analysis/vitest.browser.config.js
@@ -4,7 +4,11 @@ import { playwright } from '@vitest/browser-playwright';
 config.test.browser = {
   enabled: true,
   instances: [{ browser: 'chromium' }],
-  provider: playwright(),
+  provider: playwright({
+    launchOptions: {
+      executablePath: process.env.PLAYWRIGHT_LAUNCH_OPTIONS_EXECUTABLE_PATH,
+    },
+  }),
   headless: true,
 };
 

--- a/packages/vitest-runner/testResources/browser-project/vitest.config.js
+++ b/packages/vitest-runner/testResources/browser-project/vitest.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
     globals: true,
     browser: {
       enabled: true,
-      provider: playwright(),
+      provider: playwright({
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_LAUNCH_OPTIONS_EXECUTABLE_PATH,
+        },
+      }),
       headless: true,
       instances: [{ browser: 'chromium' }],
     },

--- a/packages/vitest-runner/testResources/simple-project/vitest.browser.config.js
+++ b/packages/vitest-runner/testResources/simple-project/vitest.browser.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
     browser: {
       instances: [{ browser: 'chromium' }],
       headless: true,
-      provider: playwright(),
+      provider: playwright({
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_LAUNCH_OPTIONS_EXECUTABLE_PATH,
+        },
+      }),
       enabled: true,
     },
     include: ['tests/*.ts'],

--- a/packages/vitest-runner/testResources/vi-mock/vite.config.ts
+++ b/packages/vitest-runner/testResources/vi-mock/vite.config.ts
@@ -13,7 +13,11 @@ export default defineConfig({
       headless: true,
       enabled: true,
       instances: [{ browser: 'chromium' }],
-      provider: playwright(),
+      provider: playwright({
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_LAUNCH_OPTIONS_EXECUTABLE_PATH,
+        },
+      }),
     },
   },
 });


### PR DESCRIPTION
Optionally allows for configuring the used browser executable using an environment variable. This can be useful to allow using pre-installed browser versions instead of having to install the Playwright browser executable.