### PR TITLE
fix(string-literal-mutator): exclude dynamic import call expressions from mutation

### DIFF
--- a/packages/instrumenter/src/mutators/string-literal-mutator.ts
+++ b/packages/instrumenter/src/mutators/string-literal-mutator.ts
@@ -43,6 +43,7 @@ function isValidParent(child: NodePath<babel.types.StringLiteral>): boolean {
     (types.isCallExpression(parent) &&
       types.isIdentifier(parent.callee, { name: 'require' })) ||
     (types.isCallExpression(parent) &&
-      types.isIdentifier(parent.callee, { name: 'Symbol' }))
+      types.isIdentifier(parent.callee, { name: 'Symbol' })) ||
+    (types.isCallExpression(parent) && types.isImport(parent.callee))
   );
 }

--- a/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/string-literal-mutator.spec.ts
@@ -88,6 +88,10 @@ describe(sut.name, () => {
       expectJSMutation(sut, 'require("./lib/square");');
     });
 
+    it('should not mutate import call expressions', () => {
+      expectJSMutation(sut, 'import("foo/bar");');
+    });
+
     it('should mutate other call statements', () => {
       expectJSMutation(sut, 'require2("./lib/square");', 'require2("");');
     });


### PR DESCRIPTION
This updates the StringLiteral mutator to ensure that import() call expressions are not mutated. Mutating these expressions can break module resolution, so they are now explicitly excluded from mutation.

Closes #5769
