### PR TITLE
fix(core): rebase incremental report paths across project roots

### DIFF
--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -21,6 +21,8 @@ _Setting `"incremental": true` in your stryker.config.json file is also supporte
 
 StrykerJS stores the previous result in a "reports/stryker-incremental.json" file (determined by the [--incrementalFile](./configuration.md#incrementalfile-string) option). The next time StrykerJS runs, it will read this JSON file and try to reuse as much of it as possible.
 
+The incremental file also stores the `projectRoot` of the run that produced it. When that root differs from your current working directory, StrykerJS rebases incremental file entries to the current directory before diffing, so reuse still works when invocation context changes.
+
 Reuse is possible when:
 
 - A mutant was "Killed"; the culprit test still exists, and it didn't change.

--- a/packages/core/src/fs/project-reader.ts
+++ b/packages/core/src/fs/project-reader.ts
@@ -15,6 +15,7 @@ import {
   ERROR_CODES,
   I,
   isErrnoException,
+  normalizeFileName,
   notEmpty,
 } from '@stryker-mutator/util';
 import type { MutationTestResult } from 'mutation-testing-report-schema/api';
@@ -418,7 +419,7 @@ export class ProjectReader {
     try {
       // TODO: Validate against the schema or stryker version?
       const contents = await this.fs.readFile(this.incrementalFile, 'utf-8');
-      const result: MutationTestResult = JSON.parse(contents);
+      const result = this.rebaseIncrementalReport(JSON.parse(contents));
       return {
         ...result,
         files: Object.fromEntries(
@@ -464,6 +465,36 @@ export class ProjectReader {
       // Whoops, didn't mean to catch this one!
       throw err;
     }
+  }
+
+  private rebaseIncrementalReport(
+    report: MutationTestResult,
+  ): MutationTestResult {
+    const reportProjectRoot = report.projectRoot;
+    if (!reportProjectRoot || reportProjectRoot === process.cwd()) {
+      return report;
+    }
+    const toCurrentWorkingDir = (fileName: string): string =>
+      normalizeFileName(
+        path.relative(process.cwd(), path.resolve(reportProjectRoot, fileName)),
+      );
+    return {
+      ...report,
+      files: Object.fromEntries(
+        Object.entries(report.files).map(([fileName, fileResult]) => [
+          toCurrentWorkingDir(fileName),
+          fileResult,
+        ]),
+      ),
+      testFiles:
+        report.testFiles &&
+        Object.fromEntries(
+          Object.entries(report.testFiles).map(([fileName, testFile]) => [
+            toCurrentWorkingDir(fileName),
+            testFile,
+          ]),
+        ),
+    };
   }
 }
 

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -892,6 +892,49 @@ describe(ProjectReader.name, () => {
       });
       expect(actualProject.incrementalReport).deep.eq(expected);
     });
+    it('should rebase report file names when projectRoot differs from cwd', async () => {
+      testInjector.options.incremental = true;
+      const reportProjectRoot = path.resolve('/some/other/project');
+      const rebasedMutatedFile = normalizeFileName(
+        path.relative(
+          process.cwd(),
+          path.resolve(reportProjectRoot, 'src/foo.js'),
+        ),
+      );
+      const rebasedTestFile = normalizeFileName(
+        path.relative(
+          process.cwd(),
+          path.resolve(reportProjectRoot, 'test/foo.spec.js'),
+        ),
+      );
+      stubFileSystem({
+        reports: {
+          'stryker-incremental.json': JSON.stringify(
+            factory.mutationTestReportSchemaMutationTestResult({
+              projectRoot: reportProjectRoot,
+              files: {
+                'src/foo.js': factory.mutationTestReportSchemaFileResult({}),
+              },
+              testFiles: {
+                'test/foo.spec.js': factory.mutationTestReportSchemaTestFile(
+                  {},
+                ),
+              },
+            }),
+          ),
+        },
+      });
+      const sut = createSut();
+
+      const actualProject = await sut.read(undefined);
+
+      expect(Object.keys(actualProject.incrementalReport?.files ?? {})).deep.eq(
+        [rebasedMutatedFile],
+      );
+      expect(
+        Object.keys(actualProject.incrementalReport?.testFiles ?? {}),
+      ).deep.eq([rebasedTestFile]);
+    });
     it('should respect the incremental file location', async () => {
       testInjector.options.incremental = true;
       testInjector.options.incrementalFile = 'some/other/file.json';


### PR DESCRIPTION
- This PR restores the incremental report path-rebasing improvement as a focused follow-up, split out from #5866.
- It addresses a real incremental-mode usability gap: reuse currently depends on report file keys matching the caller's current working directory.
- When an incremental report was produced from a different `projectRoot`, Stryker now rebases stored `files` and `testFiles` entries to the current working directory before diffing.
- This preserves existing behavior when `projectRoot` is unchanged or absent.
- Scope is intentionally narrow: only incremental report key rebasing plus focused docs/tests.
- Coverage includes a unit test proving report file names are remapped correctly when `projectRoot` differs from `cwd`.
- Net effect: incremental reuse stays stable across invocation contexts without changing default mutation behavior.

## Summary

This PR extracts the incremental report path-rebasing behavior into its own focused change.

Today, incremental reuse depends on the stored report keys lining up with the current invocation context. When an incremental report was generated from a different `projectRoot`, that alignment can break even when the underlying files are still the same, causing otherwise reusable history to be missed.

This PR fixes that by rebasing the incremental report's `files` and `testFiles` keys from the report's stored `projectRoot` to the current working directory before Stryker performs its diffing and reuse logic.

## Why this matters

Incremental mode is supposed to help users keep reuse stable between runs. In practice, invocation context can vary:

- running from a different working directory
- generating the prior report in another checkout location
- using tooling that changes the effective project root between runs

Without rebasing, those cases can make equivalent paths look different and reduce incremental reuse for no meaningful behavioral reason.

This PR closes that gap by normalizing the stored report paths to the current invocation context before reuse analysis starts.

## What’s included

### 1) Incremental report key rebasing
- `ProjectReader` now checks the incremental report's `projectRoot`.
- When `projectRoot` differs from `process.cwd()`, report keys are rebased to the current working directory.
- Rebasing is applied to:
  - `files`
  - `testFiles`

### 2) No-op when rebasing is unnecessary
- If `projectRoot` is absent, behavior stays unchanged.
- If `projectRoot === process.cwd()`, behavior stays unchanged.

### 3) Documentation update
- `docs/incremental.md` now explains that the incremental file stores `projectRoot` and that entries are rebased when the invocation context differs.

### 4) Focused unit coverage
- Added a unit test proving that report file names are remapped correctly when the report was produced from another project root.

## Benefits vs costs

### Benefits
- **More stable incremental reuse** across different invocation contexts.
- **Less surprising behavior** when equivalent reports are reused from another checkout/root.
- **Small, isolated scope** with no change to default non-incremental behavior.

### Costs / trade-offs
- **Slightly more preprocessing** when loading an incremental report.
- **Behavior change in incremental mode** for cross-root reuse scenarios, which is why this is split into its own PR.

## Compatibility and risk

- Backward compatibility: preserved for unchanged-root scenarios.
- Risk level: low to moderate; behavior only changes when loading incremental reports produced from a different `projectRoot`.
- Scope is intentionally limited to the incremental report loading path.

## Test coverage

Added focused coverage for:

- rebasing incremental `files` keys when `projectRoot` differs from `cwd`
- rebasing incremental `testFiles` keys when `projectRoot` differs from `cwd`
- preserving existing behavior for normal incremental reads

## Commits (high level)

- rebase incremental report keys to current working directory during report loading
- document the cross-root incremental behavior
- add focused unit coverage for rebased report paths