### PR TITLE
feat(core): cli option for command runner

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ You can also specify a percentage string (e.g., `"50%"`) to compute the worker c
 ### `commandRunner` [`object`]
 
 Default: `{ command: 'npm test' }`<br />
-Command line: _none_<br />
+Command line: `--commandRunner.command "npm run mocha"`<br />
 Config file: `"commandRunner": { "command": "npm run mocha" }`
 
 With `commandRunner`, you can specify the command to execute for running tests.

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -3,9 +3,9 @@ import semver from 'semver';
 guardMinimalNodeVersion();
 import { Argument, Command } from 'commander';
 import {
-  DashboardOptions,
   ALL_REPORT_TYPES,
   PartialStrykerOptions,
+  StrykerOptions,
 } from '@stryker-mutator/api/core';
 
 import { initializerFactory } from './initializer/index.js';
@@ -14,6 +14,7 @@ import { defaultOptions } from './config/index.js';
 import { strykerEngines, strykerVersion } from './stryker-package.js';
 import { StrykerServer, StrykerServerOptions } from './stryker-server.js';
 import { createInjector } from 'typed-inject';
+import { DeepPartial } from '@stryker-mutator/util';
 
 const list = createSplitter(',');
 
@@ -207,6 +208,10 @@ export class StrykerCli {
           " Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like `babel/register` or `ts-node`.",
       )
       .option(
+        '--commandRunner.command <command>',
+        'Configure the command used by the test runner. Example: "npm run mocha". This maps to the `commandRunner.command` config option.',
+      )
+      .option(
         '--dryRunOnly',
         'Execute the initial test run only, without doing actual mutation testing. Doing a dry run only can be used to test that StrykerJS can run your test setup, for example, in CI pipelines.',
       )
@@ -337,11 +342,17 @@ export class StrykerCli {
     // Cleanup commander state
     delete options.version;
     Object.keys(options)
-      .filter((key) => key.startsWith('dashboard.'))
+      .filter((key) => key.includes('.'))
       .forEach((key) => {
-        options.dashboard ??= {};
-        const dashboardOpt = key.split('.')[1] as keyof DashboardOptions;
-        options.dashboard[dashboardOpt] = options[key] as any;
+        const parts = key.split('.');
+        let target = options;
+
+        for (let i = 0; i < parts.length - 1; i++) {
+          const part = parts[i];
+          target[part] ??= {};
+          target = target[part] as DeepPartial<StrykerOptions>;
+        }
+        target[parts[parts.length - 1]] = options[key];
         delete options[key];
       });
 

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -96,11 +96,12 @@ describe(StrykerCli.name, () => {
       });
     });
 
-    describe('dashboard options', () => {
+    describe('dotted options', () => {
       beforeEach(() => {
         runMutationTestingStub.resolves();
       });
-      it('should parse options to a deep object', () => {
+
+      it('should parse dotted options to nested objects', () => {
         const expectedDashboardOptions: Required<DashboardOptions> = {
           baseUrl: 'https://dashboard.qux.io',
           module: 'baz/module',
@@ -119,13 +120,17 @@ describe(StrykerCli.name, () => {
           expectedDashboardOptions.baseUrl,
           '--dashboard.reportType',
           'full',
+          '--commandRunner.command',
+          'npm run tests-only',
         );
+
         expect(runMutationTestingStub).calledWithMatch({
           dashboard: expectedDashboardOptions,
+          commandRunner: { command: 'npm run tests-only' },
         });
       });
 
-      it('should remove any lingering options', () => {
+      it('should remove any lingering dotted keys', () => {
         actRun(
           '--dashboard.version',
           'foo',
@@ -135,13 +140,15 @@ describe(StrykerCli.name, () => {
           'baz',
           '--dashboard.baseUrl',
           'quux',
+          '--commandRunner.command',
+          'npm run tests-only',
         );
         const call = runMutationTestingStub.getCall(0);
         const actualOptions: StrykerOptions = call.args[0];
-        const dashboardKeys = Object.keys(actualOptions).filter((key) =>
-          key.startsWith('dashboard.'),
+        const dottedKeys = Object.keys(actualOptions).filter((key) =>
+          key.includes('.'),
         );
-        expect(dashboardKeys, JSON.stringify(dashboardKeys)).lengthOf(0);
+        expect(dottedKeys, JSON.stringify(dottedKeys)).lengthOf(0);
       });
     });
 

--- a/packages/core/test/unit/stryker-cli.spec.ts.snap
+++ b/packages/core/test/unit/stryker-cli.spec.ts.snap
@@ -33,6 +33,7 @@ Options:
   It is possible to specify exactly which code blocks to mutate by means of a _mutation range_. This can be done postfixing your file with \`:startLine[:startColumn]-endLine[:endColumn]\`. Example: src/index.js:1:3-1:5
   -t, --testFiles <testFilesToRun>             With \`testFiles\` you can limit which test files are executed during mutation testing. When specified, only tests from these files will be run. This allows you to verify that a module's dedicated unit tests can kill all its mutants independently.
   -b, --buildCommand <command>                 Configure a build command to run after mutating the code, but before mutants are tested. This is generally used to transpile your code before testing. Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like \`babel/register\` or \`ts-node\`.
+  --commandRunner.command <command>            Configure the command used by the test runner. Example: \\"npm run mocha\\". This maps to the \`commandRunner.command\` config option.
   --dryRunOnly                                 Execute the initial test run only, without doing actual mutation testing. Doing a dry run only can be used to test that StrykerJS can run your test setup, for example, in CI pipelines.
   --checkers <listOfCheckersOrEmptyString>     A comma separated list of checkers to use, for example --checkers typescript
   --checkerNodeArgs <listOfNodeArgs>           A list of node args to be passed to checker child processes.
@@ -94,6 +95,7 @@ Options:
   It is possible to specify exactly which code blocks to mutate by means of a _mutation range_. This can be done postfixing your file with \`:startLine[:startColumn]-endLine[:endColumn]\`. Example: src/index.js:1:3-1:5
   -t, --testFiles <testFilesToRun>             With \`testFiles\` you can limit which test files are executed during mutation testing. When specified, only tests from these files will be run. This allows you to verify that a module's dedicated unit tests can kill all its mutants independently.
   -b, --buildCommand <command>                 Configure a build command to run after mutating the code, but before mutants are tested. This is generally used to transpile your code before testing. Only configure this if your test runner doesn't take care of this already and you're not using just-in-time transpiler like \`babel/register\` or \`ts-node\`.
+  --commandRunner.command <command>            Configure the command used by the test runner. Example: \\"npm run mocha\\". This maps to the \`commandRunner.command\` config option.
   --dryRunOnly                                 Execute the initial test run only, without doing actual mutation testing. Doing a dry run only can be used to test that StrykerJS can run your test setup, for example, in CI pipelines.
   --checkers <listOfCheckersOrEmptyString>     A comma separated list of checkers to use, for example --checkers typescript
   --checkerNodeArgs <listOfNodeArgs>           A list of node args to be passed to checker child processes.


### PR DESCRIPTION
This addresses the specific option requested in #5153. As per later comments on the issue, I'm also not convinced that exposing every available config option on the CLI (to the best extent possible) is the way to go. So the decision needs to be made on whether this PR fully resolves the issue.

The option name is not `--testCommand` to mirror the existing `--buildCommand`, because the assumption in code and types is that the config file options and CLI flags' names are the same.