### PR TITLE
feat(initializer): add reports/ to .gitignore template

### DIFF
--- a/packages/core/src/initializer/gitignore-writer.ts
+++ b/packages/core/src/initializer/gitignore-writer.ts
@@ -9,24 +9,41 @@ import { initializerTokens } from './index.js';
 
 const GITIGNORE_FILE = '.gitignore';
 
+interface GitignoreEntry {
+  comment: string;
+  path: string;
+}
+
 export class GitignoreWriter {
   public static inject = tokens(initializerTokens.out);
   constructor(private readonly out: typeof console.log) {}
 
   public async addStrykerTempFolder(): Promise<void> {
-    const defaultTempDirName = defaultOptions.tempDirName;
+    const entries: GitignoreEntry[] = [
+      { comment: 'stryker temp files', path: defaultOptions.tempDirName },
+      { comment: 'stryker reports', path: 'reports/' },
+    ];
     if (existsSync(GITIGNORE_FILE)) {
-      const gitignoreContent = await fs.readFile(GITIGNORE_FILE);
-      if (!gitignoreContent.toString().includes(defaultTempDirName)) {
-        const strykerTempFolderSpecification = `${os.EOL}# stryker temp files${os.EOL}${defaultTempDirName}${os.EOL}`;
-        await fs.appendFile(GITIGNORE_FILE, strykerTempFolderSpecification);
+      const gitignoreContent = (await fs.readFile(GITIGNORE_FILE)).toString();
+      const missing = entries.filter(
+        (entry) => !gitignoreContent.includes(entry.path),
+      );
+      if (missing.length > 0) {
+        const specification = missing
+          .map(
+            (entry) =>
+              `${os.EOL}# ${entry.comment}${os.EOL}${entry.path}${os.EOL}`,
+          )
+          .join('');
+        await fs.appendFile(GITIGNORE_FILE, specification);
         this.out(
           'Note: Your .gitignore file has been updated to include recommended git ignore patterns for Stryker',
         );
       }
     } else {
+      const paths = entries.map((entry) => entry.path).join(', ');
       this.out(
-        'No .gitignore file could be found. Please add the following to your .gitignore file: *.stryker-tmp',
+        `No .gitignore file could be found. Please add the following to your .gitignore file: ${paths}`,
       );
     }
   }

--- a/packages/core/test/unit/initializer/gitignore-writer.spec.ts
+++ b/packages/core/test/unit/initializer/gitignore-writer.spec.ts
@@ -44,14 +44,14 @@ describe(GitignoreWriter.name, () => {
         fsReadFile.returns(Buffer.from('node_modules'));
       });
 
-      it('should append the stryker gitignore configuration', async () => {
+      it('should append both stryker entries when neither is present', async () => {
         // Act
         await sut.addStrykerTempFolder();
 
         // Assert
         expect(fsAppendFile).calledWithExactly(
           GITIGNORE_FILE,
-          `${os.EOL}# stryker temp files${os.EOL}.stryker-tmp${os.EOL}`,
+          `${os.EOL}# stryker temp files${os.EOL}.stryker-tmp${os.EOL}${os.EOL}# stryker reports${os.EOL}reports/${os.EOL}`,
         );
       });
 
@@ -68,9 +68,39 @@ describe(GitignoreWriter.name, () => {
         );
       });
 
-      it("should not append the stryker gitignore configuration if it's already present", async () => {
+      it('should append only the reports entry when the temp dir is already present', async () => {
         // Arrange
         fsReadFile.returns(`node_modules${os.EOL}.stryker-tmp${os.EOL}temp`);
+
+        // Act
+        await sut.addStrykerTempFolder();
+
+        // Assert
+        expect(fsAppendFile).calledWithExactly(
+          GITIGNORE_FILE,
+          `${os.EOL}# stryker reports${os.EOL}reports/${os.EOL}`,
+        );
+      });
+
+      it('should append only the temp dir entry when the reports dir is already present', async () => {
+        // Arrange
+        fsReadFile.returns(`node_modules${os.EOL}reports/${os.EOL}temp`);
+
+        // Act
+        await sut.addStrykerTempFolder();
+
+        // Assert
+        expect(fsAppendFile).calledWithExactly(
+          GITIGNORE_FILE,
+          `${os.EOL}# stryker temp files${os.EOL}.stryker-tmp${os.EOL}`,
+        );
+      });
+
+      it('should not append anything if both entries are already present', async () => {
+        // Arrange
+        fsReadFile.returns(
+          `node_modules${os.EOL}.stryker-tmp${os.EOL}reports/${os.EOL}temp`,
+        );
 
         // Act
         await sut.addStrykerTempFolder();
@@ -91,7 +121,7 @@ describe(GitignoreWriter.name, () => {
 
         // Assert
         expect(out).calledWithExactly(
-          'No .gitignore file could be found. Please add the following to your .gitignore file: *.stryker-tmp',
+          'No .gitignore file could be found. Please add the following to your .gitignore file: .stryker-tmp, reports/',
         );
       });
     });


### PR DESCRIPTION
## What

When `npm init stryker` runs, the initializer already appends a `.stryker-tmp` entry to `.gitignore` if not present. This change extends the same logic to also append `reports/` — the directory created by `npx stryker run` (default `htmlReporter.fileName` is `reports/mutation/mutation.html`).

## Why

Closes #6005. Without `reports/` in `.gitignore`, every Stryker run leaves a `reports/` tree as untracked changes, which is noisy in `git status` and easy to accidentally commit.

## How

`packages/core/src/initializer/gitignore-writer.ts`:
- Replaced the single hardcoded `defaultTempDirName` block with a small `entries` list of `{ comment, path }` pairs.
- Each entry is independently checked against the existing `.gitignore` content; only the missing entries are appended (as one combined block, with a single user-facing "Note: …updated" message).
- When `.gitignore` doesn't exist, the warning message now lists both required paths from the same source-of-truth (`.stryker-tmp, reports/`) instead of the previous `*.stryker-tmp` literal. This is a minor cosmetic alignment with what actually gets written when the file does exist — happy to revert if you'd prefer to preserve the original wording.

`packages/core/test/unit/initializer/gitignore-writer.spec.ts`:
- Replaced the single "should append" test with four cases covering the full truth table: neither entry present, only `.stryker-tmp` present, only `reports/` present, both present.
- Updated the "no .gitignore" message assertion to match.

## Tests

- `pnpm test --filter @stryker-mutator/core` — all green locally.
- No e2e / integration changes needed; this is initializer-only.

## Notes for the reviewer

- I deliberately did not rename `addStrykerTempFolder()` even though it now adds more than the temp folder. Renaming is a public-ish API change; happy to do it as a follow-up if you want.
- Issue body suggested adding `reports/` literally; I confirmed the path against `packages/api/schema/stryker-core.json` `htmlReporterOptions.fileName` default (`reports/mutation/mutation.html`), so `reports/` is the correct parent.
