### PR TITLE
feat(mocha-runner): support Mocha v12

### DIFF
--- a/packages/mocha-runner/package.json
+++ b/packages/mocha-runner/package.json
@@ -54,10 +54,11 @@
   },
   "devDependencies": {
     "@stryker-mutator/test-helpers": "workspace:*",
-    "@types/node": "24.13.2"
+    "@types/node": "24.13.2",
+    "mocha": "11.7.5"
   },
   "peerDependencies": {
     "@stryker-mutator/core": "workspace:*",
-    "mocha": ">= 7.2 < 12"
+    "mocha": ">= 7.2 < 13"
   }
 }

--- a/packages/mocha-runner/src/lib-wrapper.ts
+++ b/packages/mocha-runner/src/lib-wrapper.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
 
 import Mocha, { type RootHookObject } from 'mocha';
 
@@ -24,11 +25,23 @@ let collectFiles:
  * @see https://mochajs.org/api/module-lib_cli_options.html#.loadOptions
  */
 
-const loadOptions: (
+type LoadOptions = (
   argv?: string[] | string,
-) => Record<string, any> | undefined = require(
-  `${mochaRoot}/lib/cli/options`,
-).loadOptions;
+) => Record<string, any> | undefined;
+
+async function resolveLoadOptions(): Promise<LoadOptions> {
+  try {
+    return require(`${mochaRoot}/lib/cli/options`).loadOptions;
+  } catch {
+    // Since Mocha 12 the cli is distributed as ECMAScript modules
+    const options = await import(
+      pathToFileURL(path.join(mochaRoot, 'lib/cli/options.mjs')).href
+    );
+    return options.loadOptions;
+  }
+}
+
+const loadOptions = await resolveLoadOptions();
 
 const handleRequires: (requires?: string[]) => Promise<RootHookObject> =
   runHelpers.handleRequires;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,9 +1353,6 @@ importers:
       '@stryker-mutator/util':
         specifier: workspace:*
         version: link:../util
-      mocha:
-        specifier: '>= 7.2 < 12'
-        version: 11.7.5
       tslib:
         specifier: ~2.8.0
         version: 2.8.1
@@ -1366,6 +1363,9 @@ importers:
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
+      mocha:
+        specifier: 11.7.5
+        version: 11.7.5
 
   packages/tap-runner:
     dependencies:
@@ -4892,7 +4892,7 @@ packages:
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@stryker-mutator/core': workspace:*
-      mocha: '>= 7.2 < 12'
+      mocha: '>= 7.2 < 13'
 
   '@stryker-mutator/tap-runner@file:packages/tap-runner':
     resolution: {directory: packages/tap-runner, type: directory}


### PR DESCRIPTION
Mocha 12 migrated its CLI to ES modules, so the runner's synchronous `require('mocha/lib/cli/options')` no longer resolves. `lib-wrapper` now falls back to a dynamic `import()` of `lib/cli/options.mjs` when the require fails, leaving the existing path intact for Mocha < 12, and the peer dependency range is widened to `>= 7.2 < 13`.

Verified by running the integration suite against `mocha@12.0.0-beta-9.4` (note: a prerelease won't satisfy the range under strict semver, but the upcoming `12.0.0` stable will).