### PR TITLE
fix(jest-runner): resolve preset-provided testEnvironment for coverage analysis

### DIFF
--- a/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
+++ b/packages/jest-runner/src/config-loaders/custom-jest-config-loader.ts
@@ -59,6 +59,33 @@ export class CustomJestConfigLoader implements JestConfigLoader {
     } else {
       this.log.debug(`No config file read ${hint}.`);
     }
+    // `readInitialOptions` returns the *raw* options and deliberately does not apply
+    // a `preset`. A `testEnvironment` supplied through a preset is therefore absent
+    // here. Consumers that read `testEnvironment` directly (e.g. the coverage-analysis
+    // environment override) would otherwise silently fall back to jest's default
+    // (`node`) and run tests in the wrong environment. Resolve the merged value via
+    // jest's own `normalize` (once, at config-load time) so presets — and any other
+    // config merging jest performs — are honored. Best-effort: on any failure we keep
+    // the raw config, so behavior never regresses.
+    if (config.testEnvironment === undefined) {
+      try {
+        const { options } = await this.jestConfig.normalize(
+          { ...config },
+          { _: [], $0: 'stryker' } as Config.Argv,
+          configPath,
+        );
+        if (options.testEnvironment) {
+          config.testEnvironment = options.testEnvironment;
+          this.log.debug(
+            `Resolved testEnvironment "${options.testEnvironment}" from preset/defaults ${hint}.`,
+          );
+        }
+      } catch (err) {
+        this.log.debug(
+          `Could not resolve testEnvironment via jest's normalize: ${String(err)}`,
+        );
+      }
+    }
     return config;
   }
 

--- a/packages/jest-runner/src/utils/jest-config-wrapper.ts
+++ b/packages/jest-runner/src/utils/jest-config-wrapper.ts
@@ -27,4 +27,10 @@ export class JestConfigWrapper {
   ): ReturnType<typeof jestConfig.readInitialOptions> {
     return this.jestConfig.readInitialOptions(...args);
   }
+
+  public normalize(
+    ...args: Parameters<typeof jestConfig.normalize>
+  ): ReturnType<typeof jestConfig.normalize> {
+    return this.jestConfig.normalize(...args);
+  }
 }

--- a/packages/jest-runner/test/unit/config-loaders/custom-jest-config-loader.spec.ts
+++ b/packages/jest-runner/test/unit/config-loaders/custom-jest-config-loader.spec.ts
@@ -86,6 +86,55 @@ describe(CustomJestConfigLoader.name, () => {
     });
   });
 
+  describe('preset testEnvironment resolution', () => {
+    it('should resolve testEnvironment via jest normalize when the raw config has none', async () => {
+      jestConfigWrapperMock.readInitialOptions.resolves({
+        config: { preset: 'some-preset' },
+        configPath: path.resolve('jest.config.js'),
+      });
+      jestConfigWrapperMock.normalize.resolves({
+        options: { testEnvironment: 'jsdom' },
+        hasDeprecationWarnings: false,
+      } as Awaited<ReturnType<JestConfigWrapper['normalize']>>);
+
+      const config = await sut.loadConfig();
+
+      expect(config.testEnvironment).eq('jsdom');
+      sinon.assert.calledOnceWithExactly(
+        jestConfigWrapperMock.normalize,
+        { preset: 'some-preset' },
+        { _: [], $0: 'stryker' },
+        path.resolve('jest.config.js'),
+      );
+    });
+
+    it('should not call normalize when testEnvironment is already set', async () => {
+      jestConfigWrapperMock.readInitialOptions.resolves({
+        config: { testEnvironment: 'node' },
+        configPath: path.resolve('jest.config.js'),
+      });
+
+      const config = await sut.loadConfig();
+
+      expect(config.testEnvironment).eq('node');
+      sinon.assert.notCalled(jestConfigWrapperMock.normalize);
+    });
+
+    it('should keep the raw config when normalize fails', async () => {
+      const rawConfig: Config.InitialOptions = { preset: 'broken-preset' };
+      jestConfigWrapperMock.readInitialOptions.resolves({
+        config: rawConfig,
+        configPath: path.resolve('jest.config.js'),
+      });
+      jestConfigWrapperMock.normalize.rejects(new Error('cannot find preset'));
+
+      const config = await sut.loadConfig();
+
+      expect(config).eq(rawConfig);
+      expect(config.testEnvironment).eq(undefined);
+    });
+  });
+
   describe('manual read config', () => {
     const projectRoot = process.cwd();
     let readFileStub: sinon.SinonStubbedMember<typeof fs.promises.readFile>;


### PR DESCRIPTION
## Summary

`@stryker-mutator/jest-runner` ignores a `testEnvironment` that comes from a jest **`preset`** when it sets up coverage analysis, silently running those projects' tests under jest's default environment (`node`) instead of the one the preset specifies (e.g. `jsdom`). This fixes it by resolving the merged `testEnvironment` via jest's own `normalize`, once, at config-load time. This is probably a very common problem with integrating stryker into nx projects, and may address some of the OOM/hang issues others have reported.

## Root cause

`CustomJestConfigLoader.readConfigNative()` reads the project's jest config with jest's [`readInitialOptions`](https://github.com/jestjs/jest/blob/main/packages/jest-config/src/index.ts), which by design returns the **raw, un-merged** options — a `preset` is *not* applied. The returned config therefore has `testEnvironment: undefined` whenever the environment is supplied by a preset.

Downstream, the coverage-analysis path (`with-coverage-analysis.ts` → `overrideEnvironment`) reads `jestConfig.testEnvironment ?? <jest default>`, sees `undefined`, and wraps the **default `node`** environment. Plain `jest` applies the preset, so it runs under the preset's env and passes — which makes the breakage look Stryker-specific and environment-dependent.

For a `jsdom`-via-preset project the symptom is severe: tests that rely on `window`/`XMLHttpRequest` throw under `node`, fail, and (if the failing values are large/cross-referential, e.g. a scene graph or a big DOM-ish object) jest's `pretty-format` failure diff can balloon CPU/memory — which reads like an OOM/“memory leak” in the runner rather than a wrong-environment problem.

## Reproduction

A project whose `testEnvironment` is only set by a preset:

```js
// jest.config.js
export default {
  preset: 'jest-preset-foo', // preset sets `testEnvironment: 'jsdom'`
};
```

```jsonc
// stryker.conf.json
{ "testRunner": "jest", "coverageAnalysis": "perTest" }
```

`jest` runs under `jsdom`; Stryker's dry run executes under `node`.

## Fix

After `readInitialOptions`, when `testEnvironment` is unset, resolve the **merged** value with jest's own `normalize` and backfill it:

- `JestConfigWrapper` now also exposes `normalize` (it already wraps the resolved `jest-config` module; this just surfaces the method, mirroring `readInitialOptions`).
- `readConfigNative()` calls `normalize({ ...config }, { _: [], $0: 'stryker' }, configPath)` only when `config.testEnvironment === undefined`, and copies `options.testEnvironment` onto the config.

```ts
if (config.testEnvironment === undefined) {
  try {
    const { options } = await this.jestConfig.normalize(
      { ...config },
      { _: [], $0: 'stryker' } as Config.Argv,
      configPath,
    );
    if (options.testEnvironment) {
      config.testEnvironment = options.testEnvironment;
    }
  } catch (err) {
    // best-effort: keep the raw config, behavior never regresses
  }
}
```

### Why this approach

- **Durable** — it uses jest's *own* resolution (`normalize`), so it tracks preset/merge semantics exactly; nothing is re-implemented or duplicated. `normalize` (and `readConfig`/`readConfigs`) have been part of `jest-config`'s public surface for a long time and are the same primitives `jest-cli` uses.
- **Efficient** — runs once per project at config-load time (not per-test, not per-mutant); a few ms, off the hot path.
- **Non-regressing** — gated on `testEnvironment === undefined`, wrapped in try/catch. If `normalize` throws (e.g. an unrelated invalid option) the raw config is returned exactly as before. When there is no preset and no explicit env, it backfills the same default (`node`) the runner would have used anyway, so behavior is preserved.
- **Right layer** — fixing it in the loader means the resolved environment is correct for every consumer of the config, not just the coverage path.

### Alternatives considered

- Resolve inside `overrideEnvironment` only — narrower, but leaves the rest of the config consumers seeing `undefined`, and that function isn't the natural place to do async config resolution.
- Use `readConfig(argv, configPath)` instead of `normalize` — also works, but it re-reads the file from disk; `normalize` reuses the already-read raw config.

## Test plan

- Added unit tests to `custom-jest-config-loader.spec.ts`:
  - resolves `testEnvironment` via `normalize` when the raw config has none;
  - does **not** call `normalize` when `testEnvironment` is already set;
  - keeps the raw config (no throw) when `normalize` fails.
- Verified end-to-end on a real `jsdom`-via-(nx)-preset, Babylon.js-heavy project with `coverageAnalysis: "perTest"`: before, the dry run hung for ~5 min and OOM'd; after, the loader resolves `…/jest-environment-jsdom/build/index.js` from the preset, the dry run succeeds in ~6s, and the full mutation run completes with an accurate per-test coverage map.

Context: this implements the “resolve the merged `testEnvironment` (including presets), or at least warn on fallback” improvement noted in the discussion on #6022.
