### PR TITLE
feat(instrumenter): add FloorDivision mutator (#5642)

### DIFF
--- a/packages/instrumenter/src/mutators/floor-division-mutator.ts
+++ b/packages/instrumenter/src/mutators/floor-division-mutator.ts
@@ -1,0 +1,67 @@
+import babel from '@babel/core';
+
+import { deepCloneNode } from '../util/index.js';
+
+import { NodeMutator } from './node-mutator.js';
+
+const { types } = babel;
+
+export const floorDivisionMutator: NodeMutator = {
+  name: 'FloorDivision',
+
+  *mutate(path) {
+    // Forward: a % b → Math.floor(a / b)
+    // We emit only Math.floor (not also Math.trunc) because the two differ only
+    // for negative operands, making a second forward mutant near-redundant noise.
+    // The reverse direction accepts both Math.floor and Math.trunc so that
+    // either idiom in the source can be mutated back to %.
+    if (path.isBinaryExpression() && path.node.operator === '%') {
+      const left = deepCloneNode(path.node.left);
+      const right = deepCloneNode(path.node.right);
+      yield types.callExpression(
+        types.memberExpression(
+          types.identifier('Math'),
+          types.identifier('floor'),
+        ),
+        [types.binaryExpression('/', left, right)],
+      );
+      return;
+    }
+
+    // Reverse: Math.floor(x / y) or Math.trunc(x / y) → x % y
+    if (!path.isCallExpression()) {
+      return;
+    }
+
+    const { callee, arguments: args } = path.node;
+
+    // Must be a non-computed member expression: Math.floor or Math.trunc
+    if (
+      !types.isMemberExpression(callee) ||
+      callee.computed ||
+      !types.isIdentifier(callee.object, { name: 'Math' }) ||
+      !types.isIdentifier(callee.property)
+    ) {
+      return;
+    }
+
+    const methodName = callee.property.name;
+    if (methodName !== 'floor' && methodName !== 'trunc') {
+      return;
+    }
+
+    // Must have exactly one argument that is a BinaryExpression with '/'
+    if (args.length !== 1) {
+      return;
+    }
+
+    const arg = args[0];
+    if (!types.isBinaryExpression(arg) || arg.operator !== '/') {
+      return;
+    }
+
+    const left = deepCloneNode(arg.left);
+    const right = deepCloneNode(arg.right);
+    yield types.binaryExpression('%', left, right);
+  },
+};

--- a/packages/instrumenter/src/mutators/mutate.ts
+++ b/packages/instrumenter/src/mutators/mutate.ts
@@ -7,6 +7,7 @@ import { arrayDeclarationMutator } from './array-declaration-mutator.js';
 import { arrowFunctionMutator } from './arrow-function-mutator.js';
 import { booleanLiteralMutator } from './boolean-literal-mutator.js';
 import { equalityOperatorMutator } from './equality-operator-mutator.js';
+import { floorDivisionMutator } from './floor-division-mutator.js';
 import { methodExpressionMutator } from './method-expression-mutator.js';
 import { logicalOperatorMutator } from './logical-operator-mutator.js';
 import { objectLiteralMutator } from './object-literal-mutator.js';
@@ -24,6 +25,7 @@ export const allMutators: NodeMutator[] = [
   booleanLiteralMutator,
   conditionalExpressionMutator,
   equalityOperatorMutator,
+  floorDivisionMutator,
   logicalOperatorMutator,
   methodExpressionMutator,
   objectLiteralMutator,

--- a/packages/instrumenter/test/perf/instrumenter.perf.spec.ts
+++ b/packages/instrumenter/test/perf/instrumenter.perf.spec.ts
@@ -87,7 +87,7 @@ describe('instrumenter performance', () => {
   it('should instrument benchmark-big.ts with expected mutant count and within performance threshold', async () => {
     await benchmarkFile(
       'benchmark-big.ts',
-      933,
+      942,
       platform() === 'win32' ? 500 : 325,
     );
   });

--- a/packages/instrumenter/test/unit/mutators/floor-division-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/floor-division-mutator.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import { floorDivisionMutator as sut } from '../../../src/mutators/floor-division-mutator.js';
+import { expectJSMutation } from '../../helpers/expect-mutation.js';
+
+describe(sut.name, () => {
+  it('should have name "FloorDivision"', () => {
+    expect(sut.name).eq('FloorDivision');
+  });
+
+  it('should mutate a % b to Math.floor(a / b)', () => {
+    expectJSMutation(sut, 'a % b', 'Math.floor(a / b)');
+  });
+
+  it('should mutate Math.floor(a / b) to a % b', () => {
+    expectJSMutation(sut, 'Math.floor(a / b)', 'a % b');
+  });
+
+  it('should mutate Math.trunc(a / b) to a % b', () => {
+    expectJSMutation(sut, 'Math.trunc(a / b)', 'a % b');
+  });
+
+  it('should mutate complex operands', () => {
+    expectJSMutation(sut, '(x + 1) % (y - 2)', 'Math.floor((x + 1) / (y - 2))');
+  });
+
+  it('should not mutate Math.floor with non-division argument', () => {
+    expectJSMutation(sut, 'Math.floor(a)');
+    expectJSMutation(sut, 'Math.floor(a + b)');
+  });
+
+  it('should not mutate Math.floor with multiple arguments', () => {
+    expectJSMutation(sut, 'Math.floor(a, b)');
+  });
+
+  it('should not mutate Math.round(a / b)', () => {
+    expectJSMutation(sut, 'Math.round(a / b)');
+  });
+
+  it('should not mutate computed member access Math["floor"](a / b)', () => {
+    expectJSMutation(sut, 'Math["floor"](a / b)');
+  });
+
+  it('should mutate both calls in nested Math.floor(Math.floor(a / b) / c)', () => {
+    expectJSMutation(
+      sut,
+      'Math.floor(Math.floor(a / b) / c)',
+      'Math.floor(a / b) % c',
+      'Math.floor(a % b / c)',
+    );
+  });
+});


### PR DESCRIPTION
Adds a `FloorDivision` mutator that swaps between modulo and floor division, as requested in #5642.

- `a % b` → `Math.floor(a / b)`
- `Math.floor(a / b)` → `a % b`
- `Math.trunc(a / b)` → `a % b`

The forward direction only emits `Math.floor`, not `Math.trunc` — the two differ only for negative operands, so a second forward mutant would be near-redundant. The reverse direction accepts both so existing `floor`/`trunc` code gets mutated either way.

Closes #5642