### PR TITLE
fix(core): clarify `ignoreStatic` tradeoff in slow-mutants warning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,7 +340,7 @@ Default: `false`<br />
 Command line: `--ignoreStatic`<br />
 Config file: `"ignoreStatic": true`<br />
 
-Static mutants are mutants which are only executed during the loading of a file. Testing these mutants come with a big performance penalty. Therefore, it might make sense to ignore static mutants altogether.
+Static mutants are mutants which are only executed during the loading of a file. Testing these mutants come with a big performance penalty. Therefore, it might make sense to ignore static mutants altogether. Ignored static mutants are reported with the `Ignored` status and are excluded from your mutation score.
 
 For example:
 

--- a/packages/core/src/mutants/mutant-test-planner.ts
+++ b/packages/core/src/mutants/mutant-test-planner.ts
@@ -259,7 +259,7 @@ export class MutantTestPlanner {
             staticRunPlans.length / runPlans.length,
           )}% of total) that are estimated to take ${percentage(
             relativeTimeForStaticMutants,
-          )}% of the time running the tests!\n  You might want to enable "ignoreStatic" to ignore these static mutants for your next run. \n  For more information about static mutants visit: https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants\n  (disable "${optionsPath(
+          )}% of the time running the tests!\n  You might want to enable "ignoreStatic" to speed up your next run, at the cost of no longer testing these static mutants. They will be reported as "ignored" and excluded from your mutation score. \n  For more information about static mutants visit: https://stryker-mutator.io/docs/mutation-testing-elements/static-mutants\n  (disable "${optionsPath(
             'warnings',
             'slow',
           )}" to ignore this warning)`,

--- a/packages/core/test/unit/mutants/mutant-test-planner.spec.ts
+++ b/packages/core/test/unit/mutants/mutant-test-planner.spec.ts
@@ -545,6 +545,9 @@ describe(MutantTestPlanner.name, () => {
           'Detected 1 static mutants (14% of total) that are estimated to take 40% of the time running the tests!',
         )
         .and.calledWithMatch(
+          'They will be reported as "ignored" and excluded from your mutation score.',
+        )
+        .and.calledWithMatch(
           '(disable "warnings.slow" to ignore this warning)',
         );
     });


### PR DESCRIPTION
The "slow static mutants" warning only advertised the speed benefit of enabling `ignoreStatic`, never the cost. Enabling it marks those mutants as `Ignored` and excludes them from the mutation score, so you lose all kill/survive insight for that code. This makes the warning read as a free win when it is really a tradeoff.

The warning now states that tradeoff, and the `ignoreStatic` docs note the same. I deliberately avoid the word "coverage" here, since Stryker already uses it for test coverage of mutants and it would be ambiguous.