### PR TITLE
perf(core): schedule static mutants last to avoid transition reloads

### DIFF
--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -47,16 +47,6 @@ export interface MutationTestContext extends DryRunContext {
 
 const CHECK_BUFFER_MS = 10_000;
 
-/**
- * Sorting the tests just before running them can yield a significant performance boost,
- * because it can reduce the number of times a test runner process needs to be recreated.
- * However, we need to buffer the results in order to be able to sort them.
- *
- * This value is very low, since it would halt the test execution otherwise.
- * @see https://github.com/stryker-mutator/stryker-js/issues/3462
- */
-const BUFFER_FOR_SORTING_MS = 0;
-
 export class MutationTestExecutor {
   public static inject = tokens(
     coreTokens.reporter,
@@ -150,12 +140,18 @@ export class MutationTestExecutor {
   private executeRunInTestRunner(
     input$: Observable<MutantRunPlan>,
   ): Observable<MutantResult> {
-    const sortedPlan$ = input$.pipe(
-      bufferTime(BUFFER_FOR_SORTING_MS),
-      mergeMap((plans) => plans.sort(reloadEnvironmentLast)),
+    // Run all mutants that reuse the test environment first and the ones that need a
+    // reload (static mutants) last, across the whole run rather than per buffered batch.
+    // Interleaving them forces an extra environment reload on whichever mutant follows a
+    // static one, which on large suites adds up to many avoidable reloads.
+    const sharedPlan$ = input$.pipe(shareReplay());
+    const [reloadPlan$, noReloadPlan$] = partition(
+      sharedPlan$,
+      ({ runOptions }) => Boolean(runOptions.reloadEnvironment),
     );
+    const orderedPlan$ = concat(noReloadPlan$, reloadPlan$);
     return this.testRunnerPool.schedule(
-      sortedPlan$,
+      orderedPlan$,
       async (testRunner, { mutant, runOptions }) => {
         const result = await testRunner.mutantRun(runOptions);
         return this.mutationTestReportHelper.reportMutantRunResult(
@@ -251,22 +247,4 @@ export class MutationTestExecutor {
       );
     return checkTask$;
   }
-}
-
-/**
- * Sorting function that sorts mutant run plans that reload environments last.
- * This can yield a significant performance boost, because it reduces the times a test runner process needs to restart.
- * @see https://github.com/stryker-mutator/stryker-js/issues/3462
- */
-function reloadEnvironmentLast(a: MutantRunPlan, b: MutantRunPlan): number {
-  if (a.plan === PlanKind.Run && b.plan === PlanKind.Run) {
-    if (a.runOptions.reloadEnvironment && !b.runOptions.reloadEnvironment) {
-      return 1;
-    }
-    if (!a.runOptions.reloadEnvironment && b.runOptions.reloadEnvironment) {
-      return -1;
-    }
-    return 0;
-  }
-  return 0;
 }


### PR DESCRIPTION
Static mutants force a test-runner environment reload (a full worker restart on mocha, jasmine, karma and tap). Today the run plans are sorted only within each buffered micro-batch, so static and non-static plans interleave across batches. Each interleaving forces an *extra* reload on the non-static mutant that happens to follow a static one, on top of the reload the static mutant itself needs.

This orders the whole run non-reload-first and reload (static) last instead of per batch, so static plans no longer interleave with the rest and nothing pays a transition reload. Non-static mutants still stream and overlap with the checker as before; only the static tail is deferred.

I found this with the experimental performance report from #6136, and the two PRs are independent (apply both to reproduce). Measured as a controlled back-to-back A/B on an idle machine on a large mocha + TypeScript project (same config, 2558 mutants run):

| metric | before | after |
|---|---|---|
| environment reloads | 818 | 508 (-38%) |
| total wall time | 456.4s | 429.6s (-5.9%) |
| mutation phase | 414.1s | 382.3s (-7.7%) |

The reload-count reduction is deterministic (the transition reloads are eliminated, so the count now matches the static-mutant count). The wall-time figures are single-run and this suite is noisy, so treat them as directional; the win grows with the share of static mutants and is specific to full-restart runners (mocha, jasmine, karma, tap).
