### PR TITLE
fix(core): always print final progress line in progress-append-only reporter

### DIFF
--- a/packages/core/src/reporters/progress-append-only-reporter.ts
+++ b/packages/core/src/reporters/progress-append-only-reporter.ts
@@ -20,6 +20,9 @@ export class ProgressAppendOnlyReporter extends ProgressKeeper {
     if (this.intervalReference) {
       clearInterval(this.intervalReference);
     }
+    if (this.progress.mutants > 0) {
+      this.render();
+    }
   }
 
   private render() {

--- a/packages/core/test/unit/reporters/progress-append-only-reporter.spec.ts
+++ b/packages/core/test/unit/reporters/progress-append-only-reporter.spec.ts
@@ -138,5 +138,31 @@ describe(ProgressAppendOnlyReporter.name, () => {
         `Mutation testing 82% (elapsed: <1m, remaining: <1m) 2/4 tested (1 survived, 1 timed out)${os.EOL}`,
       );
     });
+
+    it('should log a final progress line when mutation testing completes between ticks', () => {
+      // 20/145*100 = 13.7
+      sut.onMutantTested(factory.survivedMutantResult({ id: '3' }));
+      sut.onMutantTested(factory.killedMutantResult({ id: '5' }));
+      expect(process.stdout.write).to.not.have.been.called;
+
+      sut.onMutationTestReportReady();
+
+      expect(process.stdout.write).to.have.been.calledWith(
+        `Mutation testing 13% (elapsed: <1m, remaining: n/a) 2/4 tested (1 survived, 0 timed out)${os.EOL}`,
+      );
+    });
+  });
+
+  describe('onMutationTestReportReady() without mutants to test', () => {
+    it('should not log a progress line', () => {
+      sut.onDryRunCompleted(factory.dryRunCompletedEvent());
+      sut.onMutationTestingPlanReady(
+        factory.mutationTestingPlanReadyEvent({ mutantPlans: [] }),
+      );
+
+      sut.onMutationTestReportReady();
+
+      expect(process.stdout.write).to.not.have.been.called;
+    });
   });
 });


### PR DESCRIPTION
When you pipe `stryker run` somewhere non-TTY (CI, `| cat`, and so on) it falls back to the `progress-append-only` reporter. That one only prints every 10 seconds and never printed anything when the run finished, so if things wrapped up between two ticks the last update just got dropped.

The annoying part is that the dropped line is often the one that finally shows a survived mutant, so you could end up with a failing build and nothing in the console explaining why.

This renders one last time when testing completes. Fixes #5929.