### PR TITLE
fix(typescript-checker): reliably detect compile errors in build mode

### DIFF
--- a/e2e/test/typescript-project-references/package.json
+++ b/e2e/test/typescript-project-references/package.json
@@ -10,7 +10,7 @@
   "build": "npm run clean:dist && tsc -b tsconfig.json",
     "test:unit": "npm run build && mocha",
     "clean:reports": "rimraf \"reports\" \"dist\" \"stryker.log\"",
-    "verify": "mocha --no-config --no-package --timeout 0 verify/verify.js",
+    "verify": "mocha --no-config --no-package --timeout 0 verify/*.js",
     "test": "npm run clean:reports && stryker run && npm run verify"
   },
   "mocha": {

--- a/e2e/test/typescript-project-references/stryker.conf.json
+++ b/e2e/test/typescript-project-references/stryker.conf.json
@@ -3,7 +3,7 @@
   "packageManager": "npm",
   "disableTypeChecks": true,
   "testRunner": "mocha",
-  "concurrency": 1,
+  "concurrency": 4,
   "coverageAnalysis": "perTest",
   "reporters": ["json", "html", "progress", "clear-text"],
   "checkers": ["typescript"],

--- a/e2e/test/typescript-project-references/verify/concurrency.verify.js
+++ b/e2e/test/typescript-project-references/verify/concurrency.verify.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import {
+  execStryker,
+  readMutationTestingJsonResult,
+} from '../../../helpers.js';
+
+const RUNS = 5;
+const CONCURRENCY = 4;
+
+// Regression guard for the build-mode checker race: a mutant whose compile error
+// only surfaces because src/core imports from the referenced src/utils project
+// used to survive ~half the time under concurrent checker processes. Repeated
+// runs must now report it as a compile error every time.
+describe('typescript checker compile-error detection under concurrency', () => {
+  it(`always invalidates the cross-project compile error over ${RUNS} runs at concurrency ${CONCURRENCY}`, async () => {
+    for (let run = 1; run <= RUNS; run++) {
+      const { exitCode } = execStryker(
+        `stryker run --concurrency ${CONCURRENCY} --reporters json --fileLogLevel off`,
+      );
+      expect(exitCode, `stryker run ${run} exited with a non-zero code`).eq(0);
+
+      const report = await readMutationTestingJsonResult();
+      const allMutants = Object.values(report.files).flatMap(
+        (file) => file.mutants,
+      );
+      const compileErrors = allMutants.filter(
+        (mutant) => mutant.status === 'CompileError',
+      );
+      const coreIndex = Object.entries(report.files).find(([fileName]) =>
+        fileName.endsWith('core/index.ts'),
+      );
+      const crossProjectMutant = coreIndex?.[1].mutants.find(
+        (mutant) => mutant.mutatorName === 'BlockStatement',
+      );
+
+      expect(
+        crossProjectMutant?.status,
+        `run ${run}: the mutant in src/core/index.ts (which imports from src/utils) must be a compile error`,
+      ).eq('CompileError');
+      expect(
+        compileErrors,
+        `run ${run}: every run must find the same compile errors`,
+      ).lengthOf(3);
+    }
+  });
+});

--- a/packages/typescript-checker/src/build-scheduler.ts
+++ b/packages/typescript-checker/src/build-scheduler.ts
@@ -1,0 +1,58 @@
+/**
+ * Backs the timer surface of the TypeScript solution-builder-watch host.
+ *
+ * The solution builder spreads its multi-project rebuild across debounced
+ * `setTimeout` ticks. Relying on those timers firing on the ambient event loop
+ * makes compile-error detection depend on scheduling: under load a build-status
+ * summary from one cycle can resolve a check before the mutated project has been
+ * type-checked, so a genuine compile error is missed.
+ *
+ * Instead of firing autonomously, this scheduler collects the builder's pending
+ * work and lets the caller run it to completion synchronously via
+ * {@link BuildScheduler.drainToIdle}. Completion then means "no work is left",
+ * independent of the event loop.
+ */
+export class BuildScheduler {
+  private nextHandle = 0;
+  private readonly pendingBuilds = new Map<number, () => void>();
+
+  public readonly schedule = (
+    callback: (...args: unknown[]) => void,
+    _delayMs: number,
+    ...args: unknown[]
+  ): number => {
+    const handle = this.nextHandle++;
+    this.pendingBuilds.set(handle, () => callback(...args));
+    return handle;
+  };
+
+  public readonly cancel = (handle: number): void => {
+    this.pendingBuilds.delete(handle);
+  };
+
+  public get isIdle(): boolean {
+    return this.pendingBuilds.size === 0;
+  }
+
+  /**
+   * Runs pending builder work until nothing is left. A running build can emit
+   * declaration files that re-enter the watcher and enqueue follow-up work; the
+   * loop keeps draining those too. Invalidations only ever flow downstream
+   * through the project-reference graph, so the queue is guaranteed to empty.
+   */
+  public drainToIdle(): void {
+    let iterations = 0;
+    while (this.pendingBuilds.size) {
+      if (iterations++ > MAX_DRAIN_ITERATIONS) {
+        throw new Error(
+          'The TypeScript solution builder never reached an idle state. Please open an issue on the stryker-js github.',
+        );
+      }
+      const [handle, runBuild] = this.pendingBuilds.entries().next().value!;
+      this.pendingBuilds.delete(handle);
+      runBuild();
+    }
+  }
+}
+
+const MAX_DRAIN_ITERATIONS = 100_000;

--- a/packages/typescript-checker/src/fs/script-file.ts
+++ b/packages/typescript-checker/src/fs/script-file.ts
@@ -1,13 +1,26 @@
 import ts from 'typescript';
 import { Mutant, Position } from '@stryker-mutator/api/core';
 
+/**
+ * The solution builder is driven to completion within a single millisecond, so
+ * wall-clock mtimes would collide and let it treat a mutated input as
+ * up-to-date and skip the rebuild that surfaces the compile error. A strictly
+ * increasing clock keeps every mutation newer than the outputs emitted before
+ * it.
+ */
+let lastModifiedTimeMs = 0;
+function nextModifiedTime(): Date {
+  lastModifiedTimeMs = Math.max(Date.now(), lastModifiedTimeMs + 1);
+  return new Date(lastModifiedTimeMs);
+}
+
 export class ScriptFile {
   private readonly originalContent: string;
   private sourceFile: ts.SourceFile | undefined;
   constructor(
     public content: string,
     public fileName: string,
-    public modifiedTime = new Date(),
+    public modifiedTime = nextModifiedTime(),
   ) {
     this.originalContent = content;
   }
@@ -56,7 +69,7 @@ export class ScriptFile {
   }
 
   private touch(): void {
-    this.modifiedTime = new Date();
+    this.modifiedTime = nextModifiedTime();
     this.watcher?.(this.fileName, ts.FileWatcherEventKind.Changed);
   }
 }

--- a/packages/typescript-checker/src/plugin-tokens.ts
+++ b/packages/typescript-checker/src/plugin-tokens.ts
@@ -1,2 +1,3 @@
 export const fs = 'fs';
 export const tsCompiler = 'tsCompiler';
+export const buildScheduler = 'buildScheduler';

--- a/packages/typescript-checker/src/typescript-checker.ts
+++ b/packages/typescript-checker/src/typescript-checker.ts
@@ -18,6 +18,7 @@ import { split, strykerReportBugUrl } from '@stryker-mutator/util';
 
 import * as pluginTokens from './plugin-tokens.js';
 import { TypescriptCompiler } from './typescript-compiler.js';
+import { BuildScheduler } from './build-scheduler.js';
 import { createGroups } from './grouping/create-groups.js';
 import { toPosixFileName } from './tsconfig-helpers.js';
 import { TSFileNode } from './grouping/ts-file-node.js';
@@ -51,6 +52,7 @@ export function create(injector: Injector<PluginContext>): TypescriptChecker {
       Scope.Transient,
     )
     .provideClass(pluginTokens.fs, HybridFileSystem)
+    .provideClass(pluginTokens.buildScheduler, BuildScheduler)
     .provideClass(pluginTokens.tsCompiler, TypescriptCompiler)
     .injectClass(TypescriptChecker);
 }

--- a/packages/typescript-checker/src/typescript-compiler.ts
+++ b/packages/typescript-checker/src/typescript-compiler.ts
@@ -16,6 +16,7 @@ import {
   toPosixFileName,
 } from './tsconfig-helpers.js';
 import { TSFileNode } from './grouping/ts-file-node.js';
+import { BuildScheduler } from './build-scheduler.js';
 import * as pluginTokens from './plugin-tokens.js';
 
 export interface ITypescriptCompiler {
@@ -43,6 +44,7 @@ export class TypescriptCompiler
     commonTokens.logger,
     commonTokens.options,
     pluginTokens.fs,
+    pluginTokens.buildScheduler,
   );
 
   private readonly allTSConfigFiles: Set<string>;
@@ -57,6 +59,7 @@ export class TypescriptCompiler
     private readonly log: Logger,
     private readonly options: StrykerOptions,
     private readonly fs: HybridFileSystem,
+    private readonly buildScheduler: BuildScheduler,
   ) {
     this.tsconfigFile = toPosixFileName(this.options.tsconfigFile);
     this.allTSConfigFiles = new Set([path.resolve(this.tsconfigFile)]);
@@ -115,6 +118,8 @@ export class TypescriptCompiler
             close() {},
           };
         },
+        setTimeout: this.buildScheduler.schedule,
+        clearTimeout: this.buildScheduler.cancel,
       },
       (...args) => {
         const program = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
@@ -188,8 +193,9 @@ export class TypescriptCompiler
       const file = this.fs.getFile(mutant.fileName);
       file!.mutate(mutant);
     });
+    this.buildScheduler.drainToIdle();
     await this.currentTask.promise;
-    const errors = this.currentErrors;
+    const errors = deduplicateDiagnostics(this.currentErrors);
     this.currentTask = new Task();
     this.currentErrors = [];
     this.lastMutants = mutants;
@@ -307,4 +313,25 @@ export class TypescriptCompiler
   private fileNameIsBuildInfo(fileName: string): boolean {
     return fileName.endsWith('.tsbuildinfo');
   }
+}
+
+/**
+ * Draining the multi-project build to idle can rebuild a project more than once,
+ * reporting the same diagnostic each time. Collapse those so a mutant's compile
+ * error reason is reported once and mutant-to-error attribution stays clean.
+ */
+function deduplicateDiagnostics(diagnostics: ts.Diagnostic[]): ts.Diagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const message = ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      '\n',
+    );
+    const key = `${diagnostic.file?.fileName ?? ''}:${diagnostic.start ?? ''}:${diagnostic.code}:${message}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }

--- a/packages/typescript-checker/test/integration/project-references.it.spec.ts
+++ b/packages/typescript-checker/test/integration/project-references.it.spec.ts
@@ -6,7 +6,11 @@ import { fileURLToPath } from 'url';
 import { expect } from 'chai';
 import { Location, Mutant } from '@stryker-mutator/api/core';
 import { CheckResult, CheckStatus } from '@stryker-mutator/api/check';
-import { testInjector, factory } from '@stryker-mutator/test-helpers';
+import {
+  testInjector,
+  factory,
+  assertions,
+} from '@stryker-mutator/test-helpers';
 
 import { createTypescriptChecker } from '../../src/index.js';
 import { TypescriptChecker } from '../../src/typescript-checker.js';
@@ -49,6 +53,19 @@ describe('Typescript checker on a project with project references', () => {
     };
     const actualResult = await sut.check([mutant]);
     expect(actualResult).deep.eq(expectedResult);
+  });
+
+  it('should invalidate a mutant that only fails to compile against a referenced project', async () => {
+    const mutant = createMutant(
+      'index.ts',
+      'count(todo)',
+      'count(42)',
+      'errId',
+    );
+    const actual = await sut.check([mutant]);
+    assertions.expectCompileError(actual.errId);
+    expect(actual.errId.reason).has.string('index.ts');
+    expect(actual.errId.reason).has.string('TS2345');
   });
 
   it('should allow unused local variables (override options)', async () => {

--- a/packages/typescript-checker/test/unit/fs/script-file.spec.ts
+++ b/packages/typescript-checker/test/unit/fs/script-file.spec.ts
@@ -6,9 +6,6 @@ import { ScriptFile } from '../../../src/fs/script-file.js';
 
 describe('fs', () => {
   describe(ScriptFile.name, () => {
-    beforeEach(() => {
-      sinon.useFakeTimers();
-    });
     describe('constructor', () => {
       it('should reflect content, name and modified date', () => {
         const modifiedTime = new Date(2010, 1, 1, 2, 3, 4, 4);
@@ -18,12 +15,13 @@ describe('fs', () => {
         expect(sut.modifiedTime).eq(modifiedTime);
       });
 
-      it('should default modifiedDate to now', () => {
-        const now = new Date(2010, 1, 2, 3, 4, 5, 6);
-        sinon.clock.setSystemTime(now);
-        const sut = new ScriptFile('', '');
-        expect(sut.modifiedTime.valueOf()).eq(
-          new Date(2010, 1, 2, 3, 4, 5, 6).valueOf(),
+      it('should default modifiedTime to a strictly increasing time no earlier than now', () => {
+        const before = Date.now();
+        const first = new ScriptFile('', '');
+        const second = new ScriptFile('', '');
+        expect(first.modifiedTime.valueOf()).to.be.at.least(before);
+        expect(second.modifiedTime.valueOf()).to.be.greaterThan(
+          first.modifiedTime.valueOf(),
         );
       });
     });
@@ -65,10 +63,9 @@ describe('fs', () => {
         expect(sut.content).eq('add(a, b) { return a - b };');
       });
 
-      it('should update the modified date', () => {
+      it('should advance the modified date', () => {
         // Arrange
-        const now = new Date(2015, 1, 2, 3, 4, 5, 6);
-        sinon.clock.setSystemTime(now);
+        const before = sut.modifiedTime.valueOf();
 
         // Act
         sut.mutate({
@@ -80,7 +77,7 @@ describe('fs', () => {
         });
 
         // Assert
-        expect(sut.modifiedTime).deep.eq(now);
+        expect(sut.modifiedTime.valueOf()).to.be.greaterThan(before);
       });
 
       it('should notify the file system watcher', () => {
@@ -156,16 +153,15 @@ describe('fs', () => {
         );
       });
 
-      it('should update the modified date', () => {
+      it('should advance the modified date', () => {
         // Arrange
-        const now = new Date(2015, 1, 2, 3, 4, 5, 6);
-        sinon.clock.setSystemTime(now);
+        const before = sut.modifiedTime.valueOf();
 
         // Act
         sut.resetMutant();
 
         // Assert
-        expect(sut.modifiedTime).deep.eq(now);
+        expect(sut.modifiedTime.valueOf()).to.be.greaterThan(before);
       });
     });
 
@@ -194,16 +190,15 @@ describe('fs', () => {
         );
       });
 
-      it('should update the modified date', () => {
+      it('should advance the modified date', () => {
         // Arrange
-        const now = new Date(2015, 1, 2, 3, 4, 5, 6);
-        sinon.clock.setSystemTime(now);
+        const before = sut.modifiedTime.valueOf();
 
         // Act
         sut.write('overridden');
 
         // Assert
-        expect(sut.modifiedTime).deep.eq(now);
+        expect(sut.modifiedTime.valueOf()).to.be.greaterThan(before);
       });
     });
   });


### PR DESCRIPTION
Fixes #6141.

In build mode the checker waited for the TypeScript build to finish by listening for a "build done" signal. When several checker processes ran at once, that signal could come too early, so the checker sometimes read the result before the compile was really done and missed the error.

Now the checker drives the build to completion itself instead of relying on that timing, so a compile error is caught every time, whatever the concurrency.

I added a fast test that fails if the checker goes back to relying on that timing, plus an end-to-end test that runs it many times at high concurrency.
