### PR TITLE
fix(core): activate static mutants before module load

### DIFF
--- a/packages/core/src/mutants/mutant-test-planner.ts
+++ b/packages/core/src/mutants/mutant-test-planner.ts
@@ -208,7 +208,7 @@ export class MutantTestPlanner {
           mutatorName: mutant.mutatorName,
           replacement: mutant.replacement,
         },
-        mutantActivation: testFilter ? 'runtime' : 'static',
+        mutantActivation: canHotSwap ? 'runtime' : 'static',
         timeout,
         testFilter,
         sandboxFileName: this.sandbox.sandboxFileFor(mutant.fileName),

--- a/packages/core/test/unit/mutants/mutant-test-planner.spec.ts
+++ b/packages/core/test/unit/mutants/mutant-test-planner.spec.ts
@@ -472,7 +472,7 @@ describe(MutantTestPlanner.name, () => {
         // Assert
         assertIsRunPlan(plan);
         expect(plan.runOptions.testFilter).deep.eq(['sandbox/src/foo.spec.ts']);
-        expect(plan.runOptions.mutantActivation).eq('runtime');
+        expect(plan.runOptions.mutantActivation).eq('static');
         expect(plan.runOptions.reloadEnvironment).true;
       });
 
@@ -498,7 +498,7 @@ describe(MutantTestPlanner.name, () => {
         // Assert
         assertIsRunPlan(plan);
         expect(plan.runOptions.testFilter).deep.eq(['sandbox/src/foo.spec.ts']);
-        expect(plan.runOptions.mutantActivation).eq('runtime');
+        expect(plan.runOptions.mutantActivation).eq('static');
         expect(plan.runOptions.reloadEnvironment).true;
       });
     });


### PR DESCRIPTION
Fixes #6144.

Static and unknown-static mutants with a `testFilter` require a test environment reload, but the planner selected runtime activation from the filter alone. Vitest then activated the mutant after the importing module had already initialized, allowing covered static mutants to survive.

This uses the planner's existing `canHotSwap` decision for both environment reload and activation mode. Non-static filtered mutants retain runtime activation; static and unknown-static filtered mutants activate before module loading.

Validation:

- Red-phase: the two existing `testFiles` planner contracts failed with `runtime` instead of `static`.
- Green-phase: all three `testFiles` planner contracts pass.
- Targeted TypeScript build passes.
- ESLint passes for both changed files.
