### PR TITLE
fix(vitest-runner): never report a mutant run that executed zero tests as survived

### DIFF
--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -50,6 +50,12 @@ type StrykerNamespace = '__stryker__' | '__stryker2__';
 const STRYKER_SETUP = fileURLToPath(
   new URL('./stryker-setup.js', import.meta.url),
 );
+/**
+ * Maximum number of times a mutant run is re-issued when vitest completed it
+ * without executing any of the tests selected by the test filter. See
+ * https://github.com/stryker-mutator/stryker-js/issues/6073.
+ */
+const MAX_EMPTY_FILTERED_RUN_RETRIES = 3;
 
 interface RunFilter {
   /**
@@ -207,13 +213,49 @@ export class VitestTestRunner implements TestRunner {
     this.ctx!.provide('hitLimit', options.hitLimit);
     this.ctx!.provide('mutantActivation', options.mutantActivation);
     this.ctx!.provide('activeMutant', options.activeMutant.id);
-    const dryRunResult = await this.run({
+    const runFilter: RunFilter = {
       testIds: options.testFilter,
       relatedFiles: [options.sandboxFileName],
-    });
+    };
+    let dryRunResult = await this.run(runFilter);
+    for (
+      let retry = 1;
+      this.isEmptyFilteredRun(options.testFilter, dryRunResult) &&
+      retry <= MAX_EMPTY_FILTERED_RUN_RETRIES;
+      retry++
+    ) {
+      this.log.debug(
+        'Mutant run for mutant %s completed without executing any of its %s filtered tests, retrying (%s/%s).',
+        options.activeMutant.id,
+        options.testFilter!.length,
+        retry,
+        MAX_EMPTY_FILTERED_RUN_RETRIES,
+      );
+      dryRunResult = await this.run(runFilter);
+    }
+    if (this.isEmptyFilteredRun(options.testFilter, dryRunResult)) {
+      // A run that executed none of its selected tests proves nothing about
+      // the mutant; reporting it based on "no test failed" would produce a
+      // false survivor (see https://github.com/stryker-mutator/stryker-js/issues/6073).
+      return toMutantRunResult({
+        status: DryRunStatus.Error,
+        errorMessage: `Vitest completed the mutant run without executing any of the ${options.testFilter!.length} tests selected for mutant ${options.activeMutant.id} (after ${MAX_EMPTY_FILTERED_RUN_RETRIES} retries).`,
+      });
+    }
     const hitCount = this.readHitCount();
     const timeOut = determineHitLimitReached(hitCount, options.hitLimit);
     return toMutantRunResult(timeOut ?? dryRunResult);
+  }
+
+  private isEmptyFilteredRun(
+    testFilter: string[] | undefined,
+    result: DryRunResult,
+  ): boolean {
+    return (
+      (testFilter?.length ?? 0) > 0 &&
+      result.status === DryRunStatus.Complete &&
+      result.tests.length === 0
+    );
   }
 
   private async run({

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -3,15 +3,20 @@ import { expect } from 'chai';
 import fs from 'fs';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import {
+  ErrorMutantRunResult,
   MutantRunStatus,
   TestRunnerCapabilities,
 } from '@stryker-mutator/api/test-runner';
-import { Vitest } from 'vitest/node';
+import { RunnerTestFile, Vitest } from 'vitest/node';
 
 import { VitestTestRunner } from '../../src/vitest-test-runner.js';
 import { VitestRunnerOptionsWithStrykerOptions } from '../../src/vitest-runner-options-with-stryker-options.js';
 import { vitestWrapper } from '../../src/vitest-wrapper.js';
-import { createVitestMock } from '../util/factories.js';
+import {
+  createVitestFile,
+  createVitestMock,
+  createVitestTest,
+} from '../util/factories.js';
 import { VITEST_ERROR_CODES } from '../../src/vitest-helpers.js';
 
 describe(VitestTestRunner.name, () => {
@@ -155,6 +160,55 @@ describe(VitestTestRunner.name, () => {
         'mode',
         'mutant',
       );
+    });
+
+    it('should report an error instead of survived when a filtered run repeatedly executes no tests', async () => {
+      // A run that executed none of the selected tests proves nothing about
+      // the mutant; treating it as "no test failed" produces false survivors.
+      // See https://github.com/stryker-mutator/stryker-js/issues/6073
+      const options = factory.mutantRunOptions({
+        testFilter: ['file.spec.js#suite-test > test1'],
+        activeMutant: factory.mutant({ id: '42' }),
+      });
+
+      const result = await sut.mutantRun(options);
+
+      expect(result.status).eq(MutantRunStatus.Error);
+      expect((result as ErrorMutantRunResult).errorMessage).contains(
+        'without executing any of the 1 tests selected for mutant 42',
+      );
+      // initial run + 3 retries
+      sinon.assert.callCount(vitestStub.start as sinon.SinonStub, 4);
+    });
+
+    it('should return the verdict of a retried filtered run that does execute tests', async () => {
+      const passingFile = createVitestFile({
+        tasks: [createVitestTest({ result: { state: 'pass', duration: 1 } })],
+      });
+      const getFilesStub = sinon.stub<[], RunnerTestFile[]>();
+      getFilesStub.onFirstCall().returns([]);
+      getFilesStub.returns([passingFile]);
+      (
+        vitestStub.state as unknown as { getFiles: () => RunnerTestFile[] }
+      ).getFiles = getFilesStub;
+      const options = factory.mutantRunOptions({
+        testFilter: ['file.spec.js#suite-test > test1'],
+      });
+
+      const result = await sut.mutantRun(options);
+
+      expect(result.status).eq(MutantRunStatus.Survived);
+      // initial run + 1 retry
+      sinon.assert.callCount(vitestStub.start as sinon.SinonStub, 2);
+    });
+
+    it('should not treat an unfiltered run without tests as an error', async () => {
+      const result = await sut.mutantRun(
+        factory.mutantRunOptions({ testFilter: undefined }),
+      );
+
+      expect(result.status).eq(MutantRunStatus.Survived);
+      sinon.assert.callCount(vitestStub.start as sinon.SinonStub, 1);
     });
   });
 


### PR DESCRIPTION
Fixes #6073

Under load, a filtered mutant run can complete with its test tasks collected but never executed. `ctx.state` then holds result-less tasks, `.filter((test) => test.result)` empties the result list, and `toMutantRunResult` reports **survived** with `hitCount 0` — even though no test ever ran against the mutant. This is the source of the non-deterministic `Survived` ↔ `Killed`/`Timeout` verdict flips in #6073 (full instrumented evidence in [this comment](https://github.com/stryker-mutator/stryker-js/issues/6073#issuecomment-5084446638)): every unstable verdict is a zero-test run, and verdicts with at least one executed test are stable.

The run loss itself is timing-dependent (clustered after bail-aborted runs). I could not reproduce it outside real Stryker orchestration (~1,400 instrumented pure-vitest runs mimicking the runner exactly are clean), but the runner should not trust an empty run regardless of the trigger: a run that executed none of its selected tests proves nothing about the mutant.

### Change

In `mutantRun`, when `testFilter` is non-empty and the run completed with zero executed tests:

1. retry the run (bounded, 3 attempts) — re-dispatching succeeds in practice;
2. if it still comes back empty, return an **error** run result stating the invariant, so core reschedules/reports it instead of recording a phantom survivor.

Unfiltered runs (no `testFilter`) are unaffected.

### Verification

Against [stryker-pertest-flip-repro](https://github.com/scolladon/stryker-pertest-flip-repro) (vitest 4.1.9 and 4.1.10):

- unpatched: `>>> FLIP DETECTED` on every 5-run batch; survivors swing 5–11;
- patched: 5/5 byte-identical reports (`47 Killed / 5 Survived / 5 Timeout`); 16 lost runs absorbed by retries (max 3 for one mutant); genuine survivors unchanged.

Open question: if you'd rather surface exhaustion as a different status than an error result (e.g. treat it like a timeout so core retries in a fresh process), happy to adjust.