### PR TITLE
fix(deps): update typed-rest-client to ~3.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "tree-kill": "~1.2.2",
     "tslib": "2.8.1",
     "typed-inject": "~5.0.0",
-    "typed-rest-client": "~2.3.0"
+    "typed-rest-client": "~3.1.0"
   },
   "devDependencies": {
     "@stryker-mutator/test-helpers": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,8 +1092,8 @@ importers:
         specifier: ~5.0.0
         version: 5.0.0
       typed-rest-client:
-        specifier: ~2.3.0
-        version: 2.3.0
+        specifier: ~3.1.0
+        version: 3.1.0
     devDependencies:
       '@stryker-mutator/test-helpers':
         specifier: workspace:*
@@ -14317,8 +14317,8 @@ packages:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   qs@6.5.5:
@@ -15072,6 +15072,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -16157,9 +16161,9 @@ packages:
     resolution: {integrity: sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==}
     engines: {node: '>=18'}
 
-  typed-rest-client@2.3.0:
-    resolution: {integrity: sha512-FfBj5tjviexjIus3La4n4s9i+f81Zj7HU+lUlQWK219HMRfmzLsbIf4PZF2+X6EouJKyuANpvvef5VrUWM4AFw==}
-    engines: {node: '>= 16.0.0'}
+  typed-rest-client@3.1.0:
+    resolution: {integrity: sha512-8fMeur8aKaJw8WsqYUZD4CsUfpMFH3zWlRQigM3KWs406KGjqPMdTBn7RfIpMvPjZ1bH+S8QwG+FK/VY/8ndKg==}
+    engines: {node: '>= 20.0.0'}
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -23291,7 +23295,7 @@ snapshots:
       tree-kill: 1.2.2
       tslib: 2.8.1
       typed-inject: 5.0.0
-      typed-rest-client: 2.3.0
+      typed-rest-client: 3.1.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -23322,7 +23326,7 @@ snapshots:
       tree-kill: 1.2.2
       tslib: 2.8.1
       typed-inject: 5.0.0
-      typed-rest-client: 2.3.0
+      typed-rest-client: 3.1.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -23353,7 +23357,7 @@ snapshots:
       tree-kill: 1.2.2
       tslib: 2.8.1
       typed-inject: 5.0.0
-      typed-rest-client: 2.3.0
+      typed-rest-client: 3.1.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -35437,9 +35441,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.15.1:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   qs@6.5.5: {}
 
@@ -36514,6 +36519,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -37990,11 +38003,11 @@ snapshots:
 
   typed-inject@5.0.0: {}
 
-  typed-rest-client@2.3.0:
+  typed-rest-client@3.1.0:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.3
       tunnel: 0.0.6
       underscore: 1.13.8
 


### PR DESCRIPTION
Closes #6176.

## Summary

- update `typed-rest-client` from `~2.3.0` to `~3.1.0`
- update the lockfile to resolve `qs@6.15.3`, removing GHSA-q8mj-m7cp-5q26 from this dependency path
- retain compatibility with the project Node requirement (`typed-rest-client@3.1.0` requires Node >=20; Stryker requires Node >=22)

The `RestClient` and `HttpClient` APIs used by the npm initializer and dashboard reporter remain available in 3.1.0. The main upstream behavioral change is migration from the legacy Node URL parser to the WHATWG `URL` API.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run lint`
- `pnpm --filter @stryker-mutator/core test` (1,038 unit and 77 integration tests passed)