### PR TITLE
feat(vitest-runner): report test locations

### DIFF
--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -70,7 +70,7 @@ Running in incremental mode, Stryker will do its best to produce an accurate mut
 | 🔵 Karma           | ⚠ Test names only                 |
 | 🥒 CucumberJS      | ✅ Full                           |
 | 📼 Tap             | ⚠ Tests per file without location |
-| ⚡ Vitest          | ⚠ Tests per file without location |
+| ⚡ Vitest          | ✅ Full                           |
 | ▶ Command          | ❌ Nothing                        |
 
 You can use this table to understand why StrykerJS decides not to rerun a specific mutant even though you've changed tests covering that mutant.

--- a/docs/vitest-runner.md
+++ b/docs/vitest-runner.md
@@ -62,6 +62,7 @@ The following options will be set by Stryker and cannot be overridden:
 {
   threads: true,
   coverage: { enabled: false },
+  includeTaskLocation: true,
   singleThread: true,
   watch: false,
   bail: options.disableBail ? 0 : 1,
@@ -76,6 +77,8 @@ As you can see, the vitest runner:
   This is done to boost performance.
 - Will **disable code coverage reporting**  
   This is done because StrykerJS uses it's own [coverage analysis](./configuration.md#coverageanalysis-string), which _is_ supported.
+- Will **report the location of each test**  
+  This is done so [incremental mode](./incremental.md) can tell which tests changed.
 
 ## In-source testing
 

--- a/e2e/test/incremental/verify/verify.js
+++ b/e2e/test/incremental/verify/verify.js
@@ -61,9 +61,9 @@ describe('incremental', () => {
         tempDirName: 'stryker-tmp',
       },
     ],
+    ['vitest', reuseCountExpectation.withFullTestResults],
 
     ['mocha', reuseCountExpectation.withoutTestLocations],
-    ['vitest', reuseCountExpectation.withoutTestLocations],
 
     [
       'tap',

--- a/e2e/test/incremental/verify/verify.js.snap
+++ b/e2e/test/incremental/verify/verify.js.snap
@@ -2234,7 +2234,9 @@ Array [
       "coveredBy": Array [
         "spec/concat.spec.js#concat should concat a and b",
       ],
-      "killedBy": undefined,
+      "killedBy": Array [
+        "spec/concat.spec.js#concat should concat a and b",
+      ],
       "location": Object {
         "end": Object {
           "column": 1,
@@ -2248,9 +2250,10 @@ Array [
       "mutatorName": "BlockStatement",
       "replacement": "{}",
       "static": false,
-      "status": undefined,
+      "status": "Killed",
+      "testsCompleted": 1,
     },
-    "plan": "Run",
+    "plan": "EarlyResult",
   },
   Object {
     "fileName": "src/concat.js",
@@ -2258,7 +2261,9 @@ Array [
       "coveredBy": Array [
         "spec/concat.spec.js#concat should concat a and b",
       ],
-      "killedBy": undefined,
+      "killedBy": Array [
+        "spec/concat.spec.js#concat should concat a and b",
+      ],
       "location": Object {
         "end": Object {
           "column": 19,
@@ -2272,9 +2277,10 @@ Array [
       "mutatorName": "StringLiteral",
       "replacement": "\`\`",
       "static": false,
-      "status": undefined,
+      "status": "Killed",
+      "testsCompleted": 1,
     },
-    "plan": "Run",
+    "plan": "EarlyResult",
   },
   Object {
     "fileName": "src/concat.js",

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -37,6 +37,11 @@ export function convertTestToTestResult(test: RunnerTestCase): TestResult {
     name: collectTestName(test),
     timeSpentMs: test.result?.duration ?? 0,
     fileName: test.file?.filepath && path.resolve(test.file.filepath),
+    startPosition: test.location && {
+      // Stryker works 0-based internally, vitest reports 1-based: https://vitest.dev/config/#includetasklocation
+      line: test.location.line - 1,
+      column: test.location.column - 1,
+    },
   };
   if (status === TestStatus.Failed) {
     return {

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -144,6 +144,8 @@ export class VitestTestRunner implements TestRunner {
       config: this.options.vitest?.configFile,
       ...this.#getVitestPoolConfig(vitestWrapper.version),
       coverage: { enabled: false },
+      // Incremental mode diffs tests by location.
+      includeTaskLocation: true,
       maxConcurrency: 1,
       watch: false,
       dir: this.options.vitest.dir,

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -66,36 +66,42 @@ describe('VitestRunner integration', () => {
             fileName: path.resolve('tests/add.spec.ts'),
             name: 'add should be able to add two numbers',
             status: TestStatus.Success,
+            startPosition: { line: 4, column: 2 },
           },
           {
             id: test2,
             fileName: path.resolve('tests/add.spec.ts'),
             name: 'add should be able to add a negative number',
             status: TestStatus.Success,
+            startPosition: { line: 9, column: 2 },
           },
           {
             id: test3,
             fileName: path.resolve('tests/math.spec.ts'),
             name: 'math should be able negate a number',
             status: TestStatus.Success,
+            startPosition: { line: 13, column: 2 },
           },
           {
             id: test4,
             fileName: path.resolve('tests/math.spec.ts'),
             name: 'math should be able to add one to a number',
             status: TestStatus.Success,
+            startPosition: { line: 4, column: 2 },
           },
           {
             id: test5,
             fileName: path.resolve('tests/math.spec.ts'),
             name: 'math should be able to recognize a negative number',
             status: TestStatus.Success,
+            startPosition: { line: 22, column: 2 },
           },
           {
             id: test6,
             fileName: path.resolve('tests/pi.spec.ts'),
             name: 'pi should be 3.14',
             status: TestStatus.Success,
+            startPosition: { line: 4, column: 2 },
           },
         ]);
       });

--- a/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-helpers.spec.ts
@@ -119,6 +119,18 @@ describe('vitest-helpers', () => {
       const result = convertTestToTestResult(test);
       expect(result.status).to.be.equal(TestStatus.Success);
     });
+
+    it('should report the start position of the test as a 0-based position', () => {
+      const test = createVitestTest({ location: { line: 12, column: 3 } });
+      const result = convertTestToTestResult(test);
+      expect(result.startPosition).deep.equal({ line: 11, column: 2 });
+    });
+
+    it('should not report a start position when vitest did not report a location', () => {
+      const test = createVitestTest({ location: undefined });
+      const result = convertTestToTestResult(test);
+      expect(result.startPosition).undefined;
+    });
   });
 
   describe(collectTestsFromSuite.name, () => {

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -59,6 +59,7 @@ describe(VitestTestRunner.name, () => {
       expect(vitestOptions).deep.include({
         config: undefined,
         coverage: { enabled: false },
+        includeTaskLocation: true,
         maxConcurrency: 1,
         watch: false,
         dir: undefined,


### PR DESCRIPTION
Enable vitest's `includeTaskLocation` and translate the reported task location into the `startPosition` that the test runner API already carries, and that the jest-runner and cucumber-runner report today.

Incremental mode uses the test locations to diff test files. Without them, Stryker has to assume that every test in a changed test file changed, so it reruns every mutant covered by that file. With them, only the mutants covered by the tests that actually changed are rerun. This moves the vitest runner from "tests per file without location" to "full" test reporting.

Stryker stores 0-based lines and columns internally. Vitest builds the location from a V8 stack trace, so both its line and its column are 1-based, and both are decremented. The jest-runner decrements the line only, because jest takes its columns from babel, where they are already 0-based.

Closes #6186.

AI Attribution:
Assisted via Claude Code but reviewed and filed by myself.