### PR TITLE
fix(core): accept prerelease Node versions above minimum

### DIFF
--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -355,7 +355,11 @@ export class StrykerCli {
 export function guardMinimalNodeVersion(
   processVersion = process.version,
 ): void {
-  if (!semver.satisfies(processVersion, strykerEngines.node)) {
+  if (
+    !semver.satisfies(processVersion, strykerEngines.node, {
+      includePrerelease: true,
+    })
+  ) {
     throw new Error(
       `Node.js version ${processVersion} detected. StrykerJS requires version to match ${strykerEngines.node}. Please update your Node.js version or visit https://nodejs.org/ for additional instructions`,
     );

--- a/packages/core/test/unit/stryker-cli.spec.ts
+++ b/packages/core/test/unit/stryker-cli.spec.ts
@@ -343,6 +343,9 @@ describe(StrykerCli.name, () => {
     it('should not fail for >= v22.0.0', () => {
       expect(() => guardMinimalNodeVersion('v22.0.0')).not.throws();
     });
+    it('should not fail for prerelease versions >= v22.0.0', () => {
+      expect(() => guardMinimalNodeVersion('v26.8.0-alpha.0.0.0')).not.throws();
+    });
   });
 
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
## Summary

- allow prerelease Node versions to satisfy StrykerJS' minimum Node guard when they are above the supported floor
- add regression coverage for a Node 26 prerelease version

## Test plan

- `pnpm run build:no-check`
- `cd packages/core && pnpm exec mocha "dist/test/unit/stryker-cli.spec.js" --grep "guardMinimalNodeVersion"`
- `pnpm exec prettier --check packages/core/src/stryker-cli.ts packages/core/test/unit/stryker-cli.spec.ts`
- `pnpm exec eslint packages/core/src/stryker-cli.ts packages/core/test/unit/stryker-cli.spec.ts`
- `git diff --check`

Fixes #6193
