### PR TITLE
feat(core): recover incremental results after a crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ packages/report.*.json # Ignore heap dumps
 tsconfig.*.tsbuildinfo
 packages/core/schema
 __filterSpecs.js
+local-release

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ packages/report.*.json # Ignore heap dumps
 tsconfig.*.tsbuildinfo
 packages/core/schema
 __filterSpecs.js
-local-release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Here are some common tasks to use. Just remember that they don't include compili
 - Use `pnpm run e2e` will install and execute the end to end tests (located in the e2e folder). These take a while.
 - Use `pnpm run perf` will install and execute the performance tests (located in the perf folder). These take a while.
 
+The e2e tests resolve the workspace packages through [injected dependencies](https://pnpm.io/settings#dependenciesmetainjected), which are hard-linked _copies_ of each package's build output rather than symlinks. Building over the existing output keeps those copies current, but anything that recreates the files breaks the link — `pnpm run clean` in particular, since it removes `dist`. The copies then hold the previous build. Run `pnpm install --frozen-lockfile` after such a build to re-link them; this is the install step that `pnpm run e2e` performs for you. `pnpm run e2e:run` fails with an explanatory message when the copies are out of date, but running a single test folder directly (`cd e2e/test/<name> && npm test`) bypasses that check and will silently test the older build.
+
 To run local changes you made in StrykerJS in an actual project you have two options:
 
 1. You can use [install-local](https://www.npmjs.com/package/install-local) to install StrykerJS with plugins in your project. Don't forget to include `instrumenter`, `core`, `util` and `api` in each install. For example, if you want to install Stryker with the jest-runner:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -385,7 +385,7 @@ Config file: `"inPlace": true`<br />
 Determines whether Stryker should mutate your files in place.
 Note: mutating your files in place is generally not needed for mutation testing, unless you have a dependency in your project that is really dependent on the file locations (like "app-root-path" for example).
 
-When `true`, Stryker will override your files, but it will keep a copy of the originals in the temp directory (using `tempDirName`) and it will place the originals back after it is done. Also, with `true` the [`ignorePatterns`](#ignorepatterns-string) has no effect anymore.
+When `true`, Stryker will override your files, but it will keep a copy of the originals in the temp directory (using `tempDirName`) and it will place the originals back after it is done (including on unexpected process exit via a synchronous `process.on('exit')` restore). Also, with `true` the [`ignorePatterns`](#ignorepatterns-string) has no effect anymore.
 
 When `false` (default) Stryker will work in the copy of your code inside the temp directory.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,7 +297,7 @@ Config file: `"ignorePatterns": ["dist", "coverage"]`<br />
 
 Specify the patterns to all files or directories that are not used to run your tests and thus should _not be copied_ to the sandbox directory for mutation testing. Each patterns in this array should be a [glob pattern](#usage-of-globbing-expressions-on-options).
 
-These patterns are **always ignored**: `['node_modules', '.git', '*.tsbuildinfo', '/stryker.log']`. The configured files in the `tempDirName`,`incrementalFile`, `htmlReporter.fileName` and `jsonReporter.fileName` options are also ignored.
+These patterns are **always ignored**: `['node_modules', '.git', '*.tsbuildinfo', '/stryker.log']`. The configured files in the `tempDirName`, `incrementalFile`, `htmlReporter.fileName` and `jsonReporter.fileName` options are also ignored, along with the pending directory next to `incrementalFile` (for example `reports/stryker-incremental.pending/`).
 Because Stryker always ignores these, you should rarely have to adjust the `"ignorePatterns"` setting at all. If you want to undo one of these ignore patterns, you can use the `!` prefix, for example: `["!node_modules"]`.
 
 Overriding `--ignorePatterns` is only needed when you experience a slow Stryker startup, because too many (or too large) files are copied to the sandbox that are not needed to run the tests.
@@ -373,6 +373,8 @@ Config file: `"incrementalFile": "reports/stryker-incremental-alternative.json"`
 
 Specify the file to use for incremental mode.
 See [incremental](./incremental.md) for more details.
+
+While a run is in progress, StrykerJS also writes a sibling `.pending/` directory (for example `reports/stryker-incremental.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore`.
 
 ### `inPlace` [`boolean`]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,7 +297,7 @@ Config file: `"ignorePatterns": ["dist", "coverage"]`<br />
 
 Specify the patterns to all files or directories that are not used to run your tests and thus should _not be copied_ to the sandbox directory for mutation testing. Each patterns in this array should be a [glob pattern](#usage-of-globbing-expressions-on-options).
 
-These patterns are **always ignored**: `['node_modules', '.git', '*.tsbuildinfo', '/stryker.log']`. The configured files in the `tempDirName`, `incrementalFile`, `htmlReporter.fileName` and `jsonReporter.fileName` options are also ignored, along with the pending directory next to `incrementalFile` (for example `reports/stryker-incremental.pending/`).
+These patterns are **always ignored**: `['node_modules', '.git', '*.tsbuildinfo', '/stryker.log']`. The configured files in the `tempDirName`, `incrementalFile`, `htmlReporter.fileName` and `jsonReporter.fileName` options are also ignored, along with the pending directory next to `incrementalFile` (for example `reports/stryker-incremental.json.pending/`).
 Because Stryker always ignores these, you should rarely have to adjust the `"ignorePatterns"` setting at all. If you want to undo one of these ignore patterns, you can use the `!` prefix, for example: `["!node_modules"]`.
 
 Overriding `--ignorePatterns` is only needed when you experience a slow Stryker startup, because too many (or too large) files are copied to the sandbox that are not needed to run the tests.
@@ -374,7 +374,7 @@ Config file: `"incrementalFile": "reports/stryker-incremental-alternative.json"`
 Specify the file to use for incremental mode.
 See [incremental](./incremental.md) for more details.
 
-While a run is in progress, StrykerJS also writes a sibling `.pending/` directory (for example `reports/stryker-incremental.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore`.
+While a run is in progress, StrykerJS also writes a sibling `.pending/` directory (for example `reports/stryker-incremental.json.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore`.
 
 ### `inPlace` [`boolean`]
 

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -46,11 +46,9 @@ Here you can see that:
 
 ## Interrupted runs
 
-If a mutation testing run is interrupted (for example by pressing CTRL+C),
-StrykerJS saves the partial results collected so far to the incremental
-report file. This means the next incremental run can pick up where
-the interrupted run left off, instead of having to redo the work from
-the interrupted run.
+If a mutation testing run is interrupted or crashes (for example by pressing CTRL+C, or a canceled CI job), StrykerJS saves the mutant results completed so far. The next incremental run can pick up where the interrupted run left off, instead of having to redo that work.
+
+While a run is in progress, StrykerJS writes a pending directory next to [`incrementalFile`](./configuration.md#incrementalfile-string) (for the default path: `reports/stryker-incremental.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore` for the default path.
 
 ## Limitations
 

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -46,7 +46,7 @@ Here you can see that:
 
 ## Interrupted runs
 
-If a mutation testing run is interrupted or crashes (for example by pressing CTRL+C, or a canceled CI job), StrykerJS saves the mutant results completed so far. The next incremental run can pick up where the interrupted run left off, instead of having to redo that work.
+If a mutation testing run is interrupted or crashes (for example by pressing CTRL+C, a canceled CI job, or a hard kill), StrykerJS saves the mutant results completed so far. On a hard kill, at most the in-flight mutant is lost; on Ctrl+C, results that finish while the process is shutting down may also need to rerun. The next incremental run can pick up where the interrupted run left off, instead of having to redo that work.
 
 While a run is in progress, StrykerJS writes a pending directory next to [`incrementalFile`](./configuration.md#incrementalfile-string) (for the default path: `reports/stryker-incremental.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore` for the default path.
 
@@ -59,6 +59,7 @@ Running in incremental mode, Stryker will do its best to produce an accurate mut
 - Detecting test changes is only supported if the test runner plugin supports reporting test locations. (see support table below)
 - Any other changes to your environment are not detected, such as updates to other files, updated (dev) dependencies, changes to environment variables, changes to `.snap` files, readme files, etc.
 - [Static mutants](../../mutation-testing-elements/static-mutants/) don't have test coverage; thus, Stryker won't detect test changes for them.
+- Do not run two Stryker processes with `--incremental` in the same project directory at once. They already race on the sandbox and on `incrementalFile`; the pending journal shares that same race.
 
 | Test runner plugin | Test reporting                    |
 | ------------------ | --------------------------------- |

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -46,9 +46,9 @@ Here you can see that:
 
 ## Interrupted runs
 
-If a mutation testing run is interrupted or crashes (for example by pressing CTRL+C, a canceled CI job, or a hard kill), StrykerJS saves the mutant results completed so far. On a hard kill, at most the in-flight mutant is lost; on Ctrl+C, results that finish while the process is shutting down may also need to rerun. The next incremental run can pick up where the interrupted run left off, instead of having to redo that work.
+If a mutation testing run is interrupted or crashes (for example by pressing CTRL+C, a canceled CI job, or a hard kill), StrykerJS saves the mutant results completed so far. On a hard kill, at most the in-flight mutants are lost; on Ctrl+C, results that finish while the process is shutting down may also need to rerun. The next incremental run can pick up where the interrupted run left off, instead of having to redo that work.
 
-While a run is in progress, StrykerJS writes a pending directory next to [`incrementalFile`](./configuration.md#incrementalfile-string) (for the default path: `reports/stryker-incremental.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore` for the default path.
+While a run is in progress, StrykerJS writes a pending directory next to [`incrementalFile`](./configuration.md#incrementalfile-string) (for the default path: `reports/stryker-incremental.json.pending/`). Gitignore it like the incremental report. `stryker init` adds `reports/stryker-incremental.*` to `.gitignore` for the default path.
 
 ## Limitations
 

--- a/e2e/tasks/check-injected-deps.js
+++ b/e2e/tasks/check-injected-deps.js
@@ -63,11 +63,12 @@ function hash(file) {
  * Only files present in the copy are compared: `dist` also holds `*.tsbuildinfo` and
  * compiled tests, which are never published and so are legitimately absent. Identical
  * inodes mean the hard link still stands, which is the common case and costs one `stat`.
+ * A copied file with no readable counterpart in source `dist` counts as stale (removed
+ * or never rebuilt after a clean).
  *
  * Known gap: a source file added since the last install has no counterpart in the copy and
  * so goes unreported. Comparing the other direction would mean deriving each package's
- * publishable subset from its `files` field. A clean rebuild replaces every inode and is
- * caught regardless, which is the case this check exists for.
+ * publishable subset from its `files` field.
  *
  * @param {string} sourceDist
  * @param {string} injectedDist
@@ -88,7 +89,9 @@ function isStale(sourceDist, injectedDist) {
       }
       return hash(injectedFile) !== hash(sourceFile);
     } catch {
-      return false; // A file only the copy has is pnpm's business, not a rebuild signal.
+      // Missing/unreadable source output means the injected copy cannot be trusted
+      // (e.g. a file removed by a rebuild while the copy still has it).
+      return true;
     }
   });
 }

--- a/e2e/tasks/check-injected-deps.js
+++ b/e2e/tasks/check-injected-deps.js
@@ -1,0 +1,157 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, URL } from 'url';
+
+/**
+ * Workspace packages listed as `injected` in `dependenciesMeta` are hard-linked *copies* of
+ * their build output rather than symlinks to the package, linked when `pnpm install` runs.
+ *
+ * A build that overwrites the existing output in place keeps those links, so the copies do
+ * see the change. What breaks a link is recreating the file: `pnpm run clean` removes `dist`,
+ * so the next build writes fresh inodes and the copies stay pinned to the previous build.
+ * Without this check the e2e tests then silently exercise whatever was built the last time
+ * `pnpm install` ran, and both passes and failures are meaningless.
+ *
+ * `pnpm install` re-links the copies; CI does it in its "install build output" step.
+ */
+
+const e2eRoot = fileURLToPath(new URL('..', import.meta.url));
+const packagesRoot = path.join(e2eRoot, '..', 'packages');
+
+/**
+ * Relative paths of every file under `dir`.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function filesIn(dir) {
+  /** @type {string[]} */
+  const found = [];
+  /** @param {string} current */
+  const walk = (current) => {
+    /** @type {fs.Dirent[]} */
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return; // Missing or unreadable: nothing to compare.
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+      } else {
+        found.push(path.relative(dir, entryPath));
+      }
+    }
+  };
+  walk(dir);
+  return found;
+}
+
+/**
+ * @param {string} file
+ * @returns {string}
+ */
+function hash(file) {
+  return crypto.createHash('sha1').update(fs.readFileSync(file)).digest('hex');
+}
+
+/**
+ * True when the built package no longer matches the copy the e2e tests resolve.
+ *
+ * Only files present in the copy are compared: `dist` also holds `*.tsbuildinfo` and
+ * compiled tests, which are never published and so are legitimately absent. Identical
+ * inodes mean the hard link still stands, which is the common case and costs one `stat`.
+ *
+ * Known gap: a source file added since the last install has no counterpart in the copy and
+ * so goes unreported. Comparing the other direction would mean deriving each package's
+ * publishable subset from its `files` field. A clean rebuild replaces every inode and is
+ * caught regardless, which is the case this check exists for.
+ *
+ * @param {string} sourceDist
+ * @param {string} injectedDist
+ * @returns {boolean}
+ */
+function isStale(sourceDist, injectedDist) {
+  return filesIn(injectedDist).some((relative) => {
+    const injectedFile = path.join(injectedDist, relative);
+    const sourceFile = path.join(sourceDist, relative);
+    try {
+      const injectedStat = fs.statSync(injectedFile);
+      const sourceStat = fs.statSync(sourceFile);
+      if (injectedStat.ino !== 0 && injectedStat.ino === sourceStat.ino) {
+        return false; // Still hard-linked, so identical by construction.
+      }
+      if (injectedStat.size !== sourceStat.size) {
+        return true;
+      }
+      return hash(injectedFile) !== hash(sourceFile);
+    } catch {
+      return false; // A file only the copy has is pnpm's business, not a rebuild signal.
+    }
+  });
+}
+
+/**
+ * Workspace packages that e2e resolves through an injected copy.
+ * @returns {{ name: string, sourceDist: string, injectedDist: string }[]}
+ */
+function injectedPackages() {
+  /** @type {{ dependenciesMeta?: Record<string, { injected?: boolean }> }} */
+  const e2ePackage = JSON.parse(
+    fs.readFileSync(path.join(e2eRoot, 'package.json'), 'utf-8'),
+  );
+  const dependenciesMeta = e2ePackage.dependenciesMeta ?? {};
+  /** @type {Map<string, string>} */
+  const sourceDirByName = new Map();
+  for (const dir of fs.readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+    const packageDir = path.join(packagesRoot, dir.name);
+    try {
+      /** @type {{ name?: string }} */
+      const { name } = JSON.parse(
+        fs.readFileSync(path.join(packageDir, 'package.json'), 'utf-8'),
+      );
+      if (name) {
+        sourceDirByName.set(name, packageDir);
+      }
+    } catch {
+      // Not a package directory.
+    }
+  }
+
+  return Object.entries(dependenciesMeta)
+    .filter(([, meta]) => meta?.injected)
+    .map(([name]) => ({ name, sourceDir: sourceDirByName.get(name) }))
+    .filter((pkg) => pkg.sourceDir !== undefined)
+    .map(({ name, sourceDir }) => ({
+      name,
+      sourceDist: path.join(sourceDir, 'dist'),
+      injectedDist: path.join(e2eRoot, 'node_modules', name, 'dist'),
+    }));
+}
+
+/**
+ * Fail fast when a package was rebuilt after the injected copies were last linked.
+ * Set `SKIP_INJECTED_DEPS_CHECK=1` to bypass.
+ */
+export function checkInjectedDeps() {
+  if (process.env.SKIP_INJECTED_DEPS_CHECK) {
+    return;
+  }
+  const stale = injectedPackages().filter(({ sourceDist, injectedDist }) =>
+    isStale(sourceDist, injectedDist),
+  );
+
+  if (stale.length) {
+    throw new Error(
+      'These packages were rebuilt after the e2e copies were linked, so the e2e tests would run the older build:\n' +
+        stale.map(({ name }) => `  - ${name}`).join('\n') +
+        '\n\nRun `pnpm install --frozen-lockfile` from the repo root to re-link them, then run the tests again.\n' +
+        '(`pnpm run e2e` does this for you. Set SKIP_INJECTED_DEPS_CHECK=1 to bypass this check.)',
+    );
+  }
+}

--- a/e2e/tasks/run-e2e-tests.js
+++ b/e2e/tasks/run-e2e-tests.js
@@ -11,6 +11,7 @@ import { tap, mergeAll, map } from 'rxjs/operators';
 import { minimatch } from 'minimatch';
 
 import { satisfiesPlatform } from './utils.js';
+import { checkInjectedDeps } from './check-injected-deps.js';
 
 const testRootDir = fileURLToPath(new URL('../test', import.meta.url));
 const progressFile = path.join(os.tmpdir(), 'stryker-mutator-progress.json');
@@ -91,6 +92,13 @@ function runE2eTests() {
     }),
   );
 }
+try {
+  checkInjectedDeps();
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+
 runE2eTests().subscribe({
   complete: () => console.log('✅ Done'),
   error: (err) => {

--- a/e2e/test/incremental-interrupt/crash-reporter.js
+++ b/e2e/test/incremental-interrupt/crash-reporter.js
@@ -1,0 +1,51 @@
+import { PluginKind, declareClassPlugin } from '@stryker-mutator/api/plugin';
+
+/**
+ * Reporter that hard-crashes the process after a configurable number of *new*
+ * (non-reused) mutants have been tested, without going through SIGINT handlers.
+ *
+ * Used to verify incremental crash recovery via the pending journal (WAL),
+ * as opposed to the signal-handler compact path.
+ *
+ * `process.exit` is synchronous on purpose. `onMutantTested` is broadcast
+ * without awaiting the run; an async wait would let `complete()` delete the
+ * pending directory before this reporter exits.
+ *
+ * - `STRYKER_CRASH_AFTER`: number of new mutants before crash (unset = disabled)
+ * - `STRYKER_CRASH_BEFORE_BEGIN`: if set, `process.exit` on dry-run completed
+ */
+class CrashReporter {
+  #crashed = false;
+  #totalCount = 0;
+  #earlyResultCount = 0;
+  #threshold = Number(process.env.STRYKER_CRASH_AFTER);
+
+  onDryRunCompleted() {
+    if (process.env.STRYKER_CRASH_BEFORE_BEGIN && !this.#crashed) {
+      this.#crashed = true;
+      process.exit(1);
+    }
+  }
+
+  onMutationTestingPlanReady(event) {
+    this.#earlyResultCount = event.mutantPlans.filter(
+      (p) => p.plan === 'EarlyResult',
+    ).length;
+  }
+
+  onMutantTested() {
+    if (!this.#threshold) {
+      return;
+    }
+    this.#totalCount++;
+    const newMutantsTested = this.#totalCount - this.#earlyResultCount;
+    if (newMutantsTested >= this.#threshold && !this.#crashed) {
+      this.#crashed = true;
+      process.exit(1);
+    }
+  }
+}
+
+export const strykerPlugins = [
+  declareClassPlugin(PluginKind.Reporter, 'crash', CrashReporter),
+];

--- a/e2e/test/incremental-interrupt/stryker.conf.json
+++ b/e2e/test/incremental-interrupt/stryker.conf.json
@@ -4,6 +4,6 @@
   "concurrency": 1,
   "coverageAnalysis": "perTest",
   "reporters": ["clear-text", "signal"],
-  "plugins": ["@stryker-mutator/mocha-runner", "./signal-reporter.js"],
+  "plugins": ["@stryker-mutator/mocha-runner", "./signal-reporter.js", "./crash-reporter.js"],
   "incremental": true
 }

--- a/e2e/test/incremental-interrupt/verify/verify.js
+++ b/e2e/test/incremental-interrupt/verify/verify.js
@@ -29,6 +29,17 @@ const rootResolve = path.resolve.bind(
 );
 
 const incrementalFile = rootResolve('reports', 'stryker-incremental.json');
+const pendingDir = rootResolve('reports', 'stryker-incremental.pending');
+const pendingJsonl = path.join(pendingDir, 'results.jsonl');
+const mathFile = rootResolve('src', 'math.js');
+
+/**
+ * Use `--reporters=a,b` (equals form). Windows `cmd` treats a bare comma as an
+ * argument separator, so `--reporters clear-text,crash` becomes one plugin name
+ * `"clear-text crash"`.
+ */
+const crashReporters = ['--reporters=clear-text,crash'];
+const textReporter = ['--reporters=clear-text'];
 
 /**
  * Count the total number of mutants across all files in an incremental report.
@@ -43,6 +54,29 @@ async function countMutantsInReport(filePath) {
     (sum, file) => sum + file.mutants.length,
     0,
   );
+}
+
+/**
+ * Count mutants recovered from the pending WAL (base.json + results.jsonl).
+ * @returns {Promise<number>}
+ */
+async function countMutantsInPending() {
+  const base = JSON.parse(
+    await fsPromises.readFile(path.join(pendingDir, 'base.json'), 'utf-8'),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const baseCount = Object.values(base.files).reduce(
+    (sum, file) => sum + file.mutants.length,
+    0,
+  );
+  let jsonlCount = 0;
+  try {
+    const jsonl = await fsPromises.readFile(pendingJsonl, 'utf-8');
+    jsonlCount = jsonl.split('\n').filter((line) => line.trim()).length;
+  } catch {
+    // results.jsonl may be empty or missing
+  }
+  return baseCount + jsonlCount;
 }
 
 describe('incremental interrupt', () => {
@@ -163,5 +197,79 @@ describe('incremental interrupt', () => {
       `Stryker did not complete after ${MAX_ITERATIONS} iterations. ` +
         `Last report had ${previousMutantCount} mutants.`,
     );
+  });
+
+  it('should reuse journaled mutants after a hard crash without a signal handler', async () => {
+    /** @type {import('execa').ExecaError | undefined} */
+    let crashError;
+    try {
+      await execa('stryker', ['run', ...crashReporters], {
+        env: { STRYKER_CRASH_AFTER: '1' },
+      });
+    } catch (error) {
+      crashError = error;
+    }
+
+    expect(crashError, 'Stryker should have hard-crashed').to.exist;
+    expect(crashError.exitCode).to.equal(1);
+    expect(crashError.stdout ?? '').to.not.contain(
+      'Saved a partial incremental report',
+    );
+
+    const pendingMutants = await countMutantsInPending();
+    expect(pendingMutants).to.be.greaterThan(0);
+
+    const result = await execa('stryker', ['run', ...textReporter]);
+    expect(result.exitCode).to.equal(0);
+    expect(result.stdout).to.contain('mutant result(s) are reused');
+    expect(await countMutantsInReport(incrementalFile)).to.equal(9);
+  });
+
+  it('should diff pending results against edited source on the next incremental run', async () => {
+    try {
+      await execa('stryker', ['run', ...crashReporters], {
+        env: { STRYKER_CRASH_AFTER: '1' },
+      });
+    } catch {
+      // expected hard crash
+    }
+
+    expect(await countMutantsInPending()).to.be.greaterThan(0);
+
+    const original = await fsPromises.readFile(mathFile, 'utf-8');
+    await fsPromises.writeFile(
+      mathFile,
+      original.replace('return num1 + num2;', 'return num1 + num2 + 0;'),
+    );
+
+    try {
+      const result = await execa('stryker', ['run', ...textReporter]);
+      expect(result.exitCode).to.equal(0);
+      expect(result.stdout).to.contain('mutant result(s) are reused');
+      expect(await countMutantsInReport(incrementalFile)).to.be.greaterThan(0);
+    } finally {
+      await fsPromises.writeFile(mathFile, original);
+    }
+  });
+
+  it('should keep the committed incremental report when crashing before begin', async () => {
+    const fullRun = await execa('stryker', ['run', ...textReporter]);
+    expect(fullRun.exitCode).to.equal(0);
+    expect(await countMutantsInReport(incrementalFile)).to.equal(9);
+
+    try {
+      await execa('stryker', ['run', ...crashReporters], {
+        env: { STRYKER_CRASH_BEFORE_BEGIN: '1' },
+      });
+    } catch (error) {
+      expect(error.exitCode).to.equal(1);
+    }
+
+    expect(await countMutantsInReport(incrementalFile)).to.equal(9);
+
+    const result = await execa('stryker', ['run', ...textReporter]);
+    expect(result.exitCode).to.equal(0);
+    expect(result.stdout).to.contain('mutant result(s) are reused');
+    expect(await countMutantsInReport(incrementalFile)).to.equal(9);
   });
 });

--- a/e2e/test/incremental-interrupt/verify/verify.js
+++ b/e2e/test/incremental-interrupt/verify/verify.js
@@ -29,7 +29,7 @@ const rootResolve = path.resolve.bind(
 );
 
 const incrementalFile = rootResolve('reports', 'stryker-incremental.json');
-const pendingDir = rootResolve('reports', 'stryker-incremental.pending');
+const pendingDir = rootResolve('reports', 'stryker-incremental.json.pending');
 const pendingJsonl = path.join(pendingDir, 'results.jsonl');
 const mathFile = rootResolve('src', 'math.js');
 

--- a/e2e/test/incremental/verify/verify.js
+++ b/e2e/test/incremental/verify/verify.js
@@ -22,7 +22,10 @@ describe('incremental', () => {
   let strykerOptions;
 
   beforeEach(async () => {
-    await fsPromises.rm(incrementalFile, { force: true });
+    await fsPromises.rm(new URL('../reports', import.meta.url), {
+      force: true,
+      recursive: true,
+    });
     strykerOptions = {
       incremental: true,
       concurrency: 1,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "all": "pnpm run clean && pnpm run build && pnpm run lint && pnpm run test",
     "install:chromium": "playwright install chromium",
     "lint": "eslint",
-    "sync-dependencies-meta-injected": "sync-dependencies-meta-injected",
     "lint:fix": "pnpm run lint --fix",
     "clean": "rimraf --glob \"packages/*/{.nyc_output,reports,coverage,src-generated,*.tsbuildinfo,.stryker-tmp,dist,testResources/tmp}\" \"e2e/test/*/{.stryker-tmp,.stryker-tmp-2}\" \"packages/core/schema/stryker-schema.json\"",
     "generate": "node tasks/generate-json-schema-to-ts.js && node tasks/generate-mono-schema.js",

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -354,7 +354,7 @@
       "default": false
     },
     "incrementalFile": {
-      "description": "Specify the file to use for incremental mode.",
+      "description": "Specify the file to use for incremental mode. A sibling .pending/ directory and .tmp file may appear next to it during a run; gitignore them like this file.",
       "type": "string",
       "default": "reports/stryker-incremental.json"
     },

--- a/packages/core/src/di/core-tokens.ts
+++ b/packages/core/src/di/core-tokens.ts
@@ -35,5 +35,6 @@ export const resolveFromCwd = 'resolveFromCwd';
 export const fs = 'fs';
 export const testCoverage = 'testCoverage';
 export const incrementalDiffer = 'incrementalDiffer';
+export const incrementalJournal = 'incrementalJournal';
 export const project = 'project';
 export const workerIdGenerator = 'worker-id-generator';

--- a/packages/core/src/fs/incremental-journal.ts
+++ b/packages/core/src/fs/incremental-journal.ts
@@ -90,6 +90,11 @@ export function incrementalIgnorePaths(incrementalFile: string): string[] {
  * `isStarted` is true only after this process's `begin()` committed a pending pair.
  * The unexpected-exit handler uses that so Ctrl+C before `begin()` cannot compact
  * a recovered WAL from a prior crash into a truncated `incremental.json`.
+ *
+ * Not safe for two Stryker processes in the same project directory: `append`
+ * resolves `pending/results.jsonl` by path, so a second run's `begin()` can
+ * redirect the first run's appends into a different test-ID namespace. That is
+ * the same class of race as sharing the sandbox / `incremental.json`.
  */
 export class IncrementalJournal {
   public static inject = tokens(commonTokens.options, commonTokens.logger);
@@ -105,6 +110,12 @@ export class IncrementalJournal {
    * or `close()`. `append()` is a no-op while this is false.
    */
   public isStarted = false;
+
+  /**
+   * Set once `append()` has warned. A broken pending directory would otherwise
+   * produce one warning per remaining mutant.
+   */
+  private appendFailureLogged = false;
 
   constructor(
     options: Pick<StrykerOptions, 'incremental' | 'incrementalFile'>,
@@ -162,6 +173,7 @@ export class IncrementalJournal {
       return;
     }
     this.isStarted = false;
+    this.appendFailureLogged = false;
 
     try {
       await this.commitPendingPair(base);
@@ -192,10 +204,13 @@ export class IncrementalJournal {
         'utf-8',
       );
     } catch (error: unknown) {
-      this.log.warn(
-        'Failed to append a mutant result to the incremental journal: %s',
-        error,
-      );
+      if (!this.appendFailureLogged) {
+        this.appendFailureLogged = true;
+        this.log.warn(
+          'Failed to append a mutant result to the incremental journal, further append failures will not be logged: %s',
+          error,
+        );
+      }
     }
   }
 
@@ -219,7 +234,7 @@ export class IncrementalJournal {
    * Stop accepting appends.
    * Production runs call `complete()` instead; tests use this to release files.
    */
-  public async close(): Promise<void> {
+  public close(): void {
     this.isStarted = false;
   }
 
@@ -238,7 +253,10 @@ export class IncrementalJournal {
     await fs.mkdir(this.pendingNextDir, { recursive: true });
     await fs.writeFile(
       path.join(this.pendingNextDir, INCREMENTAL_PENDING_BASE),
-      JSON.stringify(base, null, 2),
+      // Machine-only WAL file, so skip pretty-printing. It embeds every mutated
+      // file's source and is rewritten on every incremental run; the committed
+      // report stays indented because people read and diff that one.
+      JSON.stringify(base),
       'utf-8',
     );
     await fs.writeFile(

--- a/packages/core/src/fs/incremental-journal.ts
+++ b/packages/core/src/fs/incremental-journal.ts
@@ -1,0 +1,447 @@
+import path from 'path';
+import { appendFileSync, promises as fs } from 'fs';
+
+import { StrykerOptions, schema } from '@stryker-mutator/api/core';
+import { Logger } from '@stryker-mutator/api/logging';
+import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
+import { ERROR_CODES, isErrnoException } from '@stryker-mutator/util';
+
+/**
+ * A report-schema mutant plus the file it belongs to.
+ * JSONL lines use this shape so `load()` can merge them onto `files[fileName].mutants`
+ * while keeping remapped test IDs from `toMutantResult()`.
+ */
+export interface IncrementalJournalMutant extends schema.MutantResult {
+  fileName: string;
+}
+
+export const INCREMENTAL_PENDING_BASE = 'base.json';
+export const INCREMENTAL_PENDING_RESULTS = 'results.jsonl';
+
+/**
+ * Directory next to `incrementalFile` that holds the in-progress write-ahead log.
+ * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.pending`.
+ * Preserves the separators used in `incrementalFile` so ignore rules match the configured path.
+ */
+export function incrementalPendingDir(incrementalFile: string): string {
+  const ext = path.extname(incrementalFile);
+  const withoutExt = ext
+    ? incrementalFile.slice(0, -ext.length)
+    : incrementalFile;
+  return `${withoutExt}.pending`;
+}
+
+/**
+ * Gitignore glob for the incremental report and its WAL siblings.
+ * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.*`
+ */
+export function incrementalGitignorePattern(incrementalFile: string): string {
+  return incrementalPendingDir(incrementalFile).replace(/\.pending$/, '.*');
+}
+
+/**
+ * Staging directory used while replacing the pending pair. Must not be mixed with
+ * an old `results.jsonl` (that would pair a new test-ID namespace with old journal lines).
+ */
+export function incrementalPendingNextDir(incrementalFile: string): string {
+  return `${incrementalPendingDir(incrementalFile)}.next`;
+}
+
+/**
+ * Previous pending directory renamed aside during an atomic swap.
+ */
+export function incrementalPendingPrevDir(incrementalFile: string): string {
+  return `${incrementalPendingDir(incrementalFile)}.prev`;
+}
+
+/**
+ * Temp file used while replacing `incrementalFile` via write + rename.
+ * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.json.tmp`.
+ */
+export function incrementalTempFile(incrementalFile: string): string {
+  return `${incrementalFile}.tmp`;
+}
+
+/**
+ * Sibling paths of `incrementalFile` that must not be copied into the sandbox
+ * or treated as source: the pending WAL dirs and the compact temp file.
+ */
+export function incrementalIgnorePaths(incrementalFile: string): string[] {
+  return [
+    incrementalPendingDir(incrementalFile),
+    incrementalPendingNextDir(incrementalFile),
+    incrementalPendingPrevDir(incrementalFile),
+    incrementalTempFile(incrementalFile),
+  ];
+}
+
+/**
+ * Write-ahead log for `--incremental` runs.
+ *
+ * `stryker-incremental.json` is committed state. A sibling `.pending/` directory
+ * holds a `MutationTestResult` taken before checker/test-runner workers (`base.json`)
+ * plus a JSONL of results completed after that (`results.jsonl`).
+ *
+ * The next `--incremental` run recovers pending files through the normal
+ * `IncrementalDiffer` path. Append is a no-op until `begin()` commits the new pair.
+ * JSONL lines are written with `appendFileSync` so a crash in the same tick as
+ * `onMutantTested` still sees the completed mutant.
+ *
+ * `isStarted` is true only after this process's `begin()` committed a pending pair.
+ * The unexpected-exit handler uses that so Ctrl+C before `begin()` cannot compact
+ * a recovered WAL from a prior crash into a truncated `incremental.json`.
+ */
+export class IncrementalJournal {
+  public static inject = tokens(commonTokens.options, commonTokens.logger);
+
+  private readonly incrementalFile: string;
+  private readonly pendingDir: string;
+  private readonly pendingNextDir: string;
+  private readonly pendingPrevDir: string;
+  private readonly enabled: boolean;
+
+  /**
+   * True after `begin()` has committed this run's pending pair, until `complete()`
+   * or `close()`. `append()` is a no-op while this is false.
+   */
+  public isStarted = false;
+
+  constructor(
+    options: Pick<StrykerOptions, 'incremental' | 'incrementalFile'>,
+    private readonly log: Logger,
+  ) {
+    this.enabled = options.incremental;
+    this.incrementalFile = options.incrementalFile;
+    this.pendingDir = incrementalPendingDir(this.incrementalFile);
+    this.pendingNextDir = incrementalPendingNextDir(this.incrementalFile);
+    this.pendingPrevDir = incrementalPendingPrevDir(this.incrementalFile);
+  }
+
+  /**
+   * Recover a previous in-progress run from pending files.
+   * Does not read `incremental.json` — callers fall back to that themselves.
+   *
+   * Tries `pending/`, then `.prev`, then `.next`. A crash during the directory
+   * swap can leave the durable pair in `.prev` (old WAL) or `.next` (new base,
+   * no old pending existed) instead of `pending/`. A recovered `.prev` / `.next`
+   * is renamed to `pending/` so `begin()` cannot delete the only copy when it
+   * wipes staging dirs.
+   * @returns The merged report, or `undefined` if no pending dir is usable.
+   */
+  public async load(): Promise<schema.MutationTestResult | undefined> {
+    if (!this.enabled) {
+      return;
+    }
+    for (const dir of [
+      this.pendingDir,
+      this.pendingPrevDir,
+      this.pendingNextDir,
+    ]) {
+      const report = await this.loadFromPendingDir(dir);
+      if (report) {
+        if (dir !== this.pendingDir) {
+          await this.promoteToPending(dir);
+        }
+        this.log.info(
+          'Recovering incremental results from pending journal at "%s".',
+          dir,
+        );
+        return report;
+      }
+    }
+    return;
+  }
+
+  /**
+   * Commit `base.json` + an empty `results.jsonl` as the new pending pair, then
+   * accept `append()` calls. `isStarted` becomes true once `.next` has been
+   * renamed to `pending`; leftover `.prev` cleanup cannot disable appends.
+   */
+  public async begin(base: schema.MutationTestResult): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    this.isStarted = false;
+
+    try {
+      await this.commitPendingPair(base);
+      this.isStarted = true;
+    } catch (error) {
+      this.isStarted = false;
+      this.log.warn(
+        'Failed to start the incremental journal at "%s". Completed mutants from this run may be lost if the process dies.',
+        this.pendingDir,
+      );
+      this.log.debug('Incremental journal begin error: %s', error);
+    }
+  }
+
+  /**
+   * Append a post-boundary mutant result. No-op before `begin()` / after `complete()`.
+   * Writes synchronously so `onMutantTested` observers (and a crash in the same
+   * tick) can see the JSONL line.
+   */
+  public append(result: IncrementalJournalMutant): void {
+    if (!this.isStarted) {
+      return;
+    }
+    try {
+      appendFileSync(
+        path.join(this.pendingDir, INCREMENTAL_PENDING_RESULTS),
+        `${JSON.stringify(result)}\n`,
+        'utf-8',
+      );
+    } catch (error: unknown) {
+      this.log.warn(
+        'Failed to append a mutant result to the incremental journal: %s',
+        error,
+      );
+    }
+  }
+
+  /**
+   * Write the committed incremental file via temp + rename, then delete pending.
+   * Never removes the WAL until the committed file is in place. Pending-dir
+   * cleanup is best-effort so a locked leftover dir cannot fail the run.
+   */
+  public async complete(finalReport: schema.MutationTestResult): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    this.isStarted = false;
+    await this.writeCommittedReport(finalReport);
+    await this.removeDirBestEffort(this.pendingDir);
+    await this.removeDirBestEffort(this.pendingNextDir);
+    await this.removeDirBestEffort(this.pendingPrevDir);
+  }
+
+  /**
+   * Stop accepting appends.
+   * Production runs call `complete()` instead; tests use this to release files.
+   */
+  public async close(): Promise<void> {
+    this.isStarted = false;
+  }
+
+  /**
+   * Write `pending.next/base.json` + empty `results.jsonl`, then swap that
+   * directory into place as `pending`. Crash before the swap leaves the old
+   * pending pair; crash after leaves the new base with an empty journal.
+   * A crash between the two renames leaves the old pair in `.prev` and the new
+   * pair in `.next`; `load()` recovers those. Deleting `.prev` after the swap
+   * is best-effort so a locked leftover dir cannot leave `isStarted` false.
+   */
+  private async commitPendingPair(
+    base: schema.MutationTestResult,
+  ): Promise<void> {
+    await fs.rm(this.pendingNextDir, { recursive: true, force: true });
+    await fs.mkdir(this.pendingNextDir, { recursive: true });
+    await fs.writeFile(
+      path.join(this.pendingNextDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(base, null, 2),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(this.pendingNextDir, INCREMENTAL_PENDING_RESULTS),
+      '',
+      'utf-8',
+    );
+
+    await fs.rm(this.pendingPrevDir, { recursive: true, force: true });
+    try {
+      await fs.rename(this.pendingDir, this.pendingPrevDir);
+    } catch (error) {
+      if (
+        !isErrnoException(error) ||
+        error.code !== ERROR_CODES.NoSuchFileOrDirectory
+      ) {
+        throw error;
+      }
+    }
+    await fs.rename(this.pendingNextDir, this.pendingDir);
+    // Pair is durable here. Removing `.prev` must not fail `begin()` / `isStarted`.
+    await this.removeDirBestEffort(this.pendingPrevDir);
+  }
+
+  /**
+   * Move a recovered `.prev` / `.next` directory to `pending/` so `begin()` can
+   * wipe staging without deleting the only remaining WAL. An unusable `pending/`
+   * (already rejected by `load()`) is removed first so the rename can proceed.
+   */
+  private async promoteToPending(dir: string): Promise<void> {
+    await this.removeDirBestEffort(this.pendingDir);
+    try {
+      await fs.rename(dir, this.pendingDir);
+    } catch (error) {
+      this.log.warn(
+        'Failed to promote incremental journal from "%s" to "%s". Recovered results may be lost if this run dies before begin() finishes.',
+        dir,
+        this.pendingDir,
+      );
+      this.log.debug('Pending promote error: %s', error);
+    }
+  }
+
+  /**
+   * `force: true` already ignores a missing path. Other errors (EPERM/EBUSY on
+   * Windows) still throw; those must not undo a rename/write that already landed.
+   */
+  private async removeDirBestEffort(dir: string): Promise<void> {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch (error) {
+      this.log.debug(
+        'Failed to remove incremental journal path "%s": %s',
+        dir,
+        error,
+      );
+    }
+  }
+
+  private async writeCommittedReport(
+    report: schema.MutationTestResult,
+  ): Promise<void> {
+    await fs.mkdir(path.dirname(this.incrementalFile), { recursive: true });
+    const tempFile = incrementalTempFile(this.incrementalFile);
+    await fs.writeFile(tempFile, JSON.stringify(report, null, 2), 'utf-8');
+    await replaceFile(tempFile, this.incrementalFile);
+  }
+
+  /**
+   * Read and merge `base.json` + `results.jsonl` from one pending directory.
+   * @returns The merged report, or `undefined` if this directory is missing or unusable.
+   */
+  private async loadFromPendingDir(
+    dir: string,
+  ): Promise<schema.MutationTestResult | undefined> {
+    const basePath = path.join(dir, INCREMENTAL_PENDING_BASE);
+    let baseRaw: string;
+    try {
+      baseRaw = await fs.readFile(basePath, 'utf-8');
+    } catch (error) {
+      if (
+        isErrnoException(error) &&
+        error.code === ERROR_CODES.NoSuchFileOrDirectory
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    let base: schema.MutationTestResult;
+    try {
+      base = JSON.parse(baseRaw) as schema.MutationTestResult;
+    } catch (error) {
+      this.log.warn(
+        'Incremental pending base at "%s" is not valid JSON; trying the next pending location.',
+        basePath,
+      );
+      this.log.debug('Pending base parse error: %s', error);
+      return;
+    }
+
+    const journalMutants = await this.readResultsJsonl(dir);
+    if (journalMutants === undefined) {
+      return;
+    }
+
+    for (const { fileName, ...mutant } of journalMutants) {
+      const fileResult = base.files[fileName];
+      if (fileResult) {
+        fileResult.mutants.push(mutant);
+      } else {
+        base.files[fileName] = {
+          language: languageFromFileName(fileName),
+          source: '',
+          mutants: [mutant],
+        };
+      }
+    }
+    return base;
+  }
+
+  /**
+   * Parse JSONL. A malformed last line (torn write) is dropped. A malformed
+   * interior line fails the whole load so callers can fall back to another pending
+   * dir or the committed file.
+   * @returns Parsed mutants, or `undefined` when this journal must not be used.
+   */
+  private async readResultsJsonl(
+    dir: string,
+  ): Promise<IncrementalJournalMutant[] | undefined> {
+    const resultsPath = path.join(dir, INCREMENTAL_PENDING_RESULTS);
+    let raw: string;
+    try {
+      raw = await fs.readFile(resultsPath, 'utf-8');
+    } catch (error) {
+      if (
+        isErrnoException(error) &&
+        error.code === ERROR_CODES.NoSuchFileOrDirectory
+      ) {
+        return [];
+      }
+      throw error;
+    }
+
+    const lines = raw.split('\n');
+    if (lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+
+    const mutants: IncrementalJournalMutant[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const isLast = i === lines.length - 1;
+      try {
+        mutants.push(JSON.parse(line) as IncrementalJournalMutant);
+      } catch (error) {
+        if (isLast) {
+          this.log.debug(
+            'Dropping a torn last line from incremental journal "%s".',
+            resultsPath,
+          );
+          break;
+        }
+        this.log.warn(
+          'Incremental pending journal at "%s" has a corrupted interior line; trying the next pending location.',
+          resultsPath,
+        );
+        this.log.debug('Pending JSONL parse error: %s', error);
+        return;
+      }
+    }
+    return mutants;
+  }
+}
+
+async function replaceFile(from: string, to: string): Promise<void> {
+  try {
+    await fs.rename(from, to);
+  } catch (error) {
+    if (
+      isErrnoException(error) &&
+      (error.code === 'EEXIST' ||
+        error.code === 'EPERM' ||
+        error.code === 'EACCES')
+    ) {
+      await fs.rm(to, { force: true });
+      await fs.rename(from, to);
+      return;
+    }
+    throw error;
+  }
+}
+
+function languageFromFileName(fileName: string): string {
+  const ext = path.extname(fileName).toLowerCase();
+  switch (ext) {
+    case '.ts':
+    case '.tsx':
+      return 'typescript';
+    case '.html':
+    case '.vue':
+      return 'html';
+    default:
+      return 'javascript';
+  }
+}

--- a/packages/core/src/fs/incremental-journal.ts
+++ b/packages/core/src/fs/incremental-journal.ts
@@ -117,6 +117,13 @@ export class IncrementalJournal {
    */
   private appendFailureLogged = false;
 
+  /**
+   * When `promoteToPending` cannot move a recovered `.prev` / `.next` into
+   * `pending/`, that directory still holds the only on-disk WAL. `begin()` must
+   * not delete it while staging the new pair.
+   */
+  private walPreserveDir: string | undefined;
+
   constructor(
     options: Pick<StrykerOptions, 'incremental' | 'incrementalFile'>,
     private readonly log: Logger,
@@ -152,6 +159,8 @@ export class IncrementalJournal {
       if (report) {
         if (dir !== this.pendingDir) {
           await this.promoteToPending(dir);
+        } else {
+          this.walPreserveDir = undefined;
         }
         this.log.info(
           'Recovering incremental results from pending journal at "%s".',
@@ -165,8 +174,8 @@ export class IncrementalJournal {
 
   /**
    * Commit `base.json` + an empty `results.jsonl` as the new pending pair, then
-   * accept `append()` calls. `isStarted` becomes true once `.next` has been
-   * renamed to `pending`; leftover `.prev` cleanup cannot disable appends.
+   * accept `append()` calls. `isStarted` becomes true once the staging directory
+   * has been renamed to `pending`; leftover staging cleanup cannot disable appends.
    */
   public async begin(base: schema.MutationTestResult): Promise<void> {
     if (!this.enabled) {
@@ -224,6 +233,7 @@ export class IncrementalJournal {
       return;
     }
     this.isStarted = false;
+    this.walPreserveDir = undefined;
     await this.writeCommittedReport(finalReport);
     await this.removeDirBestEffort(this.pendingDir);
     await this.removeDirBestEffort(this.pendingNextDir);
@@ -239,20 +249,33 @@ export class IncrementalJournal {
   }
 
   /**
-   * Write `pending.next/base.json` + empty `results.jsonl`, then swap that
-   * directory into place as `pending`. Crash before the swap leaves the old
-   * pending pair; crash after leaves the new base with an empty journal.
-   * A crash between the two renames leaves the old pair in `.prev` and the new
-   * pair in `.next`; `load()` recovers those. Deleting `.prev` after the swap
-   * is best-effort so a locked leftover dir cannot leave `isStarted` false.
+   * Write a new `base.json` + empty `results.jsonl` into a staging directory,
+   * then swap that directory into place as `pending`.
+   *
+   * Staging prefers `.next`. If a failed promote left the only WAL in `.next`,
+   * staging uses `.prev` instead so `begin()` never deletes the unrecovered copy
+   * before the new pair is durable. Crash before the swap leaves the old pair;
+   * crash after leaves the new base with an empty journal. A crash between the
+   * two renames leaves recoverable state in `.prev` / `.next`; `load()` finds
+   * those. Cleanup after the swap is best-effort so a locked leftover dir cannot
+   * leave `isStarted` false.
    */
   private async commitPendingPair(
     base: schema.MutationTestResult,
   ): Promise<void> {
-    await fs.rm(this.pendingNextDir, { recursive: true, force: true });
-    await fs.mkdir(this.pendingNextDir, { recursive: true });
+    const stagingDir =
+      this.walPreserveDir === this.pendingNextDir
+        ? this.pendingPrevDir
+        : this.pendingNextDir;
+    const asideDir =
+      stagingDir === this.pendingNextDir
+        ? this.pendingPrevDir
+        : this.pendingNextDir;
+
+    await fs.rm(stagingDir, { recursive: true, force: true });
+    await fs.mkdir(stagingDir, { recursive: true });
     await fs.writeFile(
-      path.join(this.pendingNextDir, INCREMENTAL_PENDING_BASE),
+      path.join(stagingDir, INCREMENTAL_PENDING_BASE),
       // Machine-only WAL file, so skip pretty-printing. It embeds every mutated
       // file's source and is rewritten on every incremental run; the committed
       // report stays indented because people read and diff that one.
@@ -260,39 +283,55 @@ export class IncrementalJournal {
       'utf-8',
     );
     await fs.writeFile(
-      path.join(this.pendingNextDir, INCREMENTAL_PENDING_RESULTS),
+      path.join(stagingDir, INCREMENTAL_PENDING_RESULTS),
       '',
       'utf-8',
     );
 
-    await fs.rm(this.pendingPrevDir, { recursive: true, force: true });
+    // Free aside for renaming pending into it — unless aside holds the preserved WAL.
+    if (this.walPreserveDir !== asideDir) {
+      await fs.rm(asideDir, { recursive: true, force: true });
+    }
+
     try {
-      await fs.rename(this.pendingDir, this.pendingPrevDir);
-    } catch (error) {
-      if (
-        !isErrnoException(error) ||
-        error.code !== ERROR_CODES.NoSuchFileOrDirectory
-      ) {
+      await fs.rename(this.pendingDir, asideDir);
+    } catch (error: unknown) {
+      if (isNoSuchFileOrDirectory(error)) {
+        // No pending directory to move aside.
+      } else if (this.walPreserveDir === asideDir) {
+        // Aside holds the recovered WAL, so it cannot receive pending. Drop an
+        // unusable pending (if any) so staging can take its place. If pending is
+        // still locked, the staging rename below throws and begin() fails — the
+        // preserved WAL remains intact.
+        await this.removeDirBestEffort(this.pendingDir);
+      } else {
         throw error;
       }
     }
-    await fs.rename(this.pendingNextDir, this.pendingDir);
-    // Pair is durable here. Removing `.prev` must not fail `begin()` / `isStarted`.
+
+    await fs.rename(stagingDir, this.pendingDir);
+    // New pending is durable. Safe to drop the old recovered WAL and staging leftovers.
+    this.walPreserveDir = undefined;
     await this.removeDirBestEffort(this.pendingPrevDir);
+    await this.removeDirBestEffort(this.pendingNextDir);
   }
 
   /**
    * Move a recovered `.prev` / `.next` directory to `pending/` so `begin()` can
    * wipe staging without deleting the only remaining WAL. An unusable `pending/`
    * (already rejected by `load()`) is removed first so the rename can proceed.
+   * On failure, records {@link walPreserveDir} so `commitPendingPair` stages
+   * elsewhere until the new pending pair exists.
    */
   private async promoteToPending(dir: string): Promise<void> {
     await this.removeDirBestEffort(this.pendingDir);
     try {
       await fs.rename(dir, this.pendingDir);
+      this.walPreserveDir = undefined;
     } catch (error) {
+      this.walPreserveDir = dir;
       this.log.warn(
-        'Failed to promote incremental journal from "%s" to "%s". Recovered results may be lost if this run dies before begin() finishes.',
+        'Failed to promote incremental journal from "%s" to "%s". Keeping that WAL until begin() commits a new pending pair.',
         dir,
         this.pendingDir,
       );
@@ -336,11 +375,8 @@ export class IncrementalJournal {
     let baseRaw: string;
     try {
       baseRaw = await fs.readFile(basePath, 'utf-8');
-    } catch (error) {
-      if (
-        isErrnoException(error) &&
-        error.code === ERROR_CODES.NoSuchFileOrDirectory
-      ) {
+    } catch (error: unknown) {
+      if (isNoSuchFileOrDirectory(error)) {
         return;
       }
       throw error;
@@ -391,11 +427,8 @@ export class IncrementalJournal {
     let raw: string;
     try {
       raw = await fs.readFile(resultsPath, 'utf-8');
-    } catch (error) {
-      if (
-        isErrnoException(error) &&
-        error.code === ERROR_CODES.NoSuchFileOrDirectory
-      ) {
+    } catch (error: unknown) {
+      if (isNoSuchFileOrDirectory(error)) {
         return [];
       }
       throw error;
@@ -435,19 +468,32 @@ export class IncrementalJournal {
 async function replaceFile(from: string, to: string): Promise<void> {
   try {
     await fs.rename(from, to);
-  } catch (error) {
-    if (
-      isErrnoException(error) &&
-      (error.code === 'EEXIST' ||
-        error.code === 'EPERM' ||
-        error.code === 'EACCES')
-    ) {
+  } catch (error: unknown) {
+    if (isReplaceRaceError(error)) {
       await fs.rm(to, { force: true });
       await fs.rename(from, to);
       return;
     }
     throw error;
   }
+}
+
+function isNoSuchFileOrDirectory(error: unknown): boolean {
+  if (!isErrnoException(error)) {
+    return false;
+  }
+  return error.code === ERROR_CODES.NoSuchFileOrDirectory;
+}
+
+function isReplaceRaceError(error: unknown): boolean {
+  if (!isErrnoException(error)) {
+    return false;
+  }
+  return (
+    error.code === 'EEXIST' ||
+    error.code === 'EPERM' ||
+    error.code === 'EACCES'
+  );
 }
 
 function languageFromFileName(fileName: string): string {

--- a/packages/core/src/fs/incremental-journal.ts
+++ b/packages/core/src/fs/incremental-journal.ts
@@ -6,6 +6,8 @@ import { Logger } from '@stryker-mutator/api/logging';
 import { commonTokens, tokens } from '@stryker-mutator/api/plugin';
 import { ERROR_CODES, isErrnoException } from '@stryker-mutator/util';
 
+import { fileUtils } from '../utils/file-utils.js';
+
 /**
  * A report-schema mutant plus the file it belongs to.
  * JSONL lines use this shape so `load()` can merge them onto `files[fileName].mutants`
@@ -20,15 +22,18 @@ export const INCREMENTAL_PENDING_RESULTS = 'results.jsonl';
 
 /**
  * Directory next to `incrementalFile` that holds the in-progress write-ahead log.
- * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.pending`.
- * Preserves the separators used in `incrementalFile` so ignore rules match the configured path.
+ * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.json.pending`.
+ *
+ * Appends rather than replacing the extension (like {@link incrementalTempFile}) so the
+ * result is always longer than `incrementalFile`. Replacing it would map
+ * `incrementalFile: "x.pending"` onto the report itself, and `begin()` would swap a
+ * directory over the user's report; it would also give `a.json` and `a.html` one shared WAL.
+ *
+ * Separators are preserved for filesystem use; callers that match these as globs normalize
+ * them first, because minimatch reads a backslash as an escape.
  */
 export function incrementalPendingDir(incrementalFile: string): string {
-  const ext = path.extname(incrementalFile);
-  const withoutExt = ext
-    ? incrementalFile.slice(0, -ext.length)
-    : incrementalFile;
-  return `${withoutExt}.pending`;
+  return `${incrementalFile}.pending`;
 }
 
 /**
@@ -36,7 +41,12 @@ export function incrementalPendingDir(incrementalFile: string): string {
  * Example: `reports/stryker-incremental.json` → `reports/stryker-incremental.*`
  */
 export function incrementalGitignorePattern(incrementalFile: string): string {
-  return incrementalPendingDir(incrementalFile).replace(/\.pending$/, '.*');
+  return `${stripExtension(incrementalFile)}.*`;
+}
+
+function stripExtension(fileName: string): string {
+  const ext = path.extname(fileName);
+  return ext ? fileName.slice(0, -ext.length) : fileName;
 }
 
 /**
@@ -79,8 +89,9 @@ export function incrementalIgnorePaths(incrementalFile: string): string[] {
  * Write-ahead log for `--incremental` runs.
  *
  * `stryker-incremental.json` is committed state. A sibling `.pending/` directory
- * holds a `MutationTestResult` taken before checker/test-runner workers (`base.json`)
- * plus a JSONL of results completed after that (`results.jsonl`).
+ * holds a `MutationTestResult` taken before the checkers and test runners run
+ * mutants (`base.json`) plus a JSONL of results completed after that
+ * (`results.jsonl`).
  *
  * The next `--incremental` run recovers pending files through the normal
  * `IncrementalDiffer` path. Append is a no-op until `begin()` commits the new pair.
@@ -118,9 +129,10 @@ export class IncrementalJournal {
   private appendFailureLogged = false;
 
   /**
-   * When `promoteToPending` cannot move a recovered `.prev` / `.next` into
-   * `pending/`, that directory still holds the only on-disk WAL. `begin()` must
-   * not delete it while staging the new pair.
+   * The `.prev` / `.next` directory `load()` recovered from. That directory
+   * holds the only on-disk WAL until `begin()` commits a new pending pair, so
+   * `commitPendingPair` stages into the other staging directory and skips
+   * wiping this one. Cleared once the new pair is durable.
    */
   private walPreserveDir: string | undefined;
 
@@ -141,9 +153,13 @@ export class IncrementalJournal {
    *
    * Tries `pending/`, then `.prev`, then `.next`. A crash during the directory
    * swap can leave the durable pair in `.prev` (old WAL) or `.next` (new base,
-   * no old pending existed) instead of `pending/`. A recovered `.prev` / `.next`
-   * is renamed to `pending/` so `begin()` cannot delete the only copy when it
-   * wipes staging dirs.
+   * no old pending existed) instead of `pending/`. Nothing is moved on disk:
+   * recovering from `.prev` / `.next` only records {@link walPreserveDir}, which
+   * makes `begin()` stage the new pair in the other directory instead of wiping
+   * the only copy.
+   *
+   * Best-effort like the rest of the journal: a directory that cannot be read
+   * (EACCES/EBUSY on a locked file) is skipped rather than failing the run.
    * @returns The merged report, or `undefined` if no pending dir is usable.
    */
   public async load(): Promise<schema.MutationTestResult | undefined> {
@@ -155,13 +171,19 @@ export class IncrementalJournal {
       this.pendingPrevDir,
       this.pendingNextDir,
     ]) {
-      const report = await this.loadFromPendingDir(dir);
+      let report: schema.MutationTestResult | undefined;
+      try {
+        report = await this.loadFromPendingDir(dir);
+      } catch (error) {
+        this.log.warn(
+          'Failed to read the incremental journal at "%s"; trying the next pending location.',
+          dir,
+        );
+        this.log.debug('Pending journal read error: %s', error);
+        continue;
+      }
       if (report) {
-        if (dir !== this.pendingDir) {
-          await this.promoteToPending(dir);
-        } else {
-          this.walPreserveDir = undefined;
-        }
+        this.walPreserveDir = dir === this.pendingDir ? undefined : dir;
         this.log.info(
           'Recovering incremental results from pending journal at "%s".',
           dir,
@@ -252,13 +274,13 @@ export class IncrementalJournal {
    * Write a new `base.json` + empty `results.jsonl` into a staging directory,
    * then swap that directory into place as `pending`.
    *
-   * Staging prefers `.next`. If a failed promote left the only WAL in `.next`,
-   * staging uses `.prev` instead so `begin()` never deletes the unrecovered copy
-   * before the new pair is durable. Crash before the swap leaves the old pair;
-   * crash after leaves the new base with an empty journal. A crash between the
-   * two renames leaves recoverable state in `.prev` / `.next`; `load()` finds
-   * those. Cleanup after the swap is best-effort so a locked leftover dir cannot
-   * leave `isStarted` false.
+   * Staging prefers `.next`. When `load()` recovered from `.next`, that directory
+   * holds the only WAL, so staging uses `.prev` instead and `begin()` never
+   * deletes the recovered copy before the new pair is durable. Crash before the
+   * swap leaves the old pair; crash after leaves the new base with an empty
+   * journal. A crash between the two renames leaves recoverable state in
+   * `.prev` / `.next`; `load()` finds those. Cleanup after the swap is
+   * best-effort so a locked leftover dir cannot leave `isStarted` false.
    */
   private async commitPendingPair(
     base: schema.MutationTestResult,
@@ -288,7 +310,10 @@ export class IncrementalJournal {
       'utf-8',
     );
 
-    // Free aside for renaming pending into it — unless aside holds the preserved WAL.
+    // Free aside for renaming pending into it — unless aside holds the preserved
+    // WAL. Staging already holds a complete pair by now, so this skip is not
+    // what keeps the run recoverable; it keeps the *recovered* results on disk
+    // until the swap lands, instead of trusting `base` to carry them forward.
     if (this.walPreserveDir !== asideDir) {
       await fs.rm(asideDir, { recursive: true, force: true });
     }
@@ -314,29 +339,6 @@ export class IncrementalJournal {
     this.walPreserveDir = undefined;
     await this.removeDirBestEffort(this.pendingPrevDir);
     await this.removeDirBestEffort(this.pendingNextDir);
-  }
-
-  /**
-   * Move a recovered `.prev` / `.next` directory to `pending/` so `begin()` can
-   * wipe staging without deleting the only remaining WAL. An unusable `pending/`
-   * (already rejected by `load()`) is removed first so the rename can proceed.
-   * On failure, records {@link walPreserveDir} so `commitPendingPair` stages
-   * elsewhere until the new pending pair exists.
-   */
-  private async promoteToPending(dir: string): Promise<void> {
-    await this.removeDirBestEffort(this.pendingDir);
-    try {
-      await fs.rename(dir, this.pendingDir);
-      this.walPreserveDir = undefined;
-    } catch (error) {
-      this.walPreserveDir = dir;
-      this.log.warn(
-        'Failed to promote incremental journal from "%s" to "%s". Keeping that WAL until begin() commits a new pending pair.',
-        dir,
-        this.pendingDir,
-      );
-      this.log.debug('Pending promote error: %s', error);
-    }
   }
 
   /**
@@ -405,7 +407,7 @@ export class IncrementalJournal {
         fileResult.mutants.push(mutant);
       } else {
         base.files[fileName] = {
-          language: languageFromFileName(fileName),
+          language: fileUtils.determineLanguage(fileName),
           source: '',
           mutants: [mutant],
         };
@@ -490,22 +492,6 @@ function isReplaceRaceError(error: unknown): boolean {
     return false;
   }
   return (
-    error.code === 'EEXIST' ||
-    error.code === 'EPERM' ||
-    error.code === 'EACCES'
+    error.code === 'EEXIST' || error.code === 'EPERM' || error.code === 'EACCES'
   );
-}
-
-function languageFromFileName(fileName: string): string {
-  const ext = path.extname(fileName).toLowerCase();
-  switch (ext) {
-    case '.ts':
-    case '.tsx':
-      return 'typescript';
-    case '.html':
-    case '.vue':
-      return 'html';
-    default:
-      return 'javascript';
-  }
 }

--- a/packages/core/src/fs/index.ts
+++ b/packages/core/src/fs/index.ts
@@ -1,4 +1,5 @@
 export * from './file-system.js';
+export * from './incremental-journal.js';
 export * from './project.js';
 export * from './project-file.js';
 export * from './project-reader.js';

--- a/packages/core/src/fs/project-reader.ts
+++ b/packages/core/src/fs/project-reader.ts
@@ -26,6 +26,10 @@ import { coreTokens } from '../di/index.js';
 
 import { Project } from './project.js';
 import { FileSystem } from './file-system.js';
+import {
+  IncrementalJournal,
+  incrementalIgnorePaths,
+} from './incremental-journal.js';
 
 const ALWAYS_IGNORE = Object.freeze([
   'node_modules',
@@ -60,6 +64,7 @@ export class ProjectReader {
     coreTokens.fs,
     commonTokens.logger,
     commonTokens.options,
+    coreTokens.incrementalJournal,
   );
   constructor(
     private readonly fs: I<FileSystem>,
@@ -75,6 +80,7 @@ export class ProjectReader {
       jsonReporter,
       testFiles,
     }: StrykerOptions,
+    private readonly incrementalJournal: I<IncrementalJournal>,
   ) {
     this.mutatePatterns = mutate;
     this.testFilePatterns = testFiles ?? [];
@@ -82,6 +88,7 @@ export class ProjectReader {
       ...ALWAYS_IGNORE,
       tempDirName,
       incrementalFile,
+      ...incrementalIgnorePaths(incrementalFile),
       htmlReporter.fileName,
       jsonReporter.fileName,
       ...ignorePatterns,
@@ -415,41 +422,19 @@ export class ProjectReader {
     if (!this.incremental) {
       return;
     }
+    const report =
+      (await this.incrementalJournal.load()) ??
+      (await this.readCommittedIncrementalFile());
+    return report && this.remapReportLocations(report);
+  }
+
+  private async readCommittedIncrementalFile(): Promise<
+    MutationTestResult | undefined
+  > {
     try {
       // TODO: Validate against the schema or stryker version?
       const contents = await this.fs.readFile(this.incrementalFile, 'utf-8');
-      const result: MutationTestResult = JSON.parse(contents);
-      return {
-        ...result,
-        files: Object.fromEntries(
-          Object.entries(result.files).map(([fileName, file]) => [
-            fileName,
-            {
-              ...file,
-              mutants: file.mutants.map((mutant) => ({
-                ...mutant,
-                location: reportLocationToStrykerLocation(mutant.location),
-              })),
-            },
-          ]),
-        ),
-        testFiles:
-          result.testFiles &&
-          Object.fromEntries(
-            Object.entries(result.testFiles).map(([fileName, file]) => [
-              fileName,
-              {
-                ...file,
-                tests: file.tests.map((test) => ({
-                  ...test,
-                  location:
-                    test.location &&
-                    reportOpenEndLocationToStrykerLocation(test.location),
-                })),
-              },
-            ]),
-          ),
-      };
+      return JSON.parse(contents) as MutationTestResult;
     } catch (err: unknown) {
       if (
         isErrnoException(err) &&
@@ -464,6 +449,45 @@ export class ProjectReader {
       // Whoops, didn't mean to catch this one!
       throw err;
     }
+  }
+
+  /**
+   * Report schema locations are 1-based; Stryker works 0-based internally.
+   */
+  private remapReportLocations(
+    result: MutationTestResult,
+  ): MutationTestResult {
+    return {
+      ...result,
+      files: Object.fromEntries(
+        Object.entries(result.files).map(([fileName, file]) => [
+          fileName,
+          {
+            ...file,
+            mutants: file.mutants.map((mutant) => ({
+              ...mutant,
+              location: reportLocationToStrykerLocation(mutant.location),
+            })),
+          },
+        ]),
+      ),
+      testFiles:
+        result.testFiles &&
+        Object.fromEntries(
+          Object.entries(result.testFiles).map(([fileName, file]) => [
+            fileName,
+            {
+              ...file,
+              tests: file.tests.map((test) => ({
+                ...test,
+                location:
+                  test.location &&
+                  reportOpenEndLocationToStrykerLocation(test.location),
+              })),
+            },
+          ]),
+        ),
+    };
   }
 }
 

--- a/packages/core/src/fs/project-reader.ts
+++ b/packages/core/src/fs/project-reader.ts
@@ -15,6 +15,7 @@ import {
   ERROR_CODES,
   I,
   isErrnoException,
+  normalizeFileName,
   notEmpty,
 } from '@stryker-mutator/util';
 import type { MutationTestResult } from 'mutation-testing-report-schema/api';
@@ -86,11 +87,18 @@ export class ProjectReader {
     this.testFilePatterns = testFiles ?? [];
     this.ignoreRules = [
       ...ALWAYS_IGNORE,
-      tempDirName,
-      incrementalFile,
-      ...incrementalIgnorePaths(incrementalFile),
-      htmlReporter.fileName,
-      jsonReporter.fileName,
+      // These options are paths, but they end up here as minimatch patterns, where a
+      // backslash is an escape rather than a separator. Minimatch normalizes the paths it
+      // matches against, not the patterns, so `path.join('reports', 'foo.json')` on Windows
+      // would silently match nothing. `ignorePatterns` is left alone on purpose: those are
+      // user-authored globs, where the escape is meaningful.
+      ...[
+        tempDirName,
+        incrementalFile,
+        ...incrementalIgnorePaths(incrementalFile),
+        htmlReporter.fileName,
+        jsonReporter.fileName,
+      ].map(normalizeFileName),
       ...ignorePatterns,
     ];
     this.incremental = incremental;
@@ -454,9 +462,7 @@ export class ProjectReader {
   /**
    * Report schema locations are 1-based; Stryker works 0-based internally.
    */
-  private remapReportLocations(
-    result: MutationTestResult,
-  ): MutationTestResult {
+  private remapReportLocations(result: MutationTestResult): MutationTestResult {
     return {
       ...result,
       files: Object.fromEntries(

--- a/packages/core/src/initializer/gitignore-writer.ts
+++ b/packages/core/src/initializer/gitignore-writer.ts
@@ -4,30 +4,53 @@ import { existsSync, promises as fs } from 'fs';
 import { tokens } from '@stryker-mutator/api/plugin';
 
 import { defaultOptions } from '../config/index.js';
+import { incrementalGitignorePattern } from '../fs/incremental-journal.js';
 
 import { initializerTokens } from './index.js';
 
 const GITIGNORE_FILE = '.gitignore';
 
+/**
+ * Appends recommended Stryker ignore patterns to `.gitignore` during `stryker init`.
+ * Always includes the temp dir and the default incremental report glob (json, pending WAL, tmp),
+ * even when incremental is not enabled yet.
+ */
 export class GitignoreWriter {
   public static inject = tokens(initializerTokens.out);
   constructor(private readonly out: typeof console.log) {}
 
   public async addStrykerTempFolder(): Promise<void> {
-    const defaultTempDirName = defaultOptions.tempDirName;
+    const patterns = this.gitignorePatterns();
     if (existsSync(GITIGNORE_FILE)) {
-      const gitignoreContent = await fs.readFile(GITIGNORE_FILE);
-      if (!gitignoreContent.toString().includes(defaultTempDirName)) {
-        const strykerTempFolderSpecification = `${os.EOL}# stryker temp files${os.EOL}${defaultTempDirName}${os.EOL}`;
-        await fs.appendFile(GITIGNORE_FILE, strykerTempFolderSpecification);
-        this.out(
-          'Note: Your .gitignore file has been updated to include recommended git ignore patterns for Stryker',
-        );
+      const gitignoreContent = (await fs.readFile(GITIGNORE_FILE)).toString();
+      const missing = patterns.filter(
+        (pattern) => !gitignoreContent.includes(pattern),
+      );
+      if (missing.length === 0) {
+        return;
       }
+      const header =
+        missing.length === patterns.length
+          ? `${os.EOL}# stryker${os.EOL}`
+          : os.EOL;
+      await fs.appendFile(
+        GITIGNORE_FILE,
+        `${header}${missing.join(os.EOL)}${os.EOL}`,
+      );
+      this.out(
+        'Note: Your .gitignore file has been updated to include recommended git ignore patterns for Stryker',
+      );
     } else {
       this.out(
-        'No .gitignore file could be found. Please add the following to your .gitignore file: *.stryker-tmp',
+        `No .gitignore file could be found. Please add the following to your .gitignore file: ${patterns.join(', ')}`,
       );
     }
+  }
+
+  private gitignorePatterns(): string[] {
+    return [
+      defaultOptions.tempDirName,
+      incrementalGitignorePattern(defaultOptions.incrementalFile),
+    ];
   }
 }

--- a/packages/core/src/process/1-prepare-executor.ts
+++ b/packages/core/src/process/1-prepare-executor.ts
@@ -24,7 +24,7 @@ import { MetaSchemaBuilder, OptionsValidator } from '../config/index.js';
 import { BroadcastReporter } from '../reporters/broadcast-reporter.js';
 import { UnexpectedExitHandler } from '../unexpected-exit-handler.js';
 
-import { FileSystem, ProjectReader } from '../fs/index.js';
+import { FileSystem, IncrementalJournal, ProjectReader } from '../fs/index.js';
 
 import { MutantInstrumenterContext } from './index.js';
 import { Reporter } from '@stryker-mutator/api/report';
@@ -102,6 +102,7 @@ export class PrepareExecutor {
       .provideValue(commonTokens.options, options)
       .provideClass(coreTokens.temporaryDirectory, TemporaryDirectory)
       .provideClass(coreTokens.fs, FileSystem)
+      .provideClass(coreTokens.incrementalJournal, IncrementalJournal)
       .provideValue(coreTokens.pluginsByKind, loadedPlugins.pluginsByKind);
     const project = await projectFileReaderInjector
       .injectClass(ProjectReader)

--- a/packages/core/src/process/2-mutant-instrumenter-executor.ts
+++ b/packages/core/src/process/2-mutant-instrumenter-executor.ts
@@ -25,7 +25,7 @@ import { createPreprocessor } from '../sandbox/index.js';
 import { Timer } from '../utils/timer.js';
 import { TemporaryDirectory } from '../utils/temporary-directory.js';
 import { UnexpectedExitHandler } from '../unexpected-exit-handler.js';
-import { FileSystem, Project } from '../fs/index.js';
+import { FileSystem, IncrementalJournal, Project } from '../fs/index.js';
 import { IdGenerator } from '../child-proxy/id-generator.js';
 
 import { DryRunContext } from './3-dry-run-executor.js';
@@ -41,6 +41,7 @@ export interface MutantInstrumenterContext extends PluginContext {
   [coreTokens.unexpectedExitRegistry]: I<UnexpectedExitHandler>;
   [coreTokens.pluginModulePaths]: readonly string[];
   [coreTokens.fs]: I<FileSystem>;
+  [coreTokens.incrementalJournal]: I<IncrementalJournal>;
   [coreTokens.pluginCreator]: PluginCreator;
   [coreTokens.loggingServerAddress]: { port: number };
 }

--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -100,38 +100,50 @@ export class MutationTestExecutor {
     }
 
     const mutantTestPlans = await this.planner.makePlan(this.mutants);
-    const { earlyResult$, runMutant$ } = this.executeEarlyResult(
-      from(mutantTestPlans),
-    );
-    const { passedMutant$, checkResult$ } = this.executeCheck(runMutant$);
+    const { planTimeResults, runPlans } =
+      this.collectPlanTimeResults(mutantTestPlans);
+    await this.mutationTestReportHelper.beginIncrementalJournal();
+    const { passedMutant$, checkResult$ } = this.executeCheck(from(runPlans));
     const { coveredMutant$, noCoverageResult$ } =
       this.executeNoCoverage(passedMutant$);
     const testRunnerResult$ = this.executeRunInTestRunner(coveredMutant$);
-    const results = await lastValueFrom(
-      merge(
-        testRunnerResult$,
-        checkResult$,
-        noCoverageResult$,
-        earlyResult$,
-      ).pipe(toArray()),
+    const laterResults = await lastValueFrom(
+      merge(testRunnerResult$, checkResult$, noCoverageResult$).pipe(toArray()),
     );
+    const results = [...planTimeResults, ...laterResults];
     await this.mutationTestReportHelper.reportAll(results);
     await this.reporter.wrapUp();
     this.logDone();
     return results;
   }
 
-  private executeEarlyResult(input$: Observable<MutantTestPlan>) {
-    const [earlyResultMutants$, runMutant$] = partition(
-      input$.pipe(shareReplay()),
-      isEarlyResult,
-    );
-    const earlyResult$ = earlyResultMutants$.pipe(
-      map(({ mutant }) =>
-        this.mutationTestReportHelper.reportMutantStatus(mutant, mutant.status),
-      ),
-    );
-    return { earlyResult$, runMutant$ };
+  /**
+   * Collect results known without checker / test-runner workers: incremental
+   * reused mutants and ignored mutants. Persisted in the incremental journal
+   * `base.json` before workers start.
+   *
+   * Uncovered mutants (`testFilter.length === 0`) stay on `runPlans` so checkers
+   * still run; `executeNoCoverage` reports `NoCoverage` after that, as before.
+   */
+  private collectPlanTimeResults(mutantTestPlans: readonly MutantTestPlan[]): {
+    planTimeResults: MutantResult[];
+    runPlans: MutantRunPlan[];
+  } {
+    const planTimeResults: MutantResult[] = [];
+    const runPlans: MutantRunPlan[] = [];
+    for (const plan of mutantTestPlans) {
+      if (isEarlyResult(plan)) {
+        planTimeResults.push(
+          this.mutationTestReportHelper.reportMutantStatus(
+            plan.mutant,
+            plan.mutant.status,
+          ),
+        );
+      } else {
+        runPlans.push(plan);
+      }
+    }
+    return { planTimeResults, runPlans };
   }
 
   private executeNoCoverage(input$: Observable<MutantRunPlan>) {

--- a/packages/core/src/process/4-mutation-test-executor.ts
+++ b/packages/core/src/process/4-mutation-test-executor.ts
@@ -118,9 +118,9 @@ export class MutationTestExecutor {
   }
 
   /**
-   * Collect results known without checker / test-runner workers: incremental
-   * reused mutants and ignored mutants. Persisted in the incremental journal
-   * `base.json` before workers start.
+   * Collect results known without running any mutant through the checkers or
+   * test runners: incremental reused mutants and ignored mutants. Persisted in
+   * the incremental journal `base.json` before those runs start.
    *
    * Uncovered mutants (`testFilter.length === 0`) stay on `runPlans` so checkers
    * still run; `executeNoCoverage` reports `NoCoverage` after that, as before.

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -98,7 +98,13 @@ export class MutationTestReportHelper {
         this.incrementalJournal.isStarted &&
         this.partialResults.length > 0
       ) {
-        const report = await this.mutationTestReport(this.partialResults);
+        // Freeze the WAL first. Workers can keep reporting while we await file
+        // reads; if those results were appended and then `complete()` deleted the
+        // pending dir, they would vanish from both the WAL and the compact.
+        this.incrementalJournal.close();
+        // Snapshot so `mutationTestReport` cannot see a new file appear mid-await
+        // (it builds the file map, then walks the array again after those awaits).
+        const report = await this.mutationTestReport([...this.partialResults]);
         await this.incrementalJournal.complete(report);
         this.reportCompleted = true;
         this.log.info(
@@ -177,7 +183,10 @@ export class MutationTestReportHelper {
 
   private reportOne(result: MutantResult): MutantResult {
     this.partialResults.push(result);
-    if (this.options.incremental) {
+    // `isStarted` implies incremental is enabled and `begin()` committed the pending
+    // pair. Checking it here (rather than only inside `append`) avoids building a
+    // journal mutant for every plan-time result that `append` would then discard.
+    if (this.incrementalJournal.isStarted) {
       this.incrementalJournal.append(this.toJournalMutant(result));
     }
     this.reporter.onMutantTested(result);
@@ -280,9 +289,8 @@ export class MutationTestReportHelper {
         ]),
       );
       const remapTestId = (id: string): string => testIdMap.get(id) ?? id;
-      const remapTestIds = (
-        ids: string[] | undefined,
-      ): string[] | undefined => ids?.map(remapTestId);
+      const remapTestIds = (ids: string[] | undefined): string[] | undefined =>
+        ids?.map(remapTestId);
       this.testIdRemapper = { remapTestId, remapTestIds };
     }
     return this.testIdRemapper;

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -34,7 +34,11 @@ import {
 import { strykerVersion } from '../stryker-package.js';
 import { coreTokens } from '../di/index.js';
 import { objectUtils } from '../utils/object-utils.js';
-import { Project, FileSystem } from '../fs/index.js';
+import {
+  IncrementalJournal,
+  IncrementalJournalMutant,
+  Project,
+} from '../fs/index.js';
 import { TestCoverage } from '../mutants/index.js';
 import { UnexpectedExitHandler } from '../unexpected-exit-handler.js';
 
@@ -56,6 +60,12 @@ const STRYKER_FRAMEWORK: Readonly<
 export class MutationTestReportHelper {
   private readonly partialResults: MutantResult[] = [];
   private reportCompleted = false;
+  private testIdRemapper:
+    | {
+        remapTestId: (id: string) => string;
+        remapTestIds: (ids: string[] | undefined) => string[] | undefined;
+      }
+    | undefined;
 
   public static inject = tokens(
     coreTokens.reporter,
@@ -63,9 +73,9 @@ export class MutationTestReportHelper {
     coreTokens.project,
     commonTokens.logger,
     coreTokens.testCoverage,
-    coreTokens.fs,
     coreTokens.requireFromCwd,
     coreTokens.unexpectedExitRegistry,
+    coreTokens.incrementalJournal,
   );
 
   constructor(
@@ -74,18 +84,23 @@ export class MutationTestReportHelper {
     private readonly project: Project,
     private readonly log: Logger,
     private readonly testCoverage: I<TestCoverage>,
-    private readonly fs: I<FileSystem>,
     private readonly requireFromCwd: typeof requireResolve,
     unexpectedExitHandler: I<UnexpectedExitHandler>,
+    private readonly incrementalJournal: I<IncrementalJournal>,
   ) {
     unexpectedExitHandler.registerHandler(async () => {
+      // Only compact after this run's pending pair exists. Completing before
+      // `begin()` would write a truncated plan-time report and delete a
+      // recovered WAL from a prior crash.
       if (
         this.options.incremental &&
         !this.reportCompleted &&
+        this.incrementalJournal.isStarted &&
         this.partialResults.length > 0
       ) {
         const report = await this.mutationTestReport(this.partialResults);
-        await this.writeIncrementalReport(report);
+        await this.incrementalJournal.complete(report);
+        this.reportCompleted = true;
         this.log.info(
           'Saved a partial incremental report to "%s" after an unexpected interrupt.',
           this.options.incrementalFile,
@@ -162,8 +177,25 @@ export class MutationTestReportHelper {
 
   private reportOne(result: MutantResult): MutantResult {
     this.partialResults.push(result);
+    if (this.options.incremental) {
+      this.incrementalJournal.append(this.toJournalMutant(result));
+    }
     this.reporter.onMutantTested(result);
     return result;
+  }
+
+  /**
+   * Persist plan-time mutant results (reused, ignored) as the incremental
+   * journal's `base.json` before checker/test-runner workers run.
+   * Later `reportOne` calls are appended to `results.jsonl`.
+   */
+  public async beginIncrementalJournal(): Promise<void> {
+    if (!this.options.incremental) {
+      return;
+    }
+    const base = await this.mutationTestReport(this.partialResults);
+    await this.includeRemainingMutatedFiles(base);
+    await this.incrementalJournal.begin(base);
   }
 
   private checkStatusToResultStatus(
@@ -180,23 +212,10 @@ export class MutationTestReportHelper {
     const metrics = calculateMutationTestMetrics(report);
     this.reporter.onMutationTestReportReady(report, metrics);
     if (this.options.incremental) {
-      await this.writeIncrementalReport(report);
+      await this.incrementalJournal.complete(report);
     }
     this.reportCompleted = true;
     this.determineExitCode(metrics);
-  }
-
-  private async writeIncrementalReport(
-    report: schema.MutationTestResult,
-  ): Promise<void> {
-    await this.fs.mkdir(path.dirname(this.options.incrementalFile), {
-      recursive: true,
-    });
-    await this.fs.writeFile(
-      this.options.incrementalFile,
-      JSON.stringify(report, null, 2),
-      'utf-8',
-    );
   }
 
   private determineExitCode(metrics: MutationTestMetricsResult) {
@@ -227,18 +246,7 @@ export class MutationTestReportHelper {
   private async mutationTestReport(
     results: readonly MutantResult[],
   ): Promise<schema.MutationTestResult> {
-    // Mocha, jest and karma use test titles as test ids.
-    // This can mean a lot of duplicate strings in the json report.
-    // Therefore we remap the test ids here to numbers.
-    const testIdMap = new Map(
-      [...this.testCoverage.testsById.values()].map((test, index) => [
-        test.id,
-        index.toString(),
-      ]),
-    );
-    const remapTestId = (id: string): string => testIdMap.get(id) ?? id;
-    const remapTestIds = (ids: string[] | undefined): string[] | undefined =>
-      ids?.map(remapTestId);
+    const { remapTestId, remapTestIds } = this.getTestIdRemapper();
 
     return {
       files: await this.toFileResults(results, remapTestIds),
@@ -251,6 +259,57 @@ export class MutationTestReportHelper {
         ...STRYKER_FRAMEWORK,
         dependencies: this.discoverDependencies(),
       },
+    };
+  }
+
+  /**
+   * Mocha, jest and karma use test titles as test ids.
+   * This can mean a lot of duplicate strings in the json report.
+   * Therefore we remap the test ids here to numbers.
+   * The same mapping is reused for journal JSONL lines so they share one namespace with `base.json`.
+   */
+  private getTestIdRemapper(): {
+    remapTestId: (id: string) => string;
+    remapTestIds: (ids: string[] | undefined) => string[] | undefined;
+  } {
+    if (!this.testIdRemapper) {
+      const testIdMap = new Map(
+        [...this.testCoverage.testsById.values()].map((test, index) => [
+          test.id,
+          index.toString(),
+        ]),
+      );
+      const remapTestId = (id: string): string => testIdMap.get(id) ?? id;
+      const remapTestIds = (
+        ids: string[] | undefined,
+      ): string[] | undefined => ids?.map(remapTestId);
+      this.testIdRemapper = { remapTestId, remapTestIds };
+    }
+    return this.testIdRemapper;
+  }
+
+  /**
+   * `mutationTestReport` only emits files that already have results. The journal
+   * base must also include sources for files whose mutants will be written to JSONL.
+   */
+  private async includeRemainingMutatedFiles(
+    report: schema.MutationTestResult,
+  ): Promise<void> {
+    await Promise.all(
+      [...this.project.filesToMutate].map(async ([fileName]) => {
+        const reportFileName = normalizeReportFileName(fileName);
+        if (!report.files[reportFileName]) {
+          report.files[reportFileName] = await this.toFileResult(fileName);
+        }
+      }),
+    );
+  }
+
+  private toJournalMutant(result: MutantResult): IncrementalJournalMutant {
+    const { remapTestIds } = this.getTestIdRemapper();
+    return {
+      fileName: normalizeReportFileName(result.fileName),
+      ...this.toMutantResult(result, remapTestIds),
     };
   }
 

--- a/packages/core/src/reporters/mutation-test-report-helper.ts
+++ b/packages/core/src/reporters/mutation-test-report-helper.ts
@@ -33,6 +33,7 @@ import {
 
 import { strykerVersion } from '../stryker-package.js';
 import { coreTokens } from '../di/index.js';
+import { fileUtils } from '../utils/file-utils.js';
 import { objectUtils } from '../utils/object-utils.js';
 import {
   IncrementalJournal,
@@ -60,6 +61,13 @@ const STRYKER_FRAMEWORK: Readonly<
 export class MutationTestReportHelper {
   private readonly partialResults: MutantResult[] = [];
   private reportCompleted = false;
+  /**
+   * File names already warned about, so the same warning isn't repeated when the
+   * report is generated more than once (incremental runs report at plan time as
+   * well as at the end).
+   */
+  private readonly warnedMissingSourceFiles = new Set<string>();
+  private readonly warnedMissingTestFiles = new Set<string>();
   private testIdRemapper:
     | {
         remapTestId: (id: string) => string;
@@ -195,7 +203,7 @@ export class MutationTestReportHelper {
 
   /**
    * Persist plan-time mutant results (reused, ignored) as the incremental
-   * journal's `base.json` before checker/test-runner workers run.
+   * journal's `base.json` before the checkers and test runners run mutants.
    * Later `reportOne` calls are appended to `results.jsonl`.
    */
   public async beginIncrementalJournal(): Promise<void> {
@@ -380,14 +388,15 @@ export class MutationTestReportHelper {
 
   private async toFileResult(fileName: string): Promise<schema.FileResult> {
     const fileResult: schema.FileResult = {
-      language: this.determineLanguage(fileName),
+      language: fileUtils.determineLanguage(fileName),
       mutants: [],
       source: '',
     };
     const sourceFile = this.project.files.get(fileName);
     if (sourceFile) {
       fileResult.source = await sourceFile.readOriginal();
-    } else {
+    } else if (!this.warnedMissingSourceFiles.has(fileName)) {
+      this.warnedMissingSourceFiles.add(fileName);
       this.log.warn(
         normalizeWhitespaces(`File "${fileName}" not found
     in input files, but did receive mutant result for it. This shouldn't happen`),
@@ -404,7 +413,8 @@ export class MutationTestReportHelper {
       const file = this.project.files.get(fileName);
       if (file) {
         testFile.source = await file.readOriginal();
-      } else {
+      } else if (!this.warnedMissingTestFiles.has(fileName)) {
+        this.warnedMissingTestFiles.add(fileName);
         this.log.warn(
           normalizeWhitespaces(`Test file "${fileName}" not found
         in input files, but did receive test result for it. This shouldn't happen.`),
@@ -425,20 +435,6 @@ export class MutationTestReportHelper {
         ? { start: objectUtils.toSchemaPosition(test.startPosition) }
         : undefined,
     };
-  }
-
-  private determineLanguage(name: string): string {
-    const ext = path.extname(name).toLowerCase();
-    switch (ext) {
-      case '.ts':
-      case '.tsx':
-        return 'typescript';
-      case '.html':
-      case '.vue':
-        return 'html';
-      default:
-        return 'javascript';
-    }
   }
 
   private toMutantResult(

--- a/packages/core/src/sandbox/sandbox.ts
+++ b/packages/core/src/sandbox/sandbox.ts
@@ -21,13 +21,20 @@ import { objectUtils } from '../utils/index.js';
 
 export class Sandbox implements Disposable {
   private readonly fileMap = new Map<string, string>();
+  /**
+   * Guards against restoring the backup twice (signal path runs sync handlers,
+   * then `process.exit()` fires `exit` which runs them again; normal dispose
+   * may also follow a prior unexpected restore). Set only after a successful move
+   * so a failed/partial restore can still be retried.
+   */
+  private backupRestored = false;
 
   /**
    * The working directory for this sandbox
    * Either an actual sandbox directory, or the cwd when running in --inPlace mode
    */
   public readonly workingDirectory: string;
-  /**11
+  /**
    * The backup directory when running in --inPlace mode
    */
   private readonly backupDirectory: string = '';
@@ -59,9 +66,9 @@ export class Sandbox implements Disposable {
         'In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: %s',
         path.relative(process.cwd(), this.backupDirectory),
       );
-      unexpectedExitHandler.registerHandler(
-        this.dispose.bind(this, /* unexpected */ true),
-      );
+      // Must be synchronous: `process.on('exit')` cannot await async I/O, and
+      // that is the path that covers process.exit() / uncaught exceptions.
+      unexpectedExitHandler.registerSyncHandler(() => this.restoreBackupSync());
     } else {
       this.workingDirectory = temporaryDirectory.path;
       this.log.debug(
@@ -178,21 +185,35 @@ export class Sandbox implements Disposable {
     }
   }
 
-  public async dispose(unexpected = false): Promise<void> {
-    if (this.backupDirectory) {
-      if (unexpected) {
-        console.error(
-          `Detecting unexpected exit, recovering original files from ${path.relative(process.cwd(), this.backupDirectory)}`,
-        );
-      } else {
-        this.log.info(
-          `Resetting your original files from ${path.relative(process.cwd(), this.backupDirectory)}.`,
-        );
-      }
-      await fileUtils.moveDirectoryRecursive(
-        this.backupDirectory,
-        this.workingDirectory,
-      );
+  /**
+   * Synchronous backup restore for unexpected process termination.
+   * Registered on {@link UnexpectedExitHandler.registerSyncHandler}.
+   */
+  private restoreBackupSync(): void {
+    if (!this.backupDirectory || this.backupRestored) {
+      return;
     }
+    console.error(
+      `Detecting unexpected exit, recovering original files from ${path.relative(process.cwd(), this.backupDirectory)}`,
+    );
+    fileUtils.moveDirectoryRecursiveSync(
+      this.backupDirectory,
+      this.workingDirectory,
+    );
+    this.backupRestored = true;
+  }
+
+  public async dispose(): Promise<void> {
+    if (!this.backupDirectory || this.backupRestored) {
+      return;
+    }
+    this.log.info(
+      `Resetting your original files from ${path.relative(process.cwd(), this.backupDirectory)}.`,
+    );
+    await fileUtils.moveDirectoryRecursive(
+      this.backupDirectory,
+      this.workingDirectory,
+    );
+    this.backupRestored = true;
   }
 }

--- a/packages/core/src/stryker-cli.ts
+++ b/packages/core/src/stryker-cli.ts
@@ -185,7 +185,7 @@ export class StrykerCli {
       )
       .option(
         '--incrementalFile <file>',
-        'Specify the file to use for incremental mode.',
+        'Specify the file to use for incremental mode. A sibling .pending/ directory and .tmp file may appear next to it during a run; gitignore them like this file.',
       )
       .option(
         '--force',

--- a/packages/core/src/unexpected-exit-handler.ts
+++ b/packages/core/src/unexpected-exit-handler.ts
@@ -2,18 +2,33 @@ import { Disposable } from '@stryker-mutator/api/plugin';
 
 import { coreTokens } from './di/index.js';
 
+/**
+ * Async work that can run on signal termination (the event loop stays alive
+ * long enough to await). Used for things like flushing a partial incremental report.
+ */
 export type ExitHandler = () => Promise<void>;
+
+/**
+ * Synchronous work that must run on `process.on('exit')` (and is also invoked
+ * early on signals). Used for `--inPlace` backup restore, which cannot be async.
+ */
+export type SyncExitHandler = () => void;
 
 const signals = Object.freeze(['SIGABRT', 'SIGINT', 'SIGHUP', 'SIGTERM']);
 
 export class UnexpectedExitHandler implements Disposable {
   private readonly unexpectedExitHandlers: ExitHandler[] = [];
+  private readonly syncExitHandlers: SyncExitHandler[] = [];
   private shuttingDown = false;
+  private syncHandlersRan = false;
 
   public static readonly inject = [coreTokens.process] as const;
   constructor(
     private readonly process: Pick<NodeJS.Process, 'exit' | 'off' | 'on'>,
   ) {
+    // `exit` covers process.exit(), uncaught exceptions that unwind to exit, etc.
+    // Signal handlers alone miss those paths — required for --inPlace backup restore.
+    process.on('exit', this.handleExit);
     signals.forEach((signal) => process.on(signal, this.processSignal));
   }
 
@@ -29,13 +44,17 @@ export class UnexpectedExitHandler implements Disposable {
     }
     this.shuttingDown = true;
 
+    // Restore sync-critical state (e.g. --inPlace backups) before any async work.
+    this.runSyncHandlers();
+
     if (this.unexpectedExitHandlers.length === 0) {
       this.process.exit(exitCode);
       return; // `process.exit` is stubbed in tests, so return explicitly to prevent fall-through
     }
 
     // Run async handlers before exiting. Signal handlers keep the event loop alive,
-    // so we can await async work here.
+    // so we can await async work here. process.exit() will also fire `exit`, but
+    // sync handlers are idempotent via syncHandlersRan.
     void Promise.allSettled(
       this.unexpectedExitHandlers.map((handler) => handler()),
     ).then(() => {
@@ -43,11 +62,36 @@ export class UnexpectedExitHandler implements Disposable {
     });
   };
 
+  private readonly handleExit = () => {
+    this.runSyncHandlers();
+  };
+
+  private runSyncHandlers(): void {
+    if (this.syncHandlersRan) {
+      return;
+    }
+    this.syncHandlersRan = true;
+    for (const handler of this.syncExitHandlers) {
+      try {
+        handler();
+      } catch (error) {
+        // Keep going so remaining sync handlers still run, and the signal path
+        // can still call process.exit() after this returns.
+        console.error('Unexpected exit sync handler failed:', error);
+      }
+    }
+  }
+
   public registerHandler(handler: ExitHandler): void {
     this.unexpectedExitHandlers.push(handler);
   }
 
+  public registerSyncHandler(handler: SyncExitHandler): void {
+    this.syncExitHandlers.push(handler);
+  }
+
   public dispose(): void {
+    this.process.off('exit', this.handleExit);
     signals.forEach((signal) => this.process.off(signal, this.processSignal));
   }
 }

--- a/packages/core/src/unexpected-exit-handler.ts
+++ b/packages/core/src/unexpected-exit-handler.ts
@@ -53,8 +53,8 @@ export class UnexpectedExitHandler implements Disposable {
     }
 
     // Run async handlers before exiting. Signal handlers keep the event loop alive,
-    // so we can await async work here. process.exit() will also fire `exit`, but
-    // sync handlers are idempotent via syncHandlersRan.
+    // so we can await async work here. process.exit() will also fire `exit`; sync
+    // handlers that already succeeded are skipped via syncHandlersRan.
     void Promise.allSettled(
       this.unexpectedExitHandlers.map((handler) => handler()),
     ).then(() => {
@@ -70,15 +70,20 @@ export class UnexpectedExitHandler implements Disposable {
     if (this.syncHandlersRan) {
       return;
     }
-    this.syncHandlersRan = true;
+    let allSucceeded = true;
     for (const handler of this.syncExitHandlers) {
       try {
         handler();
       } catch (error) {
         // Keep going so remaining sync handlers still run, and the signal path
-        // can still call process.exit() after this returns.
+        // can still call process.exit() after this returns. Leave syncHandlersRan
+        // false so a later `exit` event can retry (e.g. --inPlace backup restore).
+        allSucceeded = false;
         console.error('Unexpected exit sync handler failed:', error);
       }
+    }
+    if (allSucceeded) {
+      this.syncHandlersRan = true;
     }
   }
 

--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -39,7 +39,7 @@ export const fileUtils = {
   },
 
   /**
-   * Recursively walks the from directory and copy the content to the target directory
+   * Recursively walks the from directory and moves the content to the target directory.
    * @param from The source directory to move from
    * @param to The target directory to move to
    */
@@ -62,6 +62,34 @@ export const fileUtils = {
       }
     }
     await fs.promises.rmdir(from);
+  },
+
+  /**
+   * Synchronous counterpart of {@link moveDirectoryRecursive}.
+   * Required for `process.on('exit')` handlers (e.g. `--inPlace` backup restore),
+   * which cannot run async I/O.
+   * @param from The source directory to move from
+   * @param to The target directory to move to
+   */
+  moveDirectoryRecursiveSync(from: string, to: string): void {
+    if (!fs.existsSync(from)) {
+      return;
+    }
+    if (!fs.existsSync(to)) {
+      fs.mkdirSync(to, { recursive: true });
+    }
+    const files = fs.readdirSync(from);
+    for (const file of files) {
+      const fromFileName = path.join(from, file);
+      const toFileName = path.join(to, file);
+      const stats = fs.lstatSync(fromFileName);
+      if (stats.isFile()) {
+        fs.renameSync(fromFileName, toFileName);
+      } else {
+        this.moveDirectoryRecursiveSync(fromFileName, toFileName);
+      }
+    }
+    fs.rmdirSync(from);
   },
 
   /**

--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -17,6 +17,24 @@ export const fileUtils = {
     }
   },
 
+  /**
+   * Determines the language of a file, based on its extension.
+   * Used to fill in the `language` field of a mutation testing report file.
+   */
+  determineLanguage(fileName: string): string {
+    const ext = path.extname(fileName).toLowerCase();
+    switch (ext) {
+      case '.ts':
+      case '.tsx':
+        return 'typescript';
+      case '.html':
+      case '.vue':
+        return 'html';
+      default:
+        return 'javascript';
+    }
+  },
+
   async exists(fileName: string): Promise<boolean> {
     try {
       await fs.promises.access(fileName);
@@ -75,9 +93,7 @@ export const fileUtils = {
     if (!fs.existsSync(from)) {
       return;
     }
-    if (!fs.existsSync(to)) {
-      fs.mkdirSync(to, { recursive: true });
-    }
+    fs.mkdirSync(to, { recursive: true });
     const files = fs.readdirSync(from);
     for (const file of files) {
       const fromFileName = path.join(from, file);

--- a/packages/core/test/helpers/unexpected-exit-handler-test-double.ts
+++ b/packages/core/test/helpers/unexpected-exit-handler-test-double.ts
@@ -1,17 +1,27 @@
-import type { ExitHandler } from '../../src/unexpected-exit-handler.js';
+import type {
+  ExitHandler,
+  SyncExitHandler,
+} from '../../src/unexpected-exit-handler.js';
 
 export class UnexpectedExitHandlerTestDouble {
   private readonly exitHandlers: ExitHandler[] = [];
+  private readonly syncExitHandlers: SyncExitHandler[] = [];
 
   public registerHandler(handler: ExitHandler): void {
     this.exitHandlers.push(handler);
   }
 
+  public registerSyncHandler(handler: SyncExitHandler): void {
+    this.syncExitHandlers.push(handler);
+  }
+
   public dispose(): void {
     this.exitHandlers.length = 0;
+    this.syncExitHandlers.length = 0;
   }
 
   public async triggerUnexpectedExit(): Promise<void> {
+    this.syncExitHandlers.forEach((handler) => handler());
     await Promise.allSettled(this.exitHandlers.map((handler) => handler()));
   }
 }

--- a/packages/core/test/integration/fs/project-reader.it.spec.ts
+++ b/packages/core/test/integration/fs/project-reader.it.spec.ts
@@ -2,7 +2,11 @@ import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
 import { coreTokens } from '../../../src/di/index.js';
-import { FileSystem, ProjectReader } from '../../../src/fs/index.js';
+import {
+  FileSystem,
+  IncrementalJournal,
+  ProjectReader,
+} from '../../../src/fs/index.js';
 import { resolveFromRoot } from '../../helpers/test-utils.js';
 
 const resolveTestResource = resolveFromRoot.bind(
@@ -19,6 +23,7 @@ describe(`${ProjectReader.name} integration`, () => {
     originalCwd = process.cwd();
     sut = testInjector.injector
       .provideClass(coreTokens.fs, FileSystem)
+      .provideClass(coreTokens.incrementalJournal, IncrementalJournal)
       .provideValue(coreTokens.reporter, factory.reporter())
       .injectClass(ProjectReader);
   });

--- a/packages/core/test/integration/utils/file-utils.it.spec.ts
+++ b/packages/core/test/integration/utils/file-utils.it.spec.ts
@@ -74,6 +74,38 @@ describe('fileUtils', () => {
     });
   });
 
+  describe('moveDirectoryRecursiveSync', () => {
+    const from = path.resolve(os.tmpdir(), 'moveDirectoryRecursiveSyncFrom');
+    const to = path.resolve(os.tmpdir(), 'moveDirectoryRecursiveSyncTo');
+
+    afterEach(async () => {
+      await Promise.all([
+        fsPromises.rm(from, { recursive: true, force: true }),
+        fsPromises.rm(to, { recursive: true, force: true }),
+      ]);
+    });
+
+    it('should override target files synchronously', async () => {
+      const expectedFileNameA = path.resolve(to, 'a.js');
+      const expectedFileNameB = path.resolve(to, 'b', 'b.js');
+      await writeAll({
+        [path.resolve(from, 'a.js')]: 'original a',
+        [path.resolve(from, 'b', 'b.js')]: 'original b',
+        [expectedFileNameA]: 'mutated a',
+        [expectedFileNameB]: 'mutated b',
+      });
+
+      fileUtils.moveDirectoryRecursiveSync(from, to);
+
+      const files = await readDirRecursive(to);
+      expect(files).deep.eq({
+        [expectedFileNameA]: 'original a',
+        [expectedFileNameB]: 'original b',
+      });
+      await expect(fsPromises.access(from)).rejected;
+    });
+  });
+
   async function readDirRecursive(
     dir: string,
   ): Promise<Record<string, string>> {

--- a/packages/core/test/unit/fs/incremental-journal.spec.ts
+++ b/packages/core/test/unit/fs/incremental-journal.spec.ts
@@ -34,15 +34,12 @@ describe(IncrementalJournal.name, () => {
   });
 
   afterEach(async () => {
-    await sut.close();
+    sut.close();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   function createSut() {
-    return new IncrementalJournal(
-      testInjector.options,
-      testInjector.logger,
-    );
+    return new IncrementalJournal(testInjector.options, testInjector.logger);
   }
 
   function createBase(
@@ -156,9 +153,7 @@ describe(IncrementalJournal.name, () => {
       sut.append(journalMutant({ id: `run-${i}` }));
     }
     const recovered = await createSut().load();
-    const ids = recovered!.files['foo.js'].mutants
-      .slice(1)
-      .map(({ id }) => id);
+    const ids = recovered!.files['foo.js'].mutants.slice(1).map(({ id }) => id);
     expect(ids).deep.eq([...Array(count).keys()].map((i) => `run-${i}`));
   });
 
@@ -191,9 +186,7 @@ describe(IncrementalJournal.name, () => {
     expect(recovered).undefined;
     expect(await fileExists(path.join(pendingDir, INCREMENTAL_PENDING_BASE)))
       .true;
-    expect(testInjector.logger.warn).calledWithMatch(
-      'corrupted interior line',
-    );
+    expect(testInjector.logger.warn).calledWithMatch('corrupted interior line');
   });
 
   it('should write the incremental file then remove pending on complete', async () => {
@@ -221,9 +214,9 @@ describe(IncrementalJournal.name, () => {
   });
 
   it('should map incrementalFile to a gitignore glob covering the report and WAL siblings', () => {
-    expect(
-      incrementalGitignorePattern('reports/stryker-incremental.json'),
-    ).eq('reports/stryker-incremental.*');
+    expect(incrementalGitignorePattern('reports/stryker-incremental.json')).eq(
+      'reports/stryker-incremental.*',
+    );
   });
 
   it('should set isStarted only after begin succeeds, and clear it on complete', async () => {
@@ -370,8 +363,9 @@ describe(IncrementalJournal.name, () => {
       }),
     );
     expect(sut.isStarted).true;
-    expect((await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id))
-      .deep.eq(['plan-from-b']);
+    expect(
+      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-from-b']);
   });
 
   it('should replace pending with a new base and empty journal so old JSONL is not mixed in', async () => {
@@ -395,10 +389,8 @@ describe(IncrementalJournal.name, () => {
 
     expect(await readPendingBase()).deep.eq(secondBase);
     expect(await readPendingJsonl()).eq('');
-    expect(await fileExists(incrementalPendingPrevDir(incrementalFile)))
-      .false;
-    expect(await fileExists(incrementalPendingNextDir(incrementalFile)))
-      .false;
+    expect(await fileExists(incrementalPendingPrevDir(incrementalFile))).false;
+    expect(await fileExists(incrementalPendingNextDir(incrementalFile))).false;
 
     const recovered = await createSut().load();
     expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
@@ -412,9 +404,9 @@ describe(IncrementalJournal.name, () => {
 
     const nextRun = createSut();
     expect(await nextRun.load()).undefined;
-    expect(
-      JSON.parse(await fs.readFile(incrementalFile, 'utf-8')),
-    ).deep.eq(committed);
+    expect(JSON.parse(await fs.readFile(incrementalFile, 'utf-8'))).deep.eq(
+      committed,
+    );
   });
 
   it('should not destroy an existing pending pair if begin never runs after a previous crash', async () => {

--- a/packages/core/test/unit/fs/incremental-journal.spec.ts
+++ b/packages/core/test/unit/fs/incremental-journal.spec.ts
@@ -1,0 +1,445 @@
+import os from 'os';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+import { schema } from '@stryker-mutator/api/core';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+
+import {
+  IncrementalJournal,
+  IncrementalJournalMutant,
+  INCREMENTAL_PENDING_BASE,
+  INCREMENTAL_PENDING_RESULTS,
+  incrementalPendingDir,
+  incrementalPendingNextDir,
+  incrementalPendingPrevDir,
+  incrementalTempFile,
+  incrementalGitignorePattern,
+} from '../../../src/fs/incremental-journal.js';
+
+describe(IncrementalJournal.name, () => {
+  let tempDir: string;
+  let incrementalFile: string;
+  let pendingDir: string;
+  let sut: IncrementalJournal;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stryker-journal-'));
+    incrementalFile = path.join(tempDir, 'stryker-incremental.json');
+    pendingDir = incrementalPendingDir(incrementalFile);
+    testInjector.options.incremental = true;
+    testInjector.options.incrementalFile = incrementalFile;
+    sut = createSut();
+  });
+
+  afterEach(async () => {
+    await sut.close();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function createSut() {
+    return new IncrementalJournal(
+      testInjector.options,
+      testInjector.logger,
+    );
+  }
+
+  function createBase(
+    overrides?: Partial<schema.MutationTestResult>,
+  ): schema.MutationTestResult {
+    return factory.mutationTestReportSchemaMutationTestResult({
+      files: {
+        'foo.js': factory.mutationTestReportSchemaFileResult({
+          source: 'const answer = 42;',
+          mutants: [
+            factory.mutationTestReportSchemaMutantResult({
+              id: 'plan-1',
+              status: 'Ignored',
+              mutatorName: 'BlockStatement',
+            }),
+          ],
+        }),
+      },
+      testFiles: {
+        'foo.spec.js': factory.mutationTestReportSchemaTestFile({
+          tests: [
+            factory.mutationTestReportSchemaTestDefinition({
+              id: '0',
+              name: 'should work',
+            }),
+          ],
+        }),
+      },
+      ...overrides,
+    });
+  }
+
+  function journalMutant(
+    overrides?: Partial<IncrementalJournalMutant>,
+  ): IncrementalJournalMutant {
+    return {
+      ...factory.mutationTestReportSchemaMutantResult({
+        id: 'run-1',
+        status: 'Killed',
+        mutatorName: 'EqualityOperator',
+        killedBy: ['0'],
+      }),
+      fileName: 'foo.js',
+      ...overrides,
+    };
+  }
+
+  async function readPendingBase(): Promise<schema.MutationTestResult> {
+    const raw = await fs.readFile(
+      path.join(pendingDir, INCREMENTAL_PENDING_BASE),
+      'utf-8',
+    );
+    return JSON.parse(raw) as schema.MutationTestResult;
+  }
+
+  async function readPendingJsonl(): Promise<string> {
+    return fs.readFile(
+      path.join(pendingDir, INCREMENTAL_PENDING_RESULTS),
+      'utf-8',
+    );
+  }
+
+  it('should write a valid MutationTestResult and empty JSONL on begin', async () => {
+    const base = createBase();
+    await sut.begin(base);
+
+    const written = await readPendingBase();
+    expect(written).deep.eq(base);
+    expect(await readPendingJsonl()).eq('');
+    expect(await fileExists(incrementalPendingNextDir(incrementalFile))).false;
+  });
+
+  it('should ignore append before begin', async () => {
+    sut.append(journalMutant());
+    expect(await fileExists(pendingDir)).false;
+    expect(await sut.load()).undefined;
+  });
+
+  it('should ignore append when incremental is false', async () => {
+    testInjector.options.incremental = false;
+    sut = createSut();
+    const base = createBase();
+    await sut.begin(base);
+    sut.append(journalMutant());
+    expect(await fileExists(pendingDir)).false;
+  });
+
+  it('should merge base and journal mutants on load without needing testCoverage', async () => {
+    const base = createBase();
+    await sut.begin(base);
+    sut.append(journalMutant({ id: 'run-1' }));
+    sut.append(journalMutant({ id: 'run-2', status: 'Survived' }));
+    const recovered = await createSut().load();
+    expect(recovered).not.undefined;
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'run-1',
+      'run-2',
+    ]);
+    expect(recovered!.testFiles?.['foo.spec.js'].tests).lengthOf(1);
+    expect(
+      recovered,
+      'load must return a MutationTestResult, not a testCoverage object',
+    ).not.to.have.property('testCoverage');
+  });
+
+  it('should serialize appends in call order', async () => {
+    await sut.begin(createBase());
+    const count = 20;
+    for (let i = 0; i < count; i++) {
+      sut.append(journalMutant({ id: `run-${i}` }));
+    }
+    const recovered = await createSut().load();
+    const ids = recovered!.files['foo.js'].mutants
+      .slice(1)
+      .map(({ id }) => id);
+    expect(ids).deep.eq([...Array(count).keys()].map((i) => `run-${i}`));
+  });
+
+  it('should drop a torn last JSONL line and keep earlier lines', async () => {
+    await sut.begin(createBase());
+    sut.append(journalMutant({ id: 'run-1' }));
+    await fs.appendFile(
+      path.join(pendingDir, INCREMENTAL_PENDING_RESULTS),
+      '{"id":"torn"',
+    );
+
+    const recovered = await createSut().load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'run-1',
+    ]);
+  });
+
+  it('should fail load on a corrupted interior JSONL line and leave pending on disk', async () => {
+    await sut.begin(createBase());
+    sut.append(journalMutant({ id: 'run-1' }));
+    sut.append(journalMutant({ id: 'run-2' }));
+    await fs.writeFile(
+      path.join(pendingDir, INCREMENTAL_PENDING_RESULTS),
+      '{not-json}\n{"fileName":"foo.js","id":"run-2","status":"Killed","mutatorName":"x","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":2}},"replacement":""}\n',
+      'utf-8',
+    );
+
+    const recovered = await createSut().load();
+    expect(recovered).undefined;
+    expect(await fileExists(path.join(pendingDir, INCREMENTAL_PENDING_BASE)))
+      .true;
+    expect(testInjector.logger.warn).calledWithMatch(
+      'corrupted interior line',
+    );
+  });
+
+  it('should write the incremental file then remove pending on complete', async () => {
+    const base = createBase();
+    await sut.begin(base);
+    sut.append(journalMutant({ id: 'run-1' }));
+    const finalReport = createBase({
+      files: {
+        'foo.js': factory.mutationTestReportSchemaFileResult({
+          mutants: [
+            factory.mutationTestReportSchemaMutantResult({ id: 'plan-1' }),
+            factory.mutationTestReportSchemaMutantResult({ id: 'run-1' }),
+          ],
+        }),
+      },
+    });
+    await sut.complete(finalReport);
+
+    const committed = JSON.parse(
+      await fs.readFile(incrementalFile, 'utf-8'),
+    ) as schema.MutationTestResult;
+    expect(committed).deep.eq(finalReport);
+    expect(await fileExists(pendingDir)).false;
+    expect(await fileExists(incrementalTempFile(incrementalFile))).false;
+  });
+
+  it('should map incrementalFile to a gitignore glob covering the report and WAL siblings', () => {
+    expect(
+      incrementalGitignorePattern('reports/stryker-incremental.json'),
+    ).eq('reports/stryker-incremental.*');
+  });
+
+  it('should set isStarted only after begin succeeds, and clear it on complete', async () => {
+    expect(sut.isStarted).false;
+    await sut.begin(createBase());
+    expect(sut.isStarted).true;
+    await sut.complete(createBase());
+    expect(sut.isStarted).false;
+  });
+
+  it('should recover from pending.prev when pending is missing (crash mid-swap)', async () => {
+    await sut.begin(createBase());
+    sut.append(journalMutant({ id: 'from-prev' }));
+    const prevDir = incrementalPendingPrevDir(incrementalFile);
+    await fs.rename(pendingDir, prevDir);
+
+    const nextDir = incrementalPendingNextDir(incrementalFile);
+    await fs.mkdir(nextDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(
+        createBase({
+          files: {
+            'foo.js': factory.mutationTestReportSchemaFileResult({
+              mutants: [
+                factory.mutationTestReportSchemaMutantResult({
+                  id: 'from-next-only',
+                }),
+              ],
+            }),
+          },
+        }),
+      ),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
+      '',
+      'utf-8',
+    );
+
+    const recovered = await createSut().load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-prev',
+    ]);
+  });
+
+  it('should prefer pending over pending.prev when both exist', async () => {
+    await sut.begin(createBase());
+    sut.append(journalMutant({ id: 'from-pending' }));
+    const prevDir = incrementalPendingPrevDir(incrementalFile);
+    await fs.mkdir(prevDir, { recursive: true });
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(
+        createBase({
+          files: {
+            'foo.js': factory.mutationTestReportSchemaFileResult({
+              mutants: [
+                factory.mutationTestReportSchemaMutantResult({
+                  id: 'from-prev-only',
+                }),
+              ],
+            }),
+          },
+        }),
+      ),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_RESULTS),
+      '',
+      'utf-8',
+    );
+
+    const recovered = await createSut().load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-pending',
+    ]);
+  });
+
+  it('should recover from pending.next when pending and prev are missing (crash before first swap)', async () => {
+    const nextDir = incrementalPendingNextDir(incrementalFile);
+    await fs.mkdir(nextDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: 'from-next' }))}\n`,
+      'utf-8',
+    );
+
+    const recovered = await createSut().load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-next',
+    ]);
+  });
+
+  it('should promote pending.next to pending so begin cannot delete recovered mutants', async () => {
+    const nextDir = incrementalPendingNextDir(incrementalFile);
+    await fs.mkdir(nextDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: 'from-next' }))}\n`,
+      'utf-8',
+    );
+
+    const recovered = await sut.load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-next',
+    ]);
+    expect(await fileExists(pendingDir)).true;
+    expect(await fileExists(nextDir)).false;
+
+    // `begin()` deletes `.next` first. After promote, that wipe must not drop the WAL.
+    await fs.rm(nextDir, { recursive: true, force: true });
+    expect(
+      (await createSut().load())!.files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-1', 'from-next']);
+
+    await sut.begin(
+      createBase({
+        files: {
+          'foo.js': factory.mutationTestReportSchemaFileResult({
+            mutants: [
+              factory.mutationTestReportSchemaMutantResult({
+                id: 'plan-from-b',
+              }),
+            ],
+          }),
+        },
+      }),
+    );
+    expect(sut.isStarted).true;
+    expect((await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id))
+      .deep.eq(['plan-from-b']);
+  });
+
+  it('should replace pending with a new base and empty journal so old JSONL is not mixed in', async () => {
+    const firstBase = createBase();
+    await sut.begin(firstBase);
+    sut.append(journalMutant({ id: 'from-run-a' }));
+    const secondBase = createBase({
+      files: {
+        'foo.js': factory.mutationTestReportSchemaFileResult({
+          source: 'const answer = 43;',
+          mutants: [
+            factory.mutationTestReportSchemaMutantResult({
+              id: 'plan-from-b',
+              status: 'NoCoverage',
+            }),
+          ],
+        }),
+      },
+    });
+    await sut.begin(secondBase);
+
+    expect(await readPendingBase()).deep.eq(secondBase);
+    expect(await readPendingJsonl()).eq('');
+    expect(await fileExists(incrementalPendingPrevDir(incrementalFile)))
+      .false;
+    expect(await fileExists(incrementalPendingNextDir(incrementalFile)))
+      .false;
+
+    const recovered = await createSut().load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-from-b',
+    ]);
+  });
+
+  it('should keep the previous pending pair when begin is never called (crash-before-begin)', async () => {
+    const committed = createBase();
+    await sut.complete(committed);
+
+    const nextRun = createSut();
+    expect(await nextRun.load()).undefined;
+    expect(
+      JSON.parse(await fs.readFile(incrementalFile, 'utf-8')),
+    ).deep.eq(committed);
+  });
+
+  it('should not destroy an existing pending pair if begin never runs after a previous crash', async () => {
+    await sut.begin(createBase());
+    sut.append(journalMutant({ id: 'run-1' }));
+    const nextRun = createSut();
+    expect(await nextRun.load()).not.undefined;
+    expect(
+      (await nextRun.load())!.files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-1', 'run-1']);
+  });
+
+  it('should no-op load when incremental is false', async () => {
+    await sut.begin(createBase());
+    testInjector.options.incremental = false;
+    const disabled = createSut();
+    expect(await disabled.load()).undefined;
+  });
+});
+
+async function fileExists(fileName: string): Promise<boolean> {
+  try {
+    await fs.access(fileName);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/test/unit/fs/incremental-journal.spec.ts
+++ b/packages/core/test/unit/fs/incremental-journal.spec.ts
@@ -1,10 +1,11 @@
 import os from 'os';
 import path from 'path';
-import { promises as fs } from 'fs';
+import fsNode, { promises as fs } from 'fs';
 
 import { schema } from '@stryker-mutator/api/core';
 import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import {
   IncrementalJournal,
@@ -35,6 +36,7 @@ describe(IncrementalJournal.name, () => {
 
   afterEach(async () => {
     sut.close();
+    sinon.restore();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -366,6 +368,122 @@ describe(IncrementalJournal.name, () => {
     expect(
       (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
     ).deep.eq(['plan-from-b']);
+  });
+
+  it('should keep unrecovered .next WAL until begin commits when promote fails', async () => {
+    const nextDir = incrementalPendingNextDir(incrementalFile);
+    await fs.mkdir(nextDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: 'from-next' }))}\n`,
+      'utf-8',
+    );
+
+    const originalRename = fsNode.promises.rename.bind(fsNode.promises);
+    sinon
+      .stub(fsNode.promises, 'rename')
+      .callsFake(async (from: fsNode.PathLike, to: fsNode.PathLike) => {
+        if (
+          path.resolve(String(from)) === path.resolve(nextDir) &&
+          path.resolve(String(to)) === path.resolve(pendingDir)
+        ) {
+          throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+        }
+        return originalRename(from, to);
+      });
+
+    const recovered = await sut.load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-next',
+    ]);
+    expect(await fileExists(nextDir)).true;
+    expect(testInjector.logger.warn).calledWithMatch('Failed to promote');
+
+    // Crash before begin: another process must still find the unrecovered WAL.
+    expect(
+      (await createSut().load())!.files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-1', 'from-next']);
+
+    await sut.begin(
+      createBase({
+        files: {
+          'foo.js': factory.mutationTestReportSchemaFileResult({
+            mutants: [
+              factory.mutationTestReportSchemaMutantResult({
+                id: 'plan-from-b',
+              }),
+            ],
+          }),
+        },
+      }),
+    );
+    expect(sut.isStarted).true;
+    expect(
+      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-from-b']);
+    expect(await fileExists(nextDir)).false;
+    expect(await fileExists(incrementalPendingPrevDir(incrementalFile))).false;
+  });
+
+  it('should keep unrecovered .prev WAL until begin commits when promote fails', async () => {
+    const prevDir = incrementalPendingPrevDir(incrementalFile);
+    await fs.mkdir(prevDir, { recursive: true });
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: 'from-prev' }))}\n`,
+      'utf-8',
+    );
+
+    const originalRename = fsNode.promises.rename.bind(fsNode.promises);
+    sinon
+      .stub(fsNode.promises, 'rename')
+      .callsFake(async (from: fsNode.PathLike, to: fsNode.PathLike) => {
+        if (
+          path.resolve(String(from)) === path.resolve(prevDir) &&
+          path.resolve(String(to)) === path.resolve(pendingDir)
+        ) {
+          throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+        }
+        return originalRename(from, to);
+      });
+
+    const recovered = await sut.load();
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-prev',
+    ]);
+    expect(await fileExists(prevDir)).true;
+
+    await sut.begin(
+      createBase({
+        files: {
+          'foo.js': factory.mutationTestReportSchemaFileResult({
+            mutants: [
+              factory.mutationTestReportSchemaMutantResult({
+                id: 'plan-from-b',
+              }),
+            ],
+          }),
+        },
+      }),
+    );
+    expect(sut.isStarted).true;
+    expect(
+      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
+    ).deep.eq(['plan-from-b']);
+    expect(await fileExists(prevDir)).false;
+    expect(await fileExists(incrementalPendingNextDir(incrementalFile))).false;
   });
 
   it('should replace pending with a new base and empty journal so old JSONL is not mixed in', async () => {

--- a/packages/core/test/unit/fs/incremental-journal.spec.ts
+++ b/packages/core/test/unit/fs/incremental-journal.spec.ts
@@ -97,6 +97,73 @@ describe(IncrementalJournal.name, () => {
     return JSON.parse(raw) as schema.MutationTestResult;
   }
 
+  /** Make one exact path fail with `code`; every other read passes through. */
+  function stubReadFileError(file: string, code: string) {
+    const readFile = fsNode.promises.readFile as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    sinon
+      .stub(fsNode.promises, 'readFile')
+      .callsFake(((target: fsNode.PathLike, ...args: unknown[]) =>
+        path.resolve(String(target)) === path.resolve(file)
+          ? Promise.reject(Object.assign(new Error(code), { code }))
+          : readFile(target, ...args)) as typeof fsNode.promises.readFile);
+  }
+
+  /** Write a standalone WAL pair (base + one journal line) into `dir`. */
+  async function seedWal(dir: string, mutantId: string): Promise<void> {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(dir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: mutantId }))}
+`,
+      'utf-8',
+    );
+  }
+
+  /** A `pending/` dir `load()` rejects, so recovery falls through to `.prev` / `.next`. */
+  async function seedUnusablePending(): Promise<void> {
+    await fs.mkdir(pendingDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pendingDir, INCREMENTAL_PENDING_BASE),
+      '{ not json',
+      'utf-8',
+    );
+  }
+
+  /** Base for the run that recovers a WAL, distinguishable from `createBase()`. */
+  function nextRunBase(): schema.MutationTestResult {
+    return createBase({
+      files: {
+        'foo.js': factory.mutationTestReportSchemaFileResult({
+          mutants: [
+            factory.mutationTestReportSchemaMutantResult({ id: 'plan-from-b' }),
+          ],
+        }),
+      },
+    });
+  }
+
+  /** Make every `base.json` write fail, i.e. begin() dies while staging. */
+  function stubPendingBaseWriteError() {
+    const writeFile = fsNode.promises.writeFile as (
+      ...args: unknown[]
+    ) => Promise<void>;
+    sinon
+      .stub(fsNode.promises, 'writeFile')
+      .callsFake(((target: fsNode.PathLike, ...args: unknown[]) =>
+        String(target).endsWith(INCREMENTAL_PENDING_BASE)
+          ? Promise.reject(
+              Object.assign(new Error('ENOSPC'), { code: 'ENOSPC' }),
+            )
+          : writeFile(target, ...args)) as typeof fsNode.promises.writeFile);
+  }
+
   async function readPendingJsonl(): Promise<string> {
     return fs.readFile(
       path.join(pendingDir, INCREMENTAL_PENDING_RESULTS),
@@ -189,6 +256,48 @@ describe(IncrementalJournal.name, () => {
     expect(await fileExists(path.join(pendingDir, INCREMENTAL_PENDING_BASE)))
       .true;
     expect(testInjector.logger.warn).calledWithMatch('corrupted interior line');
+  });
+
+  it('should skip an unreadable pending dir and recover from the next location', async () => {
+    // begin() wipes the staging dirs, so seed .prev only after it has committed.
+    await sut.begin(createBase());
+    const prevDir = incrementalPendingPrevDir(incrementalFile);
+    await fs.mkdir(prevDir, { recursive: true });
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_BASE),
+      JSON.stringify(createBase()),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(prevDir, INCREMENTAL_PENDING_RESULTS),
+      `${JSON.stringify(journalMutant({ id: 'from-prev' }))}
+`,
+      'utf-8',
+    );
+    stubReadFileError(path.join(pendingDir, INCREMENTAL_PENDING_BASE), 'EBUSY');
+
+    const recovered = await createSut().load();
+
+    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
+      'plan-1',
+      'from-prev',
+    ]);
+    expect(testInjector.logger.warn).calledWithMatch(
+      'Failed to read the incremental journal',
+    );
+  });
+
+  it('should resolve undefined instead of failing the run when the pending dir is unreadable', async () => {
+    await sut.begin(createBase());
+    stubReadFileError(
+      path.join(pendingDir, INCREMENTAL_PENDING_BASE),
+      'EACCES',
+    );
+
+    expect(await createSut().load()).undefined;
+    expect(testInjector.logger.warn).calledWithMatch(
+      'Failed to read the incremental journal',
+    );
   });
 
   it('should write the incremental file then remove pending on complete', async () => {
@@ -323,168 +432,61 @@ describe(IncrementalJournal.name, () => {
     ]);
   });
 
-  it('should promote pending.next to pending so begin cannot delete recovered mutants', async () => {
-    const nextDir = incrementalPendingNextDir(incrementalFile);
-    await fs.mkdir(nextDir, { recursive: true });
-    await fs.writeFile(
-      path.join(nextDir, INCREMENTAL_PENDING_BASE),
-      JSON.stringify(createBase()),
-      'utf-8',
-    );
-    await fs.writeFile(
-      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
-      `${JSON.stringify(journalMutant({ id: 'from-next' }))}\n`,
-      'utf-8',
-    );
-
-    const recovered = await sut.load();
-    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
-      'plan-1',
-      'from-next',
-    ]);
-    expect(await fileExists(pendingDir)).true;
-    expect(await fileExists(nextDir)).false;
-
-    // `begin()` deletes `.next` first. After promote, that wipe must not drop the WAL.
-    await fs.rm(nextDir, { recursive: true, force: true });
-    expect(
-      (await createSut().load())!.files['foo.js'].mutants.map(({ id }) => id),
-    ).deep.eq(['plan-1', 'from-next']);
-
-    await sut.begin(
-      createBase({
-        files: {
-          'foo.js': factory.mutationTestReportSchemaFileResult({
-            mutants: [
-              factory.mutationTestReportSchemaMutantResult({
-                id: 'plan-from-b',
-              }),
-            ],
-          }),
-        },
-      }),
-    );
-    expect(sut.isStarted).true;
-    expect(
-      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
-    ).deep.eq(['plan-from-b']);
-  });
-
-  it('should keep unrecovered .next WAL until begin commits when promote fails', async () => {
-    const nextDir = incrementalPendingNextDir(incrementalFile);
-    await fs.mkdir(nextDir, { recursive: true });
-    await fs.writeFile(
-      path.join(nextDir, INCREMENTAL_PENDING_BASE),
-      JSON.stringify(createBase()),
-      'utf-8',
-    );
-    await fs.writeFile(
-      path.join(nextDir, INCREMENTAL_PENDING_RESULTS),
-      `${JSON.stringify(journalMutant({ id: 'from-next' }))}\n`,
-      'utf-8',
-    );
-
-    const originalRename = fsNode.promises.rename.bind(fsNode.promises);
-    sinon
-      .stub(fsNode.promises, 'rename')
-      .callsFake(async (from: fsNode.PathLike, to: fsNode.PathLike) => {
-        if (
-          path.resolve(String(from)) === path.resolve(nextDir) &&
-          path.resolve(String(to)) === path.resolve(pendingDir)
-        ) {
-          throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+  // `load()` never moves a WAL. Recovering from `.prev` / `.next` only marks that
+  // directory, so `begin()` stages the new pair in the other one and cannot wipe
+  // the only copy. Covers both staging dirs, with and without a pending dir that
+  // `load()` already rejected.
+  for (const [label, walDirOf] of [
+    ['.prev', incrementalPendingPrevDir],
+    ['.next', incrementalPendingNextDir],
+  ] as const) {
+    for (const withUnusablePending of [false, true]) {
+      it(`should keep a WAL recovered from ${label} until begin commits${
+        withUnusablePending ? ', dropping the unusable pending dir' : ''
+      }`, async () => {
+        const walDir = walDirOf(incrementalFile);
+        await seedWal(walDir, 'from-wal');
+        if (withUnusablePending) {
+          await seedUnusablePending();
         }
-        return originalRename(from, to);
+
+        expect(
+          (await sut.load())!.files['foo.js'].mutants.map(({ id }) => id),
+        ).deep.eq(['plan-1', 'from-wal']);
+
+        // load() is read-only, so a crash before begin() leaves the WAL findable.
+        expect(await fileExists(walDir)).true;
+        expect(
+          (await createSut().load())!.files['foo.js'].mutants.map(
+            ({ id }) => id,
+          ),
+        ).deep.eq(['plan-1', 'from-wal']);
+
+        // A begin() that dies while staging must not have wiped the WAL first.
+        stubPendingBaseWriteError();
+        await sut.begin(nextRunBase());
+        expect(sut.isStarted).false;
+        sinon.restore();
+        expect(
+          (await createSut().load())!.files['foo.js'].mutants.map(
+            ({ id }) => id,
+          ),
+        ).deep.eq(['plan-1', 'from-wal']);
+
+        await sut.begin(nextRunBase());
+
+        expect(sut.isStarted).true;
+        expect(
+          (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
+        ).deep.eq(['plan-from-b']);
+        expect(await readPendingJsonl()).eq('');
+        expect(await fileExists(incrementalPendingPrevDir(incrementalFile)))
+          .false;
+        expect(await fileExists(incrementalPendingNextDir(incrementalFile)))
+          .false;
       });
-
-    const recovered = await sut.load();
-    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
-      'plan-1',
-      'from-next',
-    ]);
-    expect(await fileExists(nextDir)).true;
-    expect(testInjector.logger.warn).calledWithMatch('Failed to promote');
-
-    // Crash before begin: another process must still find the unrecovered WAL.
-    expect(
-      (await createSut().load())!.files['foo.js'].mutants.map(({ id }) => id),
-    ).deep.eq(['plan-1', 'from-next']);
-
-    await sut.begin(
-      createBase({
-        files: {
-          'foo.js': factory.mutationTestReportSchemaFileResult({
-            mutants: [
-              factory.mutationTestReportSchemaMutantResult({
-                id: 'plan-from-b',
-              }),
-            ],
-          }),
-        },
-      }),
-    );
-    expect(sut.isStarted).true;
-    expect(
-      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
-    ).deep.eq(['plan-from-b']);
-    expect(await fileExists(nextDir)).false;
-    expect(await fileExists(incrementalPendingPrevDir(incrementalFile))).false;
-  });
-
-  it('should keep unrecovered .prev WAL until begin commits when promote fails', async () => {
-    const prevDir = incrementalPendingPrevDir(incrementalFile);
-    await fs.mkdir(prevDir, { recursive: true });
-    await fs.writeFile(
-      path.join(prevDir, INCREMENTAL_PENDING_BASE),
-      JSON.stringify(createBase()),
-      'utf-8',
-    );
-    await fs.writeFile(
-      path.join(prevDir, INCREMENTAL_PENDING_RESULTS),
-      `${JSON.stringify(journalMutant({ id: 'from-prev' }))}\n`,
-      'utf-8',
-    );
-
-    const originalRename = fsNode.promises.rename.bind(fsNode.promises);
-    sinon
-      .stub(fsNode.promises, 'rename')
-      .callsFake(async (from: fsNode.PathLike, to: fsNode.PathLike) => {
-        if (
-          path.resolve(String(from)) === path.resolve(prevDir) &&
-          path.resolve(String(to)) === path.resolve(pendingDir)
-        ) {
-          throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
-        }
-        return originalRename(from, to);
-      });
-
-    const recovered = await sut.load();
-    expect(recovered!.files['foo.js'].mutants.map(({ id }) => id)).deep.eq([
-      'plan-1',
-      'from-prev',
-    ]);
-    expect(await fileExists(prevDir)).true;
-
-    await sut.begin(
-      createBase({
-        files: {
-          'foo.js': factory.mutationTestReportSchemaFileResult({
-            mutants: [
-              factory.mutationTestReportSchemaMutantResult({
-                id: 'plan-from-b',
-              }),
-            ],
-          }),
-        },
-      }),
-    );
-    expect(sut.isStarted).true;
-    expect(
-      (await readPendingBase()).files['foo.js'].mutants.map(({ id }) => id),
-    ).deep.eq(['plan-from-b']);
-    expect(await fileExists(prevDir)).false;
-    expect(await fileExists(incrementalPendingNextDir(incrementalFile))).false;
-  });
+    }
+  }
 
   it('should replace pending with a new base and empty journal so old JSONL is not mixed in', async () => {
     const firstBase = createBase();

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -12,15 +12,19 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { ProjectReader } from '../../../src/fs/project-reader.js';
+import { IncrementalJournal } from '../../../src/fs/incremental-journal.js';
 import { coreTokens } from '../../../src/di/index.js';
 import { FileSystem } from '../../../src/fs/file-system.js';
 import { createDirent, createFileSystemMock } from '../../helpers/producers.js';
 
 describe(ProjectReader.name, () => {
   let fsMock: sinon.SinonStubbedInstance<I<FileSystem>>;
+  let incrementalJournalMock: sinon.SinonStubbedInstance<IncrementalJournal>;
 
   beforeEach(() => {
     fsMock = createFileSystemMock();
+    incrementalJournalMock = sinon.createStubInstance(IncrementalJournal);
+    incrementalJournalMock.load.resolves(undefined);
   });
 
   describe('file resolving', () => {
@@ -29,7 +33,7 @@ describe(ProjectReader.name, () => {
       const sut = createSut();
       await sut.read(undefined);
       expect(testInjector.logger.warn).calledWith(
-        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".next",".nuxt",".svelte-kit",".stryker-tmp","reports/stryker-incremental.json","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
+        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".next",".nuxt",".svelte-kit",".stryker-tmp","reports/stryker-incremental.json","reports/stryker-incremental.pending","reports/stryker-incremental.pending.next","reports/stryker-incremental.pending.prev","reports/stryker-incremental.json.tmp","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
       );
     });
     it('should discover files recursively using readdir', async () => {
@@ -114,6 +118,13 @@ describe(ProjectReader.name, () => {
         },
         reports: {
           'stryker-incremental.json': '',
+          'stryker-incremental.json.tmp': '',
+          'stryker-incremental.pending': {
+            'base.json': '',
+            'results.jsonl': '',
+          },
+          'stryker-incremental.pending.next': { 'base.json': '' },
+          'stryker-incremental.pending.prev': { 'base.json': '' },
           mutation: { 'mutation.html': '', 'mutation.json': '' },
         },
       });
@@ -904,6 +915,55 @@ describe(ProjectReader.name, () => {
         'utf-8',
       );
     });
+    it('should prefer a valid pending journal over the committed incremental file', async () => {
+      testInjector.options.incremental = true;
+      incrementalJournalMock.load.resolves(
+        factory.mutationTestReportSchemaMutationTestResult({
+          files: {
+            'foo.js': factory.mutationTestReportSchemaFileResult({
+              mutants: [
+                factory.mutationTestReportSchemaMutantResult({
+                  id: 'from-pending',
+                  location: {
+                    start: { line: 1, column: 2 },
+                    end: { line: 3, column: 4 },
+                  },
+                }),
+              ],
+            }),
+          },
+        }),
+      );
+      stubFileSystem({
+        reports: {
+          'stryker-incremental.json': JSON.stringify(
+            factory.mutationTestReportSchemaMutationTestResult({
+              files: {
+                'foo.js': factory.mutationTestReportSchemaFileResult({
+                  mutants: [
+                    factory.mutationTestReportSchemaMutantResult({
+                      id: 'from-committed',
+                    }),
+                  ],
+                }),
+              },
+            }),
+          ),
+        },
+      });
+      const sut = createSut();
+      const actualProject = await sut.read(undefined);
+      expect(
+        actualProject.incrementalReport?.files['foo.js'].mutants[0].id,
+      ).eq('from-pending');
+      expect(
+        actualProject.incrementalReport?.files['foo.js'].mutants[0].location,
+      ).deep.eq({
+        start: { line: 0, column: 1 },
+        end: { line: 2, column: 3 },
+      });
+      sinon.assert.notCalled(fsMock.readFile);
+    });
   });
 
   function mutateRange(
@@ -921,6 +981,7 @@ describe(ProjectReader.name, () => {
   function createSut() {
     return testInjector.injector
       .provideValue(coreTokens.fs, fsMock)
+      .provideValue(coreTokens.incrementalJournal, incrementalJournalMock)
       .injectClass(ProjectReader);
   }
 

--- a/packages/core/test/unit/fs/project-reader.spec.ts
+++ b/packages/core/test/unit/fs/project-reader.spec.ts
@@ -33,7 +33,7 @@ describe(ProjectReader.name, () => {
       const sut = createSut();
       await sut.read(undefined);
       expect(testInjector.logger.warn).calledWith(
-        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".next",".nuxt",".svelte-kit",".stryker-tmp","reports/stryker-incremental.json","reports/stryker-incremental.pending","reports/stryker-incremental.pending.next","reports/stryker-incremental.pending.prev","reports/stryker-incremental.json.tmp","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
+        `No files found in directory ${process.cwd()} using ignore rules: ["node_modules",".git","*.tsbuildinfo","/stryker.log",".next",".nuxt",".svelte-kit",".stryker-tmp","reports/stryker-incremental.json","reports/stryker-incremental.json.pending","reports/stryker-incremental.json.pending.next","reports/stryker-incremental.json.pending.prev","reports/stryker-incremental.json.tmp","reports/mutation/mutation.html","reports/mutation/mutation.json"]. Make sure you run Stryker from the root directory of your project with the correct "ignorePatterns".`,
       );
     });
     it('should discover files recursively using readdir', async () => {
@@ -119,12 +119,12 @@ describe(ProjectReader.name, () => {
         reports: {
           'stryker-incremental.json': '',
           'stryker-incremental.json.tmp': '',
-          'stryker-incremental.pending': {
+          'stryker-incremental.json.pending': {
             'base.json': '',
             'results.jsonl': '',
           },
-          'stryker-incremental.pending.next': { 'base.json': '' },
-          'stryker-incremental.pending.prev': { 'base.json': '' },
+          'stryker-incremental.json.pending.next': { 'base.json': '' },
+          'stryker-incremental.json.pending.prev': { 'base.json': '' },
           mutation: { 'mutation.html': '', 'mutation.json': '' },
         },
       });
@@ -171,6 +171,37 @@ describe(ProjectReader.name, () => {
       expect(keys.next().value).eq(
         path.resolve('reports', 'mutation', 'mutation.json'),
       );
+    });
+    it('should ignore configuration properties that use backslash separators', async () => {
+      // Arrange
+      stubFileSystem({
+        'index.js': '',
+        reports: {
+          'stryker-incremental.json': '',
+          'stryker-incremental.json.tmp': '',
+          'stryker-incremental.json.pending': {
+            'base.json': '',
+            'results.jsonl': '',
+          },
+          'stryker-incremental.json.pending.next': { 'base.json': '' },
+          'stryker-incremental.json.pending.prev': { 'base.json': '' },
+          mutation: { 'mutation.html': '', 'mutation.json': '' },
+        },
+      });
+      testInjector.options.incrementalFile =
+        'reports\\stryker-incremental.json';
+      testInjector.options.htmlReporter.fileName =
+        'reports\\mutation\\mutation.html';
+      testInjector.options.jsonReporter.fileName =
+        'reports\\mutation\\mutation.json';
+      const sut = createSut();
+
+      // Act
+      const { files } = await sut.read(undefined);
+
+      // Assert
+      expect(files).lengthOf(1);
+      expect(files.keys().next().value).eq(path.resolve('index.js'));
     });
     it('should not ignore deep report directories by default', async () => {
       // Arrange
@@ -953,9 +984,9 @@ describe(ProjectReader.name, () => {
       });
       const sut = createSut();
       const actualProject = await sut.read(undefined);
-      expect(
-        actualProject.incrementalReport?.files['foo.js'].mutants[0].id,
-      ).eq('from-pending');
+      expect(actualProject.incrementalReport?.files['foo.js'].mutants[0].id).eq(
+        'from-pending',
+      );
       expect(
         actualProject.incrementalReport?.files['foo.js'].mutants[0].location,
       ).deep.eq({

--- a/packages/core/test/unit/initializer/gitignore-writer.spec.ts
+++ b/packages/core/test/unit/initializer/gitignore-writer.spec.ts
@@ -10,6 +10,7 @@ import { GitignoreWriter } from '../../../src/initializer/gitignore-writer.js';
 import { initializerTokens } from '../../../src/initializer/index.js';
 
 const GITIGNORE_FILE = '.gitignore';
+const STRYKER_GITIGNORE = `${os.EOL}# stryker${os.EOL}.stryker-tmp${os.EOL}reports/stryker-incremental.*${os.EOL}`;
 
 describe(GitignoreWriter.name, () => {
   let sut: GitignoreWriter;
@@ -51,7 +52,7 @@ describe(GitignoreWriter.name, () => {
         // Assert
         expect(fsAppendFile).calledWithExactly(
           GITIGNORE_FILE,
-          `${os.EOL}# stryker temp files${os.EOL}.stryker-tmp${os.EOL}`,
+          STRYKER_GITIGNORE,
         );
       });
 
@@ -70,13 +71,29 @@ describe(GitignoreWriter.name, () => {
 
       it("should not append the stryker gitignore configuration if it's already present", async () => {
         // Arrange
-        fsReadFile.returns(`node_modules${os.EOL}.stryker-tmp${os.EOL}temp`);
+        fsReadFile.returns(
+          `node_modules${os.EOL}.stryker-tmp${os.EOL}reports/stryker-incremental.*${os.EOL}temp`,
+        );
 
         // Act
         await sut.addStrykerTempFolder();
 
         // Assert
         expect(fsAppendFile).not.called;
+      });
+
+      it('should append only the incremental glob when the temp dir is already ignored', async () => {
+        // Arrange
+        fsReadFile.returns(`node_modules${os.EOL}.stryker-tmp${os.EOL}`);
+
+        // Act
+        await sut.addStrykerTempFolder();
+
+        // Assert
+        expect(fsAppendFile).calledWithExactly(
+          GITIGNORE_FILE,
+          `${os.EOL}reports/stryker-incremental.*${os.EOL}`,
+        );
       });
     });
 
@@ -91,7 +108,7 @@ describe(GitignoreWriter.name, () => {
 
         // Assert
         expect(out).calledWithExactly(
-          'No .gitignore file could be found. Please add the following to your .gitignore file: *.stryker-tmp',
+          'No .gitignore file could be found. Please add the following to your .gitignore file: .stryker-tmp, reports/stryker-incremental.*',
         );
       });
     });

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -157,6 +157,7 @@ describe(MutationTestExecutor.name, () => {
     mutationTestReportHelperMock.reportCheckFailed.returnsArg(0);
     mutationTestReportHelperMock.reportMutantRunResult.returnsArg(0);
     mutationTestReportHelperMock.reportAll.returnsArg(0);
+    mutationTestReportHelperMock.beginIncrementalJournal.resolves();
   }
 
   function arrangeScenario(overrides?: {
@@ -243,6 +244,40 @@ describe(MutationTestExecutor.name, () => {
         'NoCoverage',
       );
     });
+
+    it('should check uncovered mutants', async () => {
+      testInjector.options.checkers.push('foo');
+      const uncovered = mutantRunPlan({ id: '1', testFilter: [] });
+      arrangeScenario({ mutantRunPlan: uncovered });
+      checker.group.resolves([[uncovered]]);
+      mutantTestPlans.push(uncovered);
+
+      await sut.execute();
+
+      expect(checker.check).called;
+      expect(testRunner.mutantRun).not.called;
+    });
+
+    it('should begin the incremental journal after plan-time results and before workers', async () => {
+      arrangeScenario();
+      mutantTestPlans.push(
+        ignoredEarlyResultPlan({ id: '1', statusReason: 'ignored' }),
+      );
+      mutantTestPlans.push(mutantRunPlan({ id: '2' }));
+      const runPlan = mutantTestPlans[1] as MutantRunPlan;
+      checker.group.resolves([[runPlan]]);
+
+      await sut.execute();
+
+      sinon.assert.callOrder(
+        mutationTestReportHelperMock.reportMutantStatus,
+        mutationTestReportHelperMock.beginIncrementalJournal,
+        testRunner.mutantRun,
+      );
+      expect(
+        mutationTestReportHelperMock.beginIncrementalJournal,
+      ).calledOnce;
+    });
   });
 
   describe('execute check', () => {
@@ -305,6 +340,7 @@ describe(MutationTestExecutor.name, () => {
       const onGoingAct = sut.execute();
 
       // Assert
+      await fakeTick();
       await fakeTick();
 
       // Assert that checker is called for the first 2 groups

--- a/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
+++ b/packages/core/test/unit/process/4-mutation-test-executor.spec.ts
@@ -274,9 +274,7 @@ describe(MutationTestExecutor.name, () => {
         mutationTestReportHelperMock.beginIncrementalJournal,
         testRunner.mutantRun,
       );
-      expect(
-        mutationTestReportHelperMock.beginIncrementalJournal,
-      ).calledOnce;
+      expect(mutationTestReportHelperMock.beginIncrementalJournal).calledOnce;
     });
   });
 

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -13,7 +13,7 @@ import { coreTokens } from '../../../src/di/index.js';
 import { MutationTestReportHelper } from '../../../src/reporters/mutation-test-report-helper.js';
 import { objectUtils } from '../../../src/utils/object-utils.js';
 import { strykerVersion } from '../../../src/stryker-package.js';
-import { Project } from '../../../src/fs/index.js';
+import { IncrementalJournal, Project } from '../../../src/fs/index.js';
 import { FileSystemTestDouble } from '../../helpers/file-system-test-double.js';
 import { TestCoverageTestDouble } from '../../helpers/test-coverage-test-double.js';
 import { UnexpectedExitHandlerTestDouble } from '../../helpers/unexpected-exit-handler-test-double.js';
@@ -25,6 +25,7 @@ describe(MutationTestReportHelper.name, () => {
   let requireFromCwdStub: sinon.SinonStubbedMember<typeof requireResolve>;
   let fileSystemTestDouble: FileSystemTestDouble;
   let unexpectedExitRegistry: UnexpectedExitHandlerTestDouble;
+  let incrementalJournalMock: sinon.SinonStubbedInstance<IncrementalJournal>;
 
   beforeEach(() => {
     requireFromCwdStub = sinon.stub();
@@ -33,6 +34,7 @@ describe(MutationTestReportHelper.name, () => {
     fileSystemTestDouble = new FileSystemTestDouble();
     testCoverage = new TestCoverageTestDouble();
     unexpectedExitRegistry = new UnexpectedExitHandlerTestDouble();
+    incrementalJournalMock = sinon.createStubInstance(IncrementalJournal);
   });
 
   function createSut() {
@@ -45,8 +47,8 @@ describe(MutationTestReportHelper.name, () => {
       .provideValue(coreTokens.project, project)
       .provideValue(coreTokens.testCoverage, testCoverage)
       .provideValue(coreTokens.requireFromCwd, requireFromCwdStub)
-      .provideValue(coreTokens.fs, fileSystemTestDouble)
       .provideValue(coreTokens.unexpectedExitRegistry, unexpectedExitRegistry)
+      .provideValue(coreTokens.incrementalJournal, incrementalJournalMock)
       .injectClass(MutationTestReportHelper);
   }
 
@@ -499,40 +501,23 @@ describe(MutationTestReportHelper.name, () => {
     });
 
     describe('incremental', () => {
-      it('should write the report to the incremental file', async () => {
+      it('should complete the incremental journal with the report', async () => {
         testInjector.options.incremental = true;
         const [actualReport] = await actReportAll();
-        const actualFileContent: string = await fileSystemTestDouble.readFile(
-          'reports/stryker-incremental.json',
+        expect(incrementalJournalMock.complete).calledOnceWithExactly(
+          actualReport,
         );
-        expect(actualFileContent).eq(JSON.stringify(actualReport, null, 2));
       });
-      it('should support the incrementalFile option', async () => {
-        testInjector.options.incremental = true;
-        testInjector.options.incrementalFile = 'some/other/incremental.json';
-        const [actualReport] = await actReportAll();
-        const actualFileContent: string = await fileSystemTestDouble.readFile(
-          'some/other/incremental.json',
-        );
-        expect(actualFileContent).eq(JSON.stringify(actualReport, null, 2));
-      });
-      it('should create the dir for the incremental file', async () => {
-        testInjector.options.incremental = true;
-        const [actualReport] = await actReportAll();
-        const actualFileContent: string = await fileSystemTestDouble.readFile(
-          'reports/stryker-incremental.json',
-        );
-        expect(actualFileContent).eq(JSON.stringify(actualReport, null, 2));
-      });
-      it('should make the directory before writing the results file', async () => {
-        testInjector.options.incremental = true;
+      it('should not complete the incremental journal when incremental is false', async () => {
+        testInjector.options.incremental = false;
         await actReportAll();
-        expect(fileSystemTestDouble.dirs).contains('reports');
+        expect(incrementalJournalMock.complete).not.called;
       });
 
-      it('should write partial results to the incremental file on unexpected exit', async () => {
+      it('should write partial results to the incremental journal on unexpected exit after begin', async () => {
         testInjector.options.incremental = true;
         fileSystemTestDouble.files['partial.js'] = 'const answer = 42;\n';
+        incrementalJournalMock.isStarted = true;
         const sut = createSut();
 
         sut.reportMutantStatus(
@@ -546,13 +531,8 @@ describe(MutationTestReportHelper.name, () => {
 
         await unexpectedExitRegistry.triggerUnexpectedExit();
 
-        const incrementalReportContent: string =
-          await fileSystemTestDouble.readFile(
-            'reports/stryker-incremental.json',
-          );
-        const actualReport = JSON.parse(
-          incrementalReportContent,
-        ) as schema.MutationTestResult;
+        expect(incrementalJournalMock.complete).calledOnce;
+        const [actualReport] = incrementalJournalMock.complete.firstCall.args;
         expect(actualReport.files['partial.js'].mutants).lengthOf(1);
         expect(actualReport.files['partial.js'].mutants[0].status).eq(
           'NoCoverage',
@@ -563,19 +543,37 @@ describe(MutationTestReportHelper.name, () => {
         );
       });
 
+      it('should not compact on unexpected exit before the journal has begun', async () => {
+        testInjector.options.incremental = true;
+        fileSystemTestDouble.files['partial.js'] = 'const answer = 42;\n';
+        incrementalJournalMock.isStarted = false;
+        const sut = createSut();
+
+        sut.reportMutantStatus(
+          factory.mutantTestCoverage({
+            fileName: 'partial.js',
+            id: '1',
+            location: factory.location(),
+          }),
+          'NoCoverage',
+        );
+
+        await unexpectedExitRegistry.triggerUnexpectedExit();
+
+        expect(incrementalJournalMock.complete).not.called;
+        expect(testInjector.logger.info).not.calledWith(
+          'Saved a partial incremental report to "%s" after an unexpected interrupt.',
+          'reports/stryker-incremental.json',
+        );
+      });
+
       it('should not overwrite the incremental file on unexpected exit when no results were reported', async () => {
         testInjector.options.incremental = true;
-        fileSystemTestDouble.files['reports/stryker-incremental.json'] =
-          'existing-report';
         createSut();
 
         await unexpectedExitRegistry.triggerUnexpectedExit();
 
-        expect(
-          await fileSystemTestDouble.readFile(
-            'reports/stryker-incremental.json',
-          ),
-        ).eq('existing-report');
+        expect(incrementalJournalMock.complete).not.called;
         expect(reporterMock.onMutationTestReportReady).not.called;
         expect(testInjector.logger.info).not.calledWith(
           'Saved a partial incremental report to "%s" after an unexpected interrupt.',
@@ -601,16 +599,86 @@ describe(MutationTestReportHelper.name, () => {
         ];
 
         await sut.reportAll(completeResults);
-        fileSystemTestDouble.files['reports/stryker-incremental.json'] =
-          'full-report';
+        incrementalJournalMock.complete.resetHistory();
 
         await unexpectedExitRegistry.triggerUnexpectedExit();
 
-        expect(
-          await fileSystemTestDouble.readFile(
-            'reports/stryker-incremental.json',
-          ),
-        ).eq('full-report');
+        expect(incrementalJournalMock.complete).not.called;
+      });
+
+      it('should forward every result to the journal (the journal no-ops until begin)', async () => {
+        testInjector.options.incremental = true;
+        fileSystemTestDouble.files['foo.js'] = 'const answer = 42;\n';
+        const sut = createSut();
+        sut.reportMutantStatus(
+          factory.mutantTestCoverage({
+            fileName: 'foo.js',
+            id: '1',
+          }),
+          'Ignored',
+        );
+        expect(incrementalJournalMock.append).calledOnce;
+        expect(incrementalJournalMock.begin).not.called;
+      });
+
+      it('should not append to the journal when incremental is false', () => {
+        testInjector.options.incremental = false;
+        fileSystemTestDouble.files['foo.js'] = 'const answer = 42;\n';
+        const sut = createSut();
+        sut.reportMutantStatus(
+          factory.mutantTestCoverage({
+            fileName: 'foo.js',
+            id: '1',
+          }),
+          'Ignored',
+        );
+        expect(incrementalJournalMock.append).not.called;
+      });
+
+      it('should begin the journal with plan-time results in base only', async () => {
+        testInjector.options.incremental = true;
+        fileSystemTestDouble.files['foo.js'] = 'const answer = 42;\n';
+        fileSystemTestDouble.files['bar.js'] = 'const other = 1;\n';
+        const sut = createSut();
+        sut.reportMutantStatus(
+          factory.mutantTestCoverage({
+            fileName: 'foo.js',
+            id: '1',
+            status: 'Ignored',
+          }),
+          'Ignored',
+        );
+
+        await sut.beginIncrementalJournal();
+
+        expect(incrementalJournalMock.begin).calledOnce;
+        const [base] = incrementalJournalMock.begin.firstCall.args;
+        expect(base.files['foo.js'].mutants).lengthOf(1);
+        expect(base.files['foo.js'].mutants[0].status).eq('Ignored');
+        expect(base.files['bar.js'].mutants).lengthOf(0);
+        expect(base.files['bar.js'].source).eq('const other = 1;\n');
+      });
+
+      it('should append checker and test-runner results to the journal after begin', async () => {
+        testInjector.options.incremental = true;
+        fileSystemTestDouble.files['foo.js'] = 'const answer = 42;\n';
+        const sut = createSut();
+        await sut.beginIncrementalJournal();
+        incrementalJournalMock.append.resetHistory();
+
+        sut.reportMutantRunResult(
+          factory.mutantTestCoverage({
+            fileName: 'foo.js',
+            id: '2',
+          }),
+          factory.killedMutantRunResult(),
+        );
+
+        expect(incrementalJournalMock.append).calledOnce;
+        const [appended] = incrementalJournalMock.append.firstCall.args;
+        expect(appended.id).eq('2');
+        expect(appended.status).eq('Killed');
+        expect(appended.fileName).eq('foo.js');
       });
     });
 

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -35,6 +35,16 @@ describe(MutationTestReportHelper.name, () => {
     testCoverage = new TestCoverageTestDouble();
     unexpectedExitRegistry = new UnexpectedExitHandlerTestDouble();
     incrementalJournalMock = sinon.createStubInstance(IncrementalJournal);
+    // Mirror the real journal: `begin` / `close` / `complete` flip `isStarted`.
+    incrementalJournalMock.begin.callsFake(async () => {
+      incrementalJournalMock.isStarted = true;
+    });
+    incrementalJournalMock.close.callsFake(() => {
+      incrementalJournalMock.isStarted = false;
+    });
+    incrementalJournalMock.complete.callsFake(async () => {
+      incrementalJournalMock.isStarted = false;
+    });
   });
 
   function createSut() {
@@ -531,7 +541,11 @@ describe(MutationTestReportHelper.name, () => {
 
         await unexpectedExitRegistry.triggerUnexpectedExit();
 
+        expect(incrementalJournalMock.close).calledOnce;
         expect(incrementalJournalMock.complete).calledOnce;
+        expect(incrementalJournalMock.close).calledBefore(
+          incrementalJournalMock.complete,
+        );
         const [actualReport] = incrementalJournalMock.complete.firstCall.args;
         expect(actualReport.files['partial.js'].mutants).lengthOf(1);
         expect(actualReport.files['partial.js'].mutants[0].status).eq(
@@ -606,10 +620,11 @@ describe(MutationTestReportHelper.name, () => {
         expect(incrementalJournalMock.complete).not.called;
       });
 
-      it('should forward every result to the journal (the journal no-ops until begin)', async () => {
+      it('should not append plan-time results, they belong in base.json', () => {
         testInjector.options.incremental = true;
         fileSystemTestDouble.files['foo.js'] = 'const answer = 42;\n';
         const sut = createSut();
+        // `isStarted` is false: `begin()` has not committed a pending pair yet.
         sut.reportMutantStatus(
           factory.mutantTestCoverage({
             fileName: 'foo.js',
@@ -617,7 +632,7 @@ describe(MutationTestReportHelper.name, () => {
           }),
           'Ignored',
         );
-        expect(incrementalJournalMock.append).calledOnce;
+        expect(incrementalJournalMock.append).not.called;
         expect(incrementalJournalMock.begin).not.called;
       });
 

--- a/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
+++ b/packages/core/test/unit/reporters/mutation-test-report-helper.spec.ts
@@ -36,14 +36,16 @@ describe(MutationTestReportHelper.name, () => {
     unexpectedExitRegistry = new UnexpectedExitHandlerTestDouble();
     incrementalJournalMock = sinon.createStubInstance(IncrementalJournal);
     // Mirror the real journal: `begin` / `close` / `complete` flip `isStarted`.
-    incrementalJournalMock.begin.callsFake(async () => {
+    incrementalJournalMock.begin.callsFake(() => {
       incrementalJournalMock.isStarted = true;
+      return Promise.resolve();
     });
     incrementalJournalMock.close.callsFake(() => {
       incrementalJournalMock.isStarted = false;
     });
-    incrementalJournalMock.complete.callsFake(async () => {
+    incrementalJournalMock.complete.callsFake(() => {
       incrementalJournalMock.isStarted = false;
+      return Promise.resolve();
     });
   });
 
@@ -694,6 +696,40 @@ describe(MutationTestReportHelper.name, () => {
         expect(appended.id).eq('2');
         expect(appended.status).eq('Killed');
         expect(appended.fileName).eq('foo.js');
+      });
+
+      it('should warn only once about a missing source file, even though the report is created twice', async () => {
+        testInjector.options.incremental = true;
+        const sut = createSut();
+        const mutantResult = factory.killedMutantResult({
+          fileName: 'not-found.js',
+        });
+        sut.reportMutantStatus(
+          factory.mutantTestCoverage({ fileName: 'not-found.js', id: '1' }),
+          'Ignored',
+        );
+
+        await sut.beginIncrementalJournal();
+        await sut.reportAll([mutantResult]);
+
+        expect(testInjector.logger.warn).calledOnce;
+        expect(testInjector.logger.warn).calledWithMatch(
+          'File "not-found.js" not found',
+        );
+      });
+
+      it('should warn only once about a missing test file, even though the report is created twice', async () => {
+        testInjector.options.incremental = true;
+        testCoverage.addTest(factory.testResult({ fileName: 'foo.spec.js' }));
+        const sut = createSut();
+
+        await sut.beginIncrementalJournal();
+        await sut.reportAll([]);
+
+        expect(testInjector.logger.warn).calledOnce;
+        expect(testInjector.logger.warn).calledWithMatch(
+          'Test file "foo.spec.js" not found in input files',
+        );
       });
     });
 

--- a/packages/core/test/unit/sandbox/sandbox.spec.ts
+++ b/packages/core/test/unit/sandbox/sandbox.spec.ts
@@ -25,6 +25,7 @@ describe(Sandbox.name, () => {
     I<UnexpectedExitHandler>
   >;
   let moveDirectoryRecursiveStub: sinon.SinonStub;
+  let moveDirectoryRecursiveSyncStub: sinon.SinonStub;
   let fsTestDouble: FileSystemTestDouble;
   const SANDBOX_WORKING_DIR = path.join('.stryker-tmp', 'sandbox-123');
 
@@ -36,9 +37,14 @@ describe(Sandbox.name, () => {
     moveDirectoryRecursiveStub = sinon
       .stub(fileUtils, 'moveDirectoryRecursive')
       .resolves();
+    moveDirectoryRecursiveSyncStub = sinon.stub(
+      fileUtils,
+      'moveDirectoryRecursiveSync',
+    );
     execaCommandMock = sinon.stub();
     unexpectedExitHandlerMock = {
       registerHandler: sinon.stub(),
+      registerSyncHandler: sinon.stub(),
       dispose: sinon.stub(),
     };
     fsTestDouble = new FileSystemTestDouble(
@@ -202,13 +208,14 @@ describe(Sandbox.name, () => {
         );
       });
 
-      it('should register an unexpected exit handler', async () => {
+      it('should register a sync unexpected exit handler', async () => {
         // Act
         const sut = createSut();
         await sut.init();
 
         // Assert
-        expect(unexpectedExitHandlerMock.registerHandler).called;
+        expect(unexpectedExitHandlerMock.registerSyncHandler).called;
+        expect(unexpectedExitHandlerMock.registerHandler).not.called;
       });
     });
 
@@ -327,18 +334,48 @@ describe(Sandbox.name, () => {
       );
     });
 
-    it('should recover from the backup dir if stryker exits unexpectedly while inPlace = true', async () => {
+    it('should register a sync unexpected-exit restore when inPlace = true', () => {
+      testInjector.options.inPlace = true;
+      createSut();
+      expect(unexpectedExitHandlerMock.registerSyncHandler).calledOnce;
+      expect(unexpectedExitHandlerMock.registerHandler).not.called;
+    });
+
+    it('should recover synchronously from the backup dir if stryker exits unexpectedly while inPlace = true', () => {
       testInjector.options.inPlace = true;
       const errorStub = sinon.stub(console, 'error');
       createSut();
-      await unexpectedExitHandlerMock.registerHandler.firstCall.args[0]();
-      expect(moveDirectoryRecursiveStub).calledWith(
+      unexpectedExitHandlerMock.registerSyncHandler.firstCall.args[0]();
+      expect(moveDirectoryRecursiveSyncStub).calledWith(
         SANDBOX_WORKING_DIR,
         process.cwd(),
       );
+      expect(moveDirectoryRecursiveStub).not.called;
       expect(errorStub).calledWith(
         `Detecting unexpected exit, recovering original files from ${SANDBOX_WORKING_DIR}`,
       );
+    });
+
+    it('should not restore the backup twice after an unexpected sync restore', async () => {
+      testInjector.options.inPlace = true;
+      sinon.stub(console, 'error');
+      const sut = createSut();
+      unexpectedExitHandlerMock.registerSyncHandler.firstCall.args[0]();
+      await sut.dispose();
+      expect(moveDirectoryRecursiveSyncStub).calledOnce;
+      expect(moveDirectoryRecursiveStub).not.called;
+    });
+
+    it('should allow dispose to restore after a failed unexpected sync restore', async () => {
+      testInjector.options.inPlace = true;
+      sinon.stub(console, 'error');
+      moveDirectoryRecursiveSyncStub.throws(new Error('disk full'));
+      const sut = createSut();
+      expect(() =>
+        unexpectedExitHandlerMock.registerSyncHandler.firstCall.args[0](),
+      ).throws('disk full');
+      await sut.dispose();
+      expect(moveDirectoryRecursiveStub).calledOnce;
     });
   });
 

--- a/packages/core/test/unit/stryker-cli.spec.ts.snap
+++ b/packages/core/test/unit/stryker-cli.spec.ts.snap
@@ -22,7 +22,7 @@ Options:
   --ignoreStatic                               Ignore static mutants. Static mutants are mutants which are only executed during the loading of a file.
   --incremental                                Enable 'incremental mode'. Stryker will store results in a file and use that file to speed up the next --incremental run
   --allowEmpty                                 Allows stryker to exit without any errors in cases where no tests are found 
-  --incrementalFile <file>                     Specify the file to use for incremental mode.
+  --incrementalFile <file>                     Specify the file to use for incremental mode. A sibling .pending/ directory and .tmp file may appear next to it during a run; gitignore them like this file.
   --force                                      Run all mutants, even if --incremental is provided and an incremental file exists. Can be used to force a rebuild of the incremental file.
   -m, --mutate <filesToMutate>                 With \`mutate\` you configure the subset of files or just one specific file to be mutated. These should be your _production code files_, and definitely not your test files. (Whereas with \`ignorePatterns\` you prevent non-relevant files from being copied to the sandbox directory in the first place)
   The default will try to guess your production code files based on sane defaults. It reads like this:
@@ -83,7 +83,7 @@ Options:
   --ignoreStatic                               Ignore static mutants. Static mutants are mutants which are only executed during the loading of a file.
   --incremental                                Enable 'incremental mode'. Stryker will store results in a file and use that file to speed up the next --incremental run
   --allowEmpty                                 Allows stryker to exit without any errors in cases where no tests are found 
-  --incrementalFile <file>                     Specify the file to use for incremental mode.
+  --incrementalFile <file>                     Specify the file to use for incremental mode. A sibling .pending/ directory and .tmp file may appear next to it during a run; gitignore them like this file.
   --force                                      Run all mutants, even if --incremental is provided and an incremental file exists. Can be used to force a rebuild of the incremental file.
   -m, --mutate <filesToMutate>                 With \`mutate\` you configure the subset of files or just one specific file to be mutated. These should be your _production code files_, and definitely not your test files. (Whereas with \`ignorePatterns\` you prevent non-relevant files from being copied to the sandbox directory in the first place)
   The default will try to guess your production code files based on sane defaults. It reads like this:

--- a/packages/core/test/unit/unexpected-exit-handler.spec.ts
+++ b/packages/core/test/unit/unexpected-exit-handler.spec.ts
@@ -29,6 +29,11 @@ describe(UnexpectedExitHandler.name, () => {
   }
 
   describe('constructor', () => {
+    it('should register an "exit" handler', () => {
+      createSut();
+      expect(processMock.listenerCount('exit')).eq(1);
+    });
+
     signals.forEach((signal) => {
       it(`should register a "${signal}" signal handler`, () => {
         createSut();
@@ -38,6 +43,11 @@ describe(UnexpectedExitHandler.name, () => {
   });
 
   describe('dispose', () => {
+    it('should remove the "exit" handler', () => {
+      createSut().dispose();
+      expect(processMock.listenerCount('exit')).eq(0);
+    });
+
     signals.forEach((signal) => {
       it(`should remove the "${signal}" signal handler`, () => {
         createSut().dispose();
@@ -67,6 +77,63 @@ describe(UnexpectedExitHandler.name, () => {
       processMock.emit(signal, signal, 4);
       // 128 + 4 (signal number), per POSIX convention for signal-terminated processes
       expect(processMock.exit).calledWith(132);
+    });
+  });
+
+  describe(UnexpectedExitHandler.prototype.registerSyncHandler.name, () => {
+    it('should call sync handlers on the "exit" event', () => {
+      const handler = sinon.stub();
+      const sut = createSut();
+      sut.registerSyncHandler(handler);
+      processMock.emit('exit');
+      expect(handler).calledOnce;
+    });
+
+    it('should call sync handlers on signal before process.exit', () => {
+      const handler = sinon.stub();
+      const sut = createSut();
+      sut.registerSyncHandler(handler);
+      processMock.emit('SIGINT', 'SIGINT', 2);
+      expect(handler).calledOnce;
+      expect(processMock.exit).calledWith(130);
+    });
+
+    it('should not run sync handlers twice when a signal triggers process.exit', () => {
+      const handler = sinon.stub();
+      const sut = createSut();
+      sut.registerSyncHandler(handler);
+      processMock.emit('SIGINT', 'SIGINT', 2);
+      // Mimic Node: process.exit() emits 'exit'
+      processMock.emit('exit');
+      expect(handler).calledOnce;
+    });
+
+    it('should still call process.exit when a sync handler throws', () => {
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const sut = createSut();
+      sut.registerSyncHandler(() => {
+        throw new Error('restore failed');
+      });
+      processMock.emit('SIGINT', 'SIGINT', 2);
+      expect(processMock.exit).calledWith(130);
+      expect(consoleErrorStub).calledWith(
+        'Unexpected exit sync handler failed:',
+        sinon.match.instanceOf(Error),
+      );
+      consoleErrorStub.restore();
+    });
+
+    it('should run remaining sync handlers when one throws', () => {
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const second = sinon.stub();
+      const sut = createSut();
+      sut.registerSyncHandler(() => {
+        throw new Error('first failed');
+      });
+      sut.registerSyncHandler(second);
+      processMock.emit('exit');
+      expect(second).calledOnce;
+      consoleErrorStub.restore();
     });
   });
 
@@ -161,6 +228,35 @@ describe(UnexpectedExitHandler.name, () => {
       );
       consoleErrorStub.restore();
       await clock.runAllAsync();
+    });
+
+    it('should run sync handlers before async handlers on signal', async () => {
+      const order: string[] = [];
+      let releaseAsync!: () => void;
+      const asyncGate = new Promise<void>((resolve) => {
+        releaseAsync = resolve;
+      });
+      const sut = createSut();
+      sut.registerSyncHandler(() => {
+        order.push('sync');
+      });
+      sut.registerHandler(async () => {
+        await asyncGate;
+        order.push('async');
+      });
+      processMock.emit('SIGINT', 'SIGINT', 2);
+      expect(order).deep.eq(['sync']);
+      releaseAsync();
+      await clock.runAllAsync();
+      expect(order).deep.eq(['sync', 'async']);
+    });
+
+    it('should not call async handlers on the "exit" event', () => {
+      const asyncHandler = sinon.stub().resolves();
+      const sut = createSut();
+      sut.registerHandler(asyncHandler);
+      processMock.emit('exit');
+      expect(asyncHandler).not.called;
     });
   });
 });

--- a/packages/core/test/unit/unexpected-exit-handler.spec.ts
+++ b/packages/core/test/unit/unexpected-exit-handler.spec.ts
@@ -108,6 +108,19 @@ describe(UnexpectedExitHandler.name, () => {
       expect(handler).calledOnce;
     });
 
+    it('should retry sync handlers on exit when a signal-path handler threw', () => {
+      const consoleErrorStub = sinon.stub(console, 'error');
+      const handler = sinon.stub();
+      handler.onFirstCall().throws(new Error('restore failed'));
+      const sut = createSut();
+      sut.registerSyncHandler(handler);
+      processMock.emit('SIGINT', 'SIGINT', 2);
+      // Mimic Node: process.exit() emits 'exit' — retry because the first run failed.
+      processMock.emit('exit');
+      expect(handler).calledTwice;
+      consoleErrorStub.restore();
+    });
+
     it('should still call process.exit when a sync handler throws', () => {
       const consoleErrorStub = sinon.stub(console, 'error');
       const sut = createSut();


### PR DESCRIPTION
## Summary

- **Main:** Recover `--incremental` results after a crash. Persist completed mutants in a new pending journal next to `incrementalFile` so the next run can reuse them after SIGKILL, OOM, or an uncaught exception—not only after a handled signal (extends #5986). On `master`, interrupted runs only flush a partial report to `incrementalFile` on Ctrl+C-style interrupts; there was no pending journal.
- Wire the journal through project reading, mutation testing, and the report helper so recovered results participate in the normal incremental path.
- Document the pending directory, ignore it from the sandbox, and have `stryker init` gitignore `reports/stryker-incremental.*` (report + pending artifacts).
- Also restore `--inPlace` file backups on unexpected process exit (including `process.exit`) without dropping async signal handlers used for partial incremental reports.

Replaces #6211 (that PR was based on the 9.6.x-era `incremental-recovery` branch). The 9.6.x work remains available on the fork as `incremental-recovery` for anyone who wants it.

## Test plan

- [ ] Unit tests for `IncrementalJournal`, unexpected-exit handler, sandbox restore, and mutation-test report helper
- [ ] e2e `incremental-interrupt` (crash mid-run, then recover on next incremental run)
- [ ] e2e `incremental` still passes
- [ ] Manual: run with `--incremental`, kill the process mid-run, confirm pending journal exists and next run reuses results
- [ ] Manual: `--inPlace` run interrupted via `process.exit` restores original files