### PR TITLE
fix(vitest-runner): match Vitest 5 test name separator when filtering tests

### DIFF
--- a/packages/vitest-runner/src/stryker-setup.ts
+++ b/packages/vitest-runner/src/stryker-setup.ts
@@ -20,6 +20,8 @@ const mode = inject('mode');
 const ns = globalThis[globalNamespace] || (globalThis[globalNamespace] = {});
 ns.hitLimit = inject('hitLimit');
 const isGreaterThanVitest4Point1 = inject('isGreaterThanVitest4Point1');
+// Must match the separator the runner filters with; see test-helpers.ts
+const testNameSeparator = inject('testNameSeparator');
 
 if (mode === 'mutant') {
   beforeAll(() => {
@@ -50,7 +52,7 @@ if (mode === 'mutant') {
   ns.activeMutant = undefined;
 
   beforeEach(({ task }) => {
-    ns.currentTestId = toRawTestId(task);
+    ns.currentTestId = toRawTestId(task, testNameSeparator);
   });
 
   afterEach(() => {
@@ -72,24 +74,27 @@ if (mode === 'mutant') {
 }
 
 // Stryker disable all: this file is copied to the sandbox dir
-function collectTestName({
-  name,
-  suite,
-}: {
-  name: string;
-  suite?: RunnerTestSuite;
-}): string {
+function collectTestName(
+  {
+    name,
+    suite,
+  }: {
+    name: string;
+    suite?: RunnerTestSuite;
+  },
+  separator: string,
+): string {
   const nameParts = [name];
   let currentSuite = suite;
   while (currentSuite) {
     nameParts.unshift(currentSuite.name);
     currentSuite = currentSuite.suite;
   }
-  return nameParts.join(' ').trim();
+  return nameParts.join(separator).trim();
 }
 
-function toRawTestId(test: RunnerTestCase): string {
-  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test)}`;
+function toRawTestId(test: RunnerTestCase, separator: string): string {
+  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test, separator)}`;
 }
 // Stryker restore all
 
@@ -101,6 +106,7 @@ declare module 'vitest' {
     activeMutant: string | undefined;
     mode: 'mutant' | 'dry-run';
     isGreaterThanVitest4Point1: boolean;
+    testNameSeparator: string;
   }
   interface TaskMeta {
     hitCount: number | undefined;

--- a/packages/vitest-runner/src/test-helpers.ts
+++ b/packages/vitest-runner/src/test-helpers.ts
@@ -4,22 +4,37 @@ import type { RunnerTestCase, RunnerTestSuite } from 'vitest';
 // This file is used from the testing environment (via stryker-setup.js) and thus could be loaded into the browser (when using vitest with browser mode).
 // Thus we should avoid unnecessary dependencies in this file.
 
-export function collectTestName({
-  name,
-  suite,
-}: {
-  name: string;
-  suite?: RunnerTestSuite;
-}): string {
+/**
+ * The separator Vitest itself uses between the suite chain and the test name.
+ * Vitest 5 matches `testNamePattern` against the full chain joined with `' > '`;
+ * before that it was a plain space.
+ * @see https://vitest.dev/guide/migration/
+ */
+export const VITEST_5_TEST_NAME_SEPARATOR = ' > ';
+export const LEGACY_TEST_NAME_SEPARATOR = ' ';
+
+export function collectTestName(
+  {
+    name,
+    suite,
+  }: {
+    name: string;
+    suite?: RunnerTestSuite;
+  },
+  separator: string = LEGACY_TEST_NAME_SEPARATOR,
+): string {
   const nameParts = [name];
   let currentSuite = suite;
   while (currentSuite) {
     nameParts.unshift(currentSuite.name);
     currentSuite = currentSuite.suite;
   }
-  return nameParts.join(' ').trim();
+  return nameParts.join(separator).trim();
 }
 
-export function toRawTestId(test: RunnerTestCase): string {
-  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test)}`;
+export function toRawTestId(
+  test: RunnerTestCase,
+  separator: string = LEGACY_TEST_NAME_SEPARATOR,
+): string {
+  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test, separator)}`;
 }

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -30,11 +30,14 @@ function convertTaskStateToTestStatus(
   return TestStatus.Failed;
 }
 
-export function convertTestToTestResult(test: RunnerTestCase): TestResult {
+export function convertTestToTestResult(
+  test: RunnerTestCase,
+  separator?: string,
+): TestResult {
   const status = convertTaskStateToTestStatus(test.result?.state, test.mode);
   const baseTestResult: BaseTestResult = {
-    id: normalizeTestId(toRawTestId(test)),
-    name: collectTestName(test),
+    id: normalizeTestId(toRawTestId(test, separator)),
+    name: collectTestName(test, separator),
     timeSpentMs: test.result?.duration ?? 0,
     fileName: test.file?.filepath && path.resolve(test.file.filepath),
   };

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -37,6 +37,10 @@ import {
 
 import { vitestWrapper, Vitest } from './vitest-wrapper.js';
 import {
+  LEGACY_TEST_NAME_SEPARATOR,
+  VITEST_5_TEST_NAME_SEPARATOR,
+} from './test-helpers.js';
+import {
   convertTestToTestResult,
   fromTestId,
   collectTestsFromSuite,
@@ -85,6 +89,18 @@ export class VitestTestRunner implements TestRunner {
     private globalNamespace: StrykerNamespace,
   ) {
     this.options = options as VitestRunnerOptionsWithStrykerOptions;
+  }
+
+  /**
+   * Vitest 5 matches `testNamePattern` against the suite chain joined with
+   * `' > '` rather than a space, so a filter built from space-joined names
+   * matches nothing and every covered mutant runs zero tests.
+   * @see https://vitest.dev/guide/migration/
+   */
+  get #testNameSeparator(): string {
+    return semver.satisfies(vitestWrapper.version, '>=5.0.0')
+      ? VITEST_5_TEST_NAME_SEPARATOR
+      : LEGACY_TEST_NAME_SEPARATOR;
   }
 
   public capabilities(): TestRunnerCapabilities {
@@ -155,6 +171,7 @@ export class VitestTestRunner implements TestRunner {
       'isGreaterThanVitest4Point1',
       semver.satisfies(vitestWrapper.version, '>=4.1.0'),
     );
+    this.ctx.provide('testNameSeparator', this.#testNameSeparator);
     this.ctx.config.browser.screenshotFailures = false;
     this.ctx.projects.forEach((project) => {
       project.config.setupFiles = [
@@ -260,7 +277,10 @@ export class VitestTestRunner implements TestRunner {
 
     let failure = false;
     const testResults = tests.map((test) => {
-      const testResult = convertTestToTestResult(test);
+      const testResult = convertTestToTestResult(
+        test,
+        this.#testNameSeparator,
+      );
       failure ||= testResult.status === TestStatus.Failed;
       return testResult;
     });

--- a/packages/vitest-runner/test/unit/test-helpers.spec.ts
+++ b/packages/vitest-runner/test/unit/test-helpers.spec.ts
@@ -1,7 +1,10 @@
 import { normalizeFileName } from '@stryker-mutator/util';
 import { expect } from 'chai';
 import path from 'path';
-import { toRawTestId } from '../../src/test-helpers.js';
+import {
+  toRawTestId,
+  VITEST_5_TEST_NAME_SEPARATOR,
+} from '../../src/test-helpers.js';
 import { createVitestTest, createVitestFile } from '../util/factories.js';
 
 describe('test-helpers', () => {
@@ -21,6 +24,18 @@ describe('test-helpers', () => {
       (test as any).file = undefined;
       const result = toRawTestId(test);
       expect(result).to.be.equal('unknown.js#suite test1');
+    });
+
+    it('should join the suite chain with the given separator', () => {
+      // Vitest 5 matches testNamePattern against the chain joined with ' > ',
+      // so the id has to be built with the same separator or the filter
+      // matches nothing and the mutant run executes no tests.
+      const filePath = normalizeFileName(path.resolve('src', 'file.js'));
+      const test = createVitestTest({
+        file: createVitestFile({ filepath: filePath }),
+      });
+      const result = toRawTestId(test, VITEST_5_TEST_NAME_SEPARATOR);
+      expect(result).to.be.equal(`${filePath}#suite > test1`);
     });
   });
 });

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -104,6 +104,29 @@ describe(VitestTestRunner.name, () => {
       });
     });
 
+    it('should provide the legacy test name separator for vitest <5.0.0', async () => {
+      sinon.replace(vitestWrapper, 'version', '4.1.11');
+      await sut.init();
+      sinon.assert.calledWith(
+        vitestStub.provide as sinon.SinonStub,
+        'testNameSeparator',
+        ' ',
+      );
+    });
+
+    it('should provide the chained test name separator for vitest >=5.0.0', async () => {
+      // Vitest 5 matches `testNamePattern` against the suite chain joined
+      // with ' > '; filtering with a space-joined name selects no tests at
+      // all, so every covered mutant runs zero tests and survives.
+      sinon.replace(vitestWrapper, 'version', '5.0.0');
+      await sut.init();
+      sinon.assert.calledWith(
+        vitestStub.provide as sinon.SinonStub,
+        'testNameSeparator',
+        ' > ',
+      );
+    });
+
     it('should initialize the vitest environment for a prerelease version beyond 4.1.0', async () => {
       sinon.replace(vitestWrapper, 'version', '5.0.0-beta.1');
       await sut.init();


### PR DESCRIPTION
Fixes #6210

On Vitest 5 the per-test name filter matches nothing, so every mutant with per-test coverage runs zero tests and is reported **Survived**.

Vitest 5 [matches `testNamePattern` against the full chain joined with `' > '`](https://vitest.dev/guide/migration/). The runner builds both the test id and the filter regex from `collectTestName`, which joins with a single space, so the pattern never matches and the mutant run selects no tests.

### Change

`collectTestName` / `toRawTestId` take the separator as a parameter, defaulting to the current `' '` so nothing changes below Vitest 5. The runner derives it once from the running Vitest version — reusing the `semver.satisfies(vitestWrapper.version, …)` approach already used for `isGreaterThanVitest4Point1` — and both ends use it:

- provided to the sandbox as `testNameSeparator`, so the ids recorded in `mutantCoverage` are built with it;
- passed to `convertTestToTestResult`, so the ids reported back match those keys.

Both ends must agree, or the coverage keys and the filter would disagree again.

### Verification

Reproduced against a real project (~1,700 unit tests, Vitest 5.0.0, runner 10.0.0), scoped to one source file:

| | statuses | `testsCompleted` |
|---|---|---|
| before | `{ Ignored: 1, Survived: 23 }` | 0 |
| after | `{ Ignored: 1, Killed: 23 }` | 1 |

`coveredBy` was correctly populated (2-37 tests per mutant) in both cases — coverage analysis was never the problem, only the filter. The patched run is also faster (25s vs 41s), because it runs the selected test instead of the whole file's worth of nothing.

Isolated with a small probe driving `createVitest` the way the runner does, on Vitest 5.0.0:

| `testNamePattern` built from | tests run |
|---|---|
| leaf test name only | 1 |
| suite chain joined with `' '` (current behaviour) | 0 |
| suite chain joined with `' > '` | 1 |

Setting `project.config.testNamePattern` after `createVitest`, and passing cwd-relative paths to `ctx.start()`, both still work on Vitest 5 — only the separator is wrong.

### Tests

- `test-helpers.spec.ts`: `toRawTestId` joins the suite chain with the given separator.
- `vitest-runner.spec.ts`: the runner provides `' '` for Vitest <5 and `' > '` for >=5. Verified discriminating — moving the threshold to `>=6.0.0` fails exactly the `>=5.0.0` case.

`npm run test:unit` (35) and `npm run test:integration` (33) pass. Note the repo's dev dependency is Vitest 4.1.11, where this change is a deliberate no-op, so CI here exercises only the backward-compatible path — the Vitest 5 behaviour is covered by the version-gate unit tests above rather than by a live Vitest 5 run.

### Related

#6146 is complementary: it stops a zero-test mutant run being reported as survived at all. With that in place this bug would have surfaced as a loud failure rather than a silently collapsed score.
