### PR TITLE
feat(vitest-runner): support selecting a project from a workspace config

### DIFF
--- a/docs/vitest-runner.md
+++ b/docs/vitest-runner.md
@@ -54,6 +54,23 @@ Default: `true`
 
 If set to `true`, Vitest will only run tests that are related to the mutated files. It uses the [`related`](https://vitest.dev/guide/cli.html#vitest-related) under the hood. Disable this if your test files don't import your source files directly, for example when using API calls to call your server code in integration tests.
 
+### `vitest.project` [`string[]` | `undefined`]
+
+_Since v10.1_
+
+Default: `undefined`
+
+Configure the `--project <name>` command line option to select one or more named [projects](https://vitest.dev/guide/projects) out of a Vitest workspace config, instead of running every project it defines. Use this when your `vitest.config.*` splits tests into multiple projects (for example, a fast unit-test project alongside a project that needs a built artifact or a different runtime) and only one of them is meaningful to run under a mutant.
+
+```json
+{
+  "testRunner": "vitest",
+  "vitest": {
+    "project": ["unit"]
+  }
+}
+```
+
 ## Non overridable options
 
 The following options will be set by Stryker and cannot be overridden:
@@ -70,6 +87,7 @@ The following options will be set by Stryker and cannot be overridden:
 ```
 
 As you can see, the vitest runner:
+
 - Will run your tests in a **single thread**  
   This is done because StrykerJS uses it's own [parallel workers](./parallel-workers.md).
 - Will **bail** on the first test failure (unless you set `disableBail` to `true`).  
@@ -87,8 +105,8 @@ For example, you can add the Stryker disable comment (`// Stryker disable all`) 
  export function add(...args: number[]) {
    return args.reduce((a, b) => a + b, 0)
  }
- 
- 
+
+
  // in-source test suites
 +// Stryker disable all: Unit tests start here
  if (import.meta.vitest) {
@@ -98,7 +116,6 @@ For example, you can add the Stryker disable comment (`// Stryker disable all`) 
    })
  }
 ```
-
 
 ## Limitations
 

--- a/packages/vitest-runner/schema/vitest-runner-options.json
+++ b/packages/vitest-runner/schema/vitest-runner-options.json
@@ -23,6 +23,13 @@
         "configFile": {
           "description": "Path to the config file. Default resolving to `vitest.config.*`, `vite.config.*`",
           "type": "string"
+        },
+        "project": {
+          "description": "Configure the `--project <name>` command line option to select one or more named projects out of a Vitest workspace (multi-project) config, instead of running every project it defines",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -35,7 +35,7 @@ import {
   testFilesProvided,
 } from '@stryker-mutator/util';
 
-import { vitestWrapper, Vitest } from './vitest-wrapper.js';
+import { vitestWrapper, Vitest, CliOptions } from './vitest-wrapper.js';
 import {
   convertTestToTestResult,
   fromTestId,
@@ -50,6 +50,13 @@ type StrykerNamespace = '__stryker__' | '__stryker2__';
 const STRYKER_SETUP = fileURLToPath(
   new URL('./stryker-setup.js', import.meta.url),
 );
+
+/**
+ * `vitest`'s own `--project <name>` CLI flag has no counterpart in its exported `CliOptions` type, even though its CLI option schema (`packages/vitest/src/node/cli/cac.ts`) declares and consumes it (`project: { argument: '<name>', array: true }`) the same way `dir` and the other options this runner already forwards are declared there. Extended locally, not upstream in `vitest` itself: this is this package's own accommodation for a real gap in `vitest`'s published types.
+ */
+interface CliOptionsWithProject extends CliOptions {
+  project?: string[];
+}
 
 interface RunFilter {
   /**
@@ -140,7 +147,7 @@ export class VitestTestRunner implements TestRunner {
     this.setEnv();
     await this.#writeStrykerSetupFile();
 
-    this.ctx = await vitestWrapper.createVitest('test', {
+    const vitestOptions: CliOptionsWithProject = {
       config: this.options.vitest?.configFile,
       ...this.#getVitestPoolConfig(vitestWrapper.version),
       coverage: { enabled: false },
@@ -149,7 +156,9 @@ export class VitestTestRunner implements TestRunner {
       dir: this.options.vitest.dir,
       bail: this.options.disableBail ? 0 : 1,
       onConsoleLog: () => false,
-    });
+      project: this.options.vitest.project,
+    };
+    this.ctx = await vitestWrapper.createVitest('test', vitestOptions);
     this.ctx.provide('globalNamespace', this.globalNamespace);
     this.ctx.provide(
       'isGreaterThanVitest4Point1',

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -368,6 +368,22 @@ describe('VitestRunner integration', () => {
       assertions.expectKilled(runResult);
       expect(runResult.killedBy).deep.eq([barTestId]);
     });
+
+    it('should only run the named project when `project` is configured', async () => {
+      options.vitest.project = ['bar'];
+      await sut.init();
+      const runResult = await sut.dryRun(factory.dryRunOptions());
+      assertions.expectCompleted(runResult);
+      expect(runResult.mutantCoverage).deep.eq({
+        static: {},
+        perTest: {
+          [barTestId]: {
+            '0': 1,
+            '1': 1,
+          },
+        },
+      });
+    });
   });
 
   describe('using a project with tests without properly awaited assertions', () => {

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -128,6 +128,22 @@ describe(VitestTestRunner.name, () => {
 
       expect(process.env.VITEST).to.equal('1');
     });
+
+    it('should forward `project` to vitest when configured', async () => {
+      options.vitest.project = ['unit'];
+
+      await sut.init();
+
+      const vitestOptions = assertCommonVitestOptions();
+      expect(vitestOptions).deep.include({ project: ['unit'] });
+    });
+
+    it('should default `project` to undefined, running every project in a workspace config', async () => {
+      await sut.init();
+
+      const vitestOptions = assertCommonVitestOptions();
+      expect(vitestOptions.project).undefined;
+    });
   });
 
   describe(VitestTestRunner.prototype.mutantRun.name, () => {


### PR DESCRIPTION
Fixes #6215.

Adds a `vitest.project` option to `@stryker-mutator/vitest-runner`, mapping onto Vitest's own `--project <name>` CLI flag. Without it, pointing `configFile` at a real multi-project (workspace) config makes Stryker instrument and run every project it defines, not just the one that's meaningful for mutation testing -- broken or wasteful for a project whose other projects need a built artifact or a different runtime than plain Node.

## Why the local `CliOptionsWithProject` interface

Vitest's own exported `CliOptions` type (from `vitest/node`) has no `project` field, even though its CLI option schema declares and consumes one at runtime (`packages/vitest/src/node/cli/cac.ts`: `project: { argument: '<name>', array: true }`) -- confirmed directly against the compiled `vitest@4.1.11` package, and by exercising the new option end to end against a real workspace fixture (see the new integration test below). Rather than an unsafe cast, this PR extends `CliOptions` locally with the one field its public type is missing, the same way `dir` (already forwarded) is a real, working option.

## Changes

- `packages/vitest-runner/schema/vitest-runner-options.json`: new `vitest.project` option (`string[]`).
- `packages/vitest-runner/src/vitest-test-runner.ts`: forward `project` to `createVitest`, via the `CliOptionsWithProject` extension described above.
- `docs/vitest-runner.md`: documents the new option, following the existing `dir`/`related`/`configFile` format.
- Tests:
  - Unit: asserts `project` is forwarded when configured, and stays `undefined` (running every project) when not.
  - Integration: extends the existing "using a project using workspaces" suite (`testResources/workspaces`, a real two-project Vitest workspace) with a case asserting that `project: ['bar']` restricts mutant coverage to just that project's own test, excluding the other project's -- this is a genuine end-to-end proof the option does what it claims, not just that the value gets passed through.

## Verification

- `pnpm run build` (generate + `tsc -b`): clean, no errors.
- `pnpm run lint`: clean, whole repo.
- `packages/vitest-runner`: `pnpm run test:unit` (34/34 passing) and `pnpm run test:integration` (34/34 passing), both including the new tests above.