### PR TITLE
Report Vitest collection failures instead of surviving mutants

### DIFF
--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -265,10 +265,22 @@ export class VitestTestRunner implements TestRunner {
       return testResult;
     });
 
-    if (!failure && this.ctx!.state.errorsSet.size > 0) {
-      const errorText = [...this.ctx!.state.errorsSet]
-        .map(errorToString)
-        .join('\n');
+    // Collection errors are stored on the file, not in errorsSet, and may
+    // leave no individual tests to report the failure.
+    const fileErrors = this.ctx!.state.getFiles()
+      .filter((file) => file.result?.state === 'fail')
+      .map(
+        (file) =>
+          `${file.filepath}: ${file.result?.errors?.map((error) => error.message).join('\n') || 'StrykerJS: Test file execution failed'}`,
+      );
+    if (
+      !failure &&
+      (fileErrors.length > 0 || this.ctx!.state.errorsSet.size > 0)
+    ) {
+      const errorText = [
+        ...fileErrors,
+        ...[...this.ctx!.state.errorsSet].map(errorToString),
+      ].join('\n');
       return {
         status: DryRunStatus.Error,
         errorMessage: `An error occurred outside of a test run: ${errorText}`,

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs/promises';
 
 import {
   factory,
@@ -137,6 +138,82 @@ describe('VitestRunner integration', () => {
           },
         });
       });
+    });
+
+    describe('test collection failures', () => {
+      const collectionFile = 'tests/collection-error.spec.ts';
+
+      it('should reject a baseline with an import error, even when other files pass', async () => {
+        await fs.writeFile(
+          'broken-module.ts',
+          'throw new Error("Cannot initialize module");',
+        );
+        await fs.writeFile(collectionFile, 'import "../broken-module";');
+        await sut.init();
+
+        const result = await sut.dryRun(factory.dryRunOptions());
+
+        assertions.expectErrored(result);
+        expect(result.errorMessage).contains('collection-error.spec.ts');
+        expect(result.errorMessage).contains('Cannot initialize module');
+      });
+
+      for (const duringDescribe of [false, true]) {
+        it(`should report a collection error ${duringDescribe ? 'in describe' : 'at import time'} instead of a surviving mutant`, async () => {
+          await fs.writeFile(
+            'checked-pi.ts',
+            `
+            import { pi } from './math';
+            if (pi !== 3.14) throw new Error('Cannot initialize module');
+            export { pi };
+          `,
+          );
+          await fs.writeFile(
+            collectionFile,
+            duringDescribe
+              ? `
+            import { describe, it, expect } from 'vitest';
+            import { pi } from '../math';
+            describe('pi', () => {
+              if (pi !== 3.14) throw new Error('Cannot initialize module');
+              it('loads', () => expect(pi).toBe(3.14));
+            });
+          `
+              : `
+            import { it, expect } from 'vitest';
+            import { pi } from '../checked-pi';
+            it('loads', () => expect(pi).toBe(3.14));
+          `,
+          );
+          await sut.init();
+          const baseline = await sut.dryRun(factory.dryRunOptions());
+          assertions.expectCompleted(baseline);
+          expect(baseline.tests).lengthOf(7);
+          expect(
+            baseline.tests.every(({ status }) => status === TestStatus.Success),
+          ).true;
+
+          const result = await sut.mutantRun(
+            factory.mutantRunOptions({
+              activeMutant: factory.mutant({ id: '0' }),
+              mutantActivation: 'static',
+              // Include a passing test to verify that it cannot hide the collection failure.
+              testFilter: [`${collectionFile}#`, test1],
+            }),
+          );
+
+          assertions.expectErrored(result);
+          expect(result.errorMessage).contains('collection-error.spec.ts');
+          expect(result.errorMessage).contains('Cannot initialize module');
+
+          const nextRun = await sut.dryRun(factory.dryRunOptions());
+          assertions.expectCompleted(nextRun);
+          expect(nextRun.tests).lengthOf(7);
+          expect(
+            nextRun.tests.every(({ status }) => status === TestStatus.Success),
+          ).true;
+        });
+      }
     });
 
     describe(VitestTestRunner.prototype.mutantRun.name, () => {

--- a/packages/vitest-runner/test/unit/vitest-runner.spec.ts
+++ b/packages/vitest-runner/test/unit/vitest-runner.spec.ts
@@ -1,7 +1,11 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 import fs from 'fs';
-import { factory, testInjector } from '@stryker-mutator/test-helpers';
+import {
+  assertions,
+  factory,
+  testInjector,
+} from '@stryker-mutator/test-helpers';
 import {
   MutantRunStatus,
   TestRunnerCapabilities,
@@ -11,7 +15,11 @@ import { Vitest } from 'vitest/node';
 import { VitestTestRunner } from '../../src/vitest-test-runner.js';
 import { VitestRunnerOptionsWithStrykerOptions } from '../../src/vitest-runner-options-with-stryker-options.js';
 import { vitestWrapper } from '../../src/vitest-wrapper.js';
-import { createVitestMock } from '../util/factories.js';
+import {
+  createVitestFile,
+  createVitestMock,
+  createVitestTest,
+} from '../util/factories.js';
 import { VITEST_ERROR_CODES } from '../../src/vitest-helpers.js';
 
 describe(VitestTestRunner.name, () => {
@@ -155,6 +163,143 @@ describe(VitestTestRunner.name, () => {
         'mode',
         'mutant',
       );
+    });
+  });
+
+  describe('test collection failures', () => {
+    beforeEach(async () => {
+      await sut.init();
+    });
+
+    it('should report a failed file even when it collected no tests and other files passed', async () => {
+      sinon.stub(vitestStub.state, 'getFiles').returns([
+        createVitestFile({
+          filepath: 'broken.spec.ts',
+          result: {
+            state: 'fail',
+            errors: [{ message: 'Cannot initialize module' }],
+          },
+        }),
+        createVitestFile({
+          filepath: 'passing.spec.ts',
+          result: { state: 'pass' },
+          tasks: [createVitestTest({ result: { state: 'pass' } })],
+        }),
+      ]);
+
+      const result = await sut.dryRun(factory.dryRunOptions());
+
+      assertions.expectErrored(result);
+      expect(result.errorMessage).contains('broken.spec.ts');
+      expect(result.errorMessage).contains('Cannot initialize module');
+    });
+
+    it('should not report a mutant as survived when a file failed to collect tests', async () => {
+      sinon.stub(vitestStub.state, 'getFiles').returns([
+        createVitestFile({
+          result: { state: 'fail', errors: [{ message: 'Collection failed' }] },
+        }),
+      ]);
+
+      const result = await sut.mutantRun(factory.mutantRunOptions());
+
+      assertions.expectErrored(result);
+      expect(result.errorMessage).contains('Collection failed');
+    });
+
+    it('should include errors from all failed files and unhandled errors', async () => {
+      sinon.stub(vitestStub.state, 'getFiles').returns([
+        createVitestFile({
+          filepath: 'first.spec.ts',
+          result: {
+            state: 'fail',
+            errors: [
+              { message: 'First collection error' },
+              { message: 'Second collection error' },
+            ],
+          },
+        }),
+        createVitestFile({
+          filepath: 'second.spec.ts',
+          result: {
+            state: 'fail',
+            errors: [{ message: 'Another collection error' }],
+          },
+        }),
+      ]);
+      vitestStub.state.errorsSet.add(new Error('Unhandled error'));
+
+      const result = await sut.dryRun(factory.dryRunOptions());
+
+      assertions.expectErrored(result);
+      for (const message of [
+        'first.spec.ts',
+        'second.spec.ts',
+        'First collection error',
+        'Second collection error',
+        'Another collection error',
+        'Unhandled error',
+      ]) {
+        expect(result.errorMessage).contains(message);
+      }
+    });
+
+    it('should report a failed file even when no error details are available', async () => {
+      sinon.stub(vitestStub.state, 'getFiles').returns([
+        createVitestFile({
+          filepath: 'broken.spec.ts',
+          result: { state: 'fail' },
+        }),
+      ]);
+
+      const result = await sut.dryRun(factory.dryRunOptions());
+
+      assertions.expectErrored(result);
+      expect(result.errorMessage).contains('broken.spec.ts');
+      expect(result.errorMessage).contains(
+        'StrykerJS: Test file execution failed',
+      );
+    });
+
+    for (const state of [undefined, 'skip', 'pass'] as const) {
+      it(`should not treat an empty file with state ${state} as a collection failure`, async () => {
+        sinon
+          .stub(vitestStub.state, 'getFiles')
+          .returns([
+            createVitestFile({ result: state ? { state } : undefined }),
+          ]);
+
+        const result = await sut.mutantRun(factory.mutantRunOptions());
+
+        assertions.expectSurvived(result);
+        expect(result.nrOfTests).eq(0);
+      });
+    }
+
+    it('should preserve a killed result when an individual test failed', async () => {
+      sinon.stub(vitestStub.state, 'getFiles').returns([
+        createVitestFile({
+          result: { state: 'fail', errors: [{ message: 'Collection failed' }] },
+        }),
+        createVitestFile({
+          result: { state: 'fail' },
+          tasks: [
+            createVitestTest({
+              result: {
+                state: 'fail',
+                errors: [{ message: 'Assertion failed' }],
+              },
+            }),
+          ],
+        }),
+      ]);
+      vitestStub.state.errorsSet.add(new Error('Unhandled error'));
+
+      const result = await sut.mutantRun(factory.mutantRunOptions());
+
+      assertions.expectKilled(result);
+      expect(result.failureMessage).eq('Assertion failed');
+      expect(result.nrOfTests).eq(1);
     });
   });
 


### PR DESCRIPTION
Fixes: https://github.com/stryker-mutator/stryker-js/issues/6150

Vitest stores collection errors on the test file, which can leave no individual failed tests for the runner to detect. This could incorrectly mark mutants as survived or accept a failing baseline. The runner now checks file-level failures and reports them as errors, while preserving killed results for ordinary test failures.