### PR TITLE
fix(windows): hide child process console windows

### DIFF
--- a/packages/core/src/child-proxy/child-process-proxy.ts
+++ b/packages/core/src/child-proxy/child-process-proxy.ts
@@ -73,15 +73,18 @@ export class ChildProcessProxy<T> implements Disposable {
     idGenerator: IdGenerator,
   ) {
     const workerId = idGenerator.next().toString();
+    const workerOptions: childProcess.ForkOptions &
+      Pick<childProcess.SpawnOptions, 'windowsHide'> = {
+      silent: true,
+      windowsHide: true,
+      execArgv,
+      env: { STRYKER_MUTATOR_WORKER: workerId, ...process.env },
+    };
     this.worker = childProcess.fork(
       fileURLToPath(
         new URL('./child-process-proxy-worker.js', import.meta.url),
       ),
-      {
-        silent: true,
-        execArgv,
-        env: { STRYKER_MUTATOR_WORKER: workerId, ...process.env },
-      },
+      workerOptions,
     );
     this.initTask = new Task();
     this.log = logger;

--- a/packages/core/src/initializer/stryker-config-writer.ts
+++ b/packages/core/src/initializer/stryker-config-writer.ts
@@ -126,6 +126,7 @@ export class StrykerConfigWriter {
     try {
       await childProcessAsPromised.exec(
         `npx prettier --write ${configFileName}`,
+        { windowsHide: true },
       );
     } catch (error) {
       this.log.debug('Prettier exited with error', error);

--- a/packages/core/src/initializer/stryker-initializer.ts
+++ b/packages/core/src/initializer/stryker-initializer.ts
@@ -242,7 +242,7 @@ export class StrykerInitializer {
     );
     this.out(cmd);
     try {
-      childProcess.execSync(cmd, { stdio: [0, 1, 2] });
+      childProcess.execSync(cmd, { stdio: [0, 1, 2], windowsHide: true });
     } catch {
       this.out(
         `An error occurred during installation, please try it yourself: "${cmd}"`,

--- a/packages/core/src/test-runner/command-test-runner.ts
+++ b/packages/core/src/test-runner/command-test-runner.ts
@@ -103,6 +103,7 @@ export class CommandTestRunner implements TestRunner {
       const childProcess = exec(this.settings.command, {
         cwd: this.workingDir,
         env,
+        windowsHide: true,
       });
       childProcess.on('error', (error) => {
         objectUtils

--- a/packages/core/test/unit/child-proxy/child-process-proxy.spec.ts
+++ b/packages/core/test/unit/child-proxy/child-process-proxy.spec.ts
@@ -74,6 +74,7 @@ describe(ChildProcessProxy.name, () => {
         ),
         {
           silent: true,
+          windowsHide: true,
           execArgv: [],
           env: { STRYKER_MUTATOR_WORKER: workerId.toString(), ...process.env },
         },

--- a/packages/core/test/unit/initializer/stryker-initializer.spec.ts
+++ b/packages/core/test/unit/initializer/stryker-initializer.spec.ts
@@ -175,7 +175,9 @@ describe(StrykerInitializer.name, () => {
       });
       await sut.initialize();
       expectStrykerConfWritten(expectedOutput);
-      expect(childExec).calledWith('npx prettier --write stryker.config.mjs');
+      expect(childExec).calledWith('npx prettier --write stryker.config.mjs', {
+        windowsHide: true,
+      });
     });
 
     it('should handle errors when formatting fails', async () => {
@@ -215,7 +217,7 @@ describe(StrykerInitializer.name, () => {
       expect(fsWriteFile).calledOnce;
       expect(childExecSync).calledWith(
         'npm i --save-dev @stryker-mutator/core my-awesome-dependency another-awesome-dependency',
-        { stdio: [0, 1, 2] },
+        { stdio: [0, 1, 2], windowsHide: true },
       );
     });
 
@@ -262,6 +264,7 @@ describe(StrykerInitializer.name, () => {
         'npm i --save-dev @stryker-mutator/core @stryker-mutator/awesome-runner stryker-dimension-reporter @stryker-mutator/mars-reporter',
         {
           stdio: [0, 1, 2],
+          windowsHide: true,
         },
       );
     });
@@ -277,6 +280,7 @@ describe(StrykerInitializer.name, () => {
         'pnpm add -D @stryker-mutator/core @stryker-mutator/awesome-runner',
         {
           stdio: [0, 1, 2],
+          windowsHide: true,
         },
       );
     });
@@ -291,7 +295,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(childExecSync).calledWith(
         'npm i --save-dev @stryker-mutator/core',
-        { stdio: [0, 1, 2] },
+        { stdio: [0, 1, 2], windowsHide: true },
       );
     });
 
@@ -305,7 +309,7 @@ describe(StrykerInitializer.name, () => {
       await sut.initialize();
       expect(childExecSync).calledWith(
         'npm i --save-dev @stryker-mutator/core stryker-dimension-reporter @stryker-mutator/mars-reporter',
-        { stdio: [0, 1, 2] },
+        { stdio: [0, 1, 2], windowsHide: true },
       );
     });
 

--- a/packages/core/test/unit/test-runner/command-test-runner.spec.ts
+++ b/packages/core/test/unit/test-runner/command-test-runner.spec.ts
@@ -50,6 +50,7 @@ describe(CommandTestRunner.name, () => {
       expect(execMock).calledWith('npm test', {
         cwd: 'foobarDir',
         env: process.env,
+        windowsHide: true,
       });
     });
 
@@ -126,6 +127,7 @@ describe(CommandTestRunner.name, () => {
       expect(execMock).calledWith('npm test', {
         cwd: 'foobarDir',
         env: { ...process.env, __STRYKER_ACTIVE_MUTANT__: '0' },
+        windowsHide: true,
       });
     });
 

--- a/packages/tap-runner/src/tap-test-runner.ts
+++ b/packages/tap-runner/src/tap-test-runner.ts
@@ -212,7 +212,10 @@ export class TapTestRunner implements TestRunner {
     }
     const now = () => new Date().getTime();
     const before = now();
-    const tapProcess = childProcess.spawn('node', args, { env });
+    const tapProcess = childProcess.spawn('node', args, {
+      env,
+      windowsHide: true,
+    });
     const result = await captureTapResult(
       tapProcess,
       !testOptions.disableBail && this.options.tap.forceBail,

--- a/packages/tap-runner/test/unit/tap-runner.spec.ts
+++ b/packages/tap-runner/test/unit/tap-runner.spec.ts
@@ -8,8 +8,11 @@ import fs from 'fs/promises';
 
 import sinon from 'sinon';
 
-import { TestRunnerCapabilities } from '@stryker-mutator/api/test-runner';
-import { testInjector } from '@stryker-mutator/test-helpers';
+import {
+  DryRunStatus,
+  TestRunnerCapabilities,
+} from '@stryker-mutator/api/test-runner';
+import { factory, testInjector } from '@stryker-mutator/test-helpers';
 import { expect } from 'chai';
 
 import * as tap from 'tap-parser';
@@ -19,9 +22,11 @@ import {
   TapTestRunner,
 } from '../../src/tap-test-runner.js';
 import { TapParser } from '../../src/tap-parser-factory.js';
+import { tapRunnerOptions } from '../helpers/factory.js';
 
 class ChildProcessMock extends EventEmitter {
   public stdout: Readable = new PassThrough();
+  public stderr = new PassThrough();
 }
 
 describe(TapTestRunner.name, () => {
@@ -60,6 +65,25 @@ describe(TapTestRunner.name, () => {
       };
 
       expect(sut.capabilities()).deep.eq(expectedCapabilities);
+    });
+  });
+
+  describe('dryRun', () => {
+    it('should hide the test process console window', async () => {
+      Object.assign(testInjector.options, { tap: tapRunnerOptions() });
+      const result = sut.dryRun(
+        factory.dryRunOptions({ testFiles: ['test.js'] }),
+      );
+      childProcessMock.stdout.push('TAP version 13\n1..1\nok 1 - passes\n');
+      childProcessMock.stdout.push(null);
+      childProcessMock.emit('exit', 0);
+
+      expect(await result).property('status', DryRunStatus.Complete);
+      expect(forkStub).calledOnceWithExactly(
+        'node',
+        sinon.match.array,
+        sinon.match({ windowsHide: true }),
+      );
     });
   });
 });


### PR DESCRIPTION
Stryker's worker, command runner, TAP runner and initializer launches omit `windowsHide`, allowing child console windows to appear when Stryker runs under a Windows GUI host. Set the option at all five launch sites while preserving their existing streams, IPC, arguments and environment handling.

The worker options explicitly include the `windowsHide` property from `SpawnOptions`: Node forwards fork options to spawn, but the current `ForkOptions` type does not declare it. Existing launch-option assertions cover the core paths, and a TAP dry-run regression test checks the option while exercising output parsing and process exit handling.

Validation on Windows: the updated core expectations failed before the fix, and the TAP regression failed before its fix. The final change passes 1,038 core unit tests, five TAP unit tests, the scoped TypeScript build, and ESLint for all changed files. The full monorepo and integration suites were not run locally.

Generated with Codex.