### PR TITLE
fix(jest-runner): resolve testEnvironment before coverage wrap

### DIFF
--- a/packages/jest-runner/src/jest-plugins/with-coverage-analysis.ts
+++ b/packages/jest-runner/src/jest-plugins/with-coverage-analysis.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath, URL } from 'url';
 
@@ -104,10 +105,66 @@ function overrideEnvironment(
   overrides: Config.InitialOptions,
   jestWrapper: JestWrapper,
 ): void {
-  const originalJestEnvironment =
-    jestConfig.testEnvironment ?? getJestDefaults(jestWrapper).testEnvironment;
-  state.jestEnvironment = nameEnvironment(originalJestEnvironment);
+  state.jestEnvironment = resolveJestEnvironment(jestConfig, jestWrapper);
   overrides.testEnvironment = jestEnvironmentGenericFileName;
+}
+
+/**
+ * Same substitution Jest's normalize uses for path options.
+ * @see https://github.com/jestjs/jest/blob/main/packages/jest-config/src/utils.ts
+ */
+function replaceRootDirInPath(rootDir: string, filePath: string): string {
+  if (!filePath.startsWith('<rootDir>')) {
+    return filePath;
+  }
+  return path.resolve(
+    rootDir,
+    path.normalize(`./${filePath.substring('<rootDir>'.length)}`),
+  );
+}
+
+function readPresetTestEnvironment(
+  preset: string | null | undefined,
+  rootDir: string,
+): string | undefined {
+  if (!preset) {
+    return undefined;
+  }
+  try {
+    const requireFromRoot = createRequire(path.join(rootDir, 'package.json'));
+    const expandedPreset = replaceRootDirInPath(rootDir, preset);
+    const candidates =
+      expandedPreset.startsWith('.') || path.isAbsolute(expandedPreset)
+        ? [path.resolve(rootDir, expandedPreset)]
+        : [`${expandedPreset}/jest-preset`, expandedPreset];
+    for (const candidate of candidates) {
+      try {
+        const presetConfig = requireFromRoot(candidate) as {
+          testEnvironment?: string;
+        };
+        if (typeof presetConfig.testEnvironment === 'string') {
+          return presetConfig.testEnvironment;
+        }
+      } catch {
+        // Try the next candidate; Jest itself reports unreadable presets later
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function resolveJestEnvironment(
+  jestConfig: Config.InitialOptions,
+  jestWrapper: JestWrapper,
+): string {
+  const rootDir = jestConfig.rootDir ?? process.cwd();
+  const unresolved =
+    jestConfig.testEnvironment ??
+    readPresetTestEnvironment(jestConfig.preset, rootDir) ??
+    getJestDefaults(jestWrapper).testEnvironment;
+  return nameEnvironment(replaceRootDirInPath(rootDir, unresolved));
 }
 
 function nameEnvironment(shortName: string): string {

--- a/packages/jest-runner/test/integration/custom-test-environment.it.spec.ts
+++ b/packages/jest-runner/test/integration/custom-test-environment.it.spec.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { commonTokens } from '@stryker-mutator/api/plugin';
+import {
+  assertions,
+  factory,
+  testInjector,
+} from '@stryker-mutator/test-helpers';
+import { expect } from 'chai';
+
+import { JestOptions } from '../../src-generated/jest-runner-options.js';
+import { JestRunnerOptionsWithStrykerOptions } from '../../src/jest-runner-options-with-stryker-options.js';
+import { jestTestRunnerFactory } from '../../src/jest-test-runner.js';
+import { createJestOptions } from '../helpers/producers.js';
+import { resolveTestResource } from '../helpers/resolve-test-resource.js';
+
+describe('custom testEnvironment with <rootDir>', () => {
+  function createSut(overrides?: Partial<JestOptions>) {
+    const options: JestRunnerOptionsWithStrykerOptions =
+      factory.strykerWithPluginOptions({
+        jest: createJestOptions(overrides),
+      });
+    return testInjector.injector
+      .provideValue(commonTokens.options, options)
+      .injectFunction(jestTestRunnerFactory);
+  }
+
+  it('should instantiate a custom testEnvironment resolved from <rootDir> when coverageAnalysis is "perTest"', async () => {
+    const markerFile = path.join(
+      os.tmpdir(),
+      `stryker-jest-custom-env-${process.pid}.log`,
+    );
+    fs.writeFileSync(markerFile, '');
+    process.env.STRYKER_JEST_CUSTOM_ENV_MARKER = markerFile;
+    process.chdir(resolveTestResource('custom-env-rootdir'));
+
+    try {
+      const sut = createSut({ enableFindRelatedTests: false });
+      await sut.init();
+      const result = await sut.dryRun(
+        factory.dryRunOptions({ coverageAnalysis: 'perTest' }),
+      );
+
+      assertions.expectCompleted(result);
+      expect(result.tests).lengthOf(1);
+      expect(fs.readFileSync(markerFile, 'utf8')).contains('constructed');
+    } finally {
+      delete process.env.STRYKER_JEST_CUSTOM_ENV_MARKER;
+      fs.rmSync(markerFile, { force: true });
+    }
+  });
+});

--- a/packages/jest-runner/test/unit/jest-plugins/with-coverage-analysis.spec.ts
+++ b/packages/jest-runner/test/unit/jest-plugins/with-coverage-analysis.spec.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath, URL } from 'url';
+
+import { expect } from 'chai';
+
+import { withCoverageAnalysis } from '../../../src/jest-plugins/with-coverage-analysis.js';
+import { state } from '../../../src/jest-plugins/messaging.cjs';
+import { JestWrapper } from '../../../src/utils/jest-wrapper.js';
+
+describe(withCoverageAnalysis.name, () => {
+  const genericEnvironment = fileURLToPath(
+    new URL(
+      '../../../src/jest-plugins/jest-environment-generic.cjs',
+      import.meta.url,
+    ),
+  );
+
+  function createJestWrapper(version = '30.4.2'): JestWrapper {
+    return { getVersion: () => version } as unknown as JestWrapper;
+  }
+
+  it('should expand <rootDir> in testEnvironment before storing it for coverage analysis', () => {
+    const rootDir = path.resolve('/tmp/project-root');
+
+    const result = withCoverageAnalysis(
+      { rootDir, testEnvironment: '<rootDir>/custom-env.js' },
+      'perTest',
+      createJestWrapper(),
+    );
+
+    expect(state.jestEnvironment).eq(path.join(rootDir, 'custom-env.js'));
+    expect(result.testEnvironment).eq(genericEnvironment);
+  });
+
+  it('should honor a preset-provided testEnvironment when the raw config omits it', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-preset-env-'));
+    fs.writeFileSync(
+      path.join(rootDir, 'jest-preset.js'),
+      'module.exports = { testEnvironment: "jsdom" };\n',
+    );
+
+    try {
+      withCoverageAnalysis(
+        { rootDir, preset: './jest-preset.js' },
+        'all',
+        createJestWrapper(),
+      );
+
+      expect(state.jestEnvironment).eq('jest-environment-jsdom');
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should expand <rootDir> in a preset-provided testEnvironment', () => {
+    const rootDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'jest-preset-rootdir-'),
+    );
+    fs.writeFileSync(
+      path.join(rootDir, 'jest-preset.js'),
+      "module.exports = { testEnvironment: '<rootDir>/custom-env.js' };\n",
+    );
+
+    try {
+      withCoverageAnalysis(
+        { rootDir, preset: './jest-preset.js' },
+        'perTest',
+        createJestWrapper(),
+      );
+
+      expect(state.jestEnvironment).eq(path.join(rootDir, 'custom-env.js'));
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should still map the "node" shortcut after resolving', () => {
+    withCoverageAnalysis(
+      { testEnvironment: 'node' },
+      'all',
+      createJestWrapper(),
+    );
+
+    expect(state.jestEnvironment).eq('jest-environment-node');
+  });
+
+  it('should not override the environment when coverage analysis is off', () => {
+    const result = withCoverageAnalysis(
+      { testEnvironment: '<rootDir>/custom-env.js' },
+      'off',
+      createJestWrapper(),
+    );
+
+    expect(result.testEnvironment).eq('<rootDir>/custom-env.js');
+    expect(state.jestEnvironment).eq('jest-environment-node');
+  });
+});

--- a/packages/jest-runner/testResources/custom-env-rootdir/custom-env.js
+++ b/packages/jest-runner/testResources/custom-env-rootdir/custom-env.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const NodeEnv = require('jest-environment-node');
+const NodeEnvironment = NodeEnv.default ?? NodeEnv;
+
+class CustomEnvironment extends NodeEnvironment {
+  constructor(config, context) {
+    super(config, context);
+    const marker = process.env.STRYKER_JEST_CUSTOM_ENV_MARKER;
+    if (marker) {
+      fs.appendFileSync(marker, 'constructed\n');
+    }
+  }
+}
+
+module.exports = CustomEnvironment;

--- a/packages/jest-runner/testResources/custom-env-rootdir/jest.config.js
+++ b/packages/jest-runner/testResources/custom-env-rootdir/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: '<rootDir>/custom-env.js',
+  testMatch: ['<rootDir>/src/**/*.spec.js'],
+};

--- a/packages/jest-runner/testResources/custom-env-rootdir/package.json
+++ b/packages/jest-runner/testResources/custom-env-rootdir/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "custom-env-rootdir"
+}

--- a/packages/jest-runner/testResources/custom-env-rootdir/src/add.js
+++ b/packages/jest-runner/testResources/custom-env-rootdir/src/add.js
@@ -1,0 +1,3 @@
+module.exports.add = function add(a, b) {
+  return a + b;
+};

--- a/packages/jest-runner/testResources/custom-env-rootdir/src/add.spec.js
+++ b/packages/jest-runner/testResources/custom-env-rootdir/src/add.spec.js
@@ -1,0 +1,5 @@
+const { add } = require('./add');
+
+test('add', () => {
+  expect(add(1, 2)).toBe(3);
+});


### PR DESCRIPTION
Fixes #6108

Credit: @offline2k-coder

When `coverageAnalysis` is `"perTest"` or `"all"`, `@stryker-mutator/jest-runner` swaps in its coverage-forwarding `testEnvironment` using the raw, un-normalized Jest config from `readInitialOptions`. That leaves `<rootDir>/…` unresolved (`MODULE_NOT_FOUND`) and silently drops a preset-provided environment in favor of `jest-environment-node`.

Resolve `<rootDir>` (the same substitution Jest's `normalize` uses) and read `testEnvironment` from a preset when the raw config omits it, before storing `state.jestEnvironment`.

Regression: `<rootDir>/custom-env.js` under `coverageAnalysis: "perTest"`.
