### PR TITLE
fix(vitest-runner): match Vitest 5 full test names

### DIFF
--- a/e2e/test/vitest-5/package.json
+++ b/e2e/test/vitest-5/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vitest-5",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Vitest 5 per-test mutation filtering with nested suite names",
+  "scripts": {
+    "test": "stryker run && npm run verify",
+    "verify": "mocha --no-config --no-package --timeout 0 verify/verify.js",
+    "test:unit": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "5.0.0",
+    "@stryker-mutator/core": "workspace:*",
+    "@stryker-mutator/vitest-runner": "workspace:*"
+  },
+  "dependenciesMeta": {
+    "@stryker-mutator/core": {
+      "injected": true
+    },
+    "@stryker-mutator/vitest-runner": {
+      "injected": true
+    }
+  }
+}

--- a/e2e/test/vitest-5/src/add.js
+++ b/e2e/test/vitest-5/src/add.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/e2e/test/vitest-5/src/add.test.js
+++ b/e2e/test/vitest-5/src/add.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { add } from './add.js';
+
+describe('math (numbers)', () => {
+  describe('add', () => {
+    it('adds two numbers', () => {
+      expect(add(2, 3)).toBe(5);
+    });
+  });
+});

--- a/e2e/test/vitest-5/stryker.conf.mjs
+++ b/e2e/test/vitest-5/stryker.conf.mjs
@@ -1,0 +1,9 @@
+export default {
+  testRunner: 'vitest',
+  concurrency: 1,
+  coverageAnalysis: 'perTest',
+  mutate: ['src/add.js'],
+  reporters: ['json', 'clear-text'],
+  thresholds: { break: 100 },
+  plugins: [import.meta.resolve('@stryker-mutator/vitest-runner')],
+};

--- a/e2e/test/vitest-5/verify/verify.js
+++ b/e2e/test/vitest-5/verify/verify.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { readMutationTestingJsonResult } from '../../../helpers.js';
+
+describe('Vitest 5 mutation filtering', () => {
+  it('kills covered mutants in nested suites', async () => {
+    const report = await readMutationTestingJsonResult();
+    expect(report.testFiles?.['src/add.test.js'].tests).deep.eq([
+      { id: '0', name: 'math (numbers) > add > adds two numbers' },
+    ]);
+    const mutants = report.files['src/add.js'].mutants;
+    expect(mutants).not.empty;
+    for (const mutant of mutants) {
+      expect(mutant.status).eq('Killed');
+      expect(mutant.killedBy).deep.eq(['0']);
+    }
+  });
+});

--- a/packages/vitest-runner/src/stryker-setup.ts
+++ b/packages/vitest-runner/src/stryker-setup.ts
@@ -16,6 +16,7 @@ import {
 const globalNamespace = inject('globalNamespace');
 const mutantActivation = inject('mutantActivation');
 const mode = inject('mode');
+const testNameSeparator = inject('testNameSeparator');
 
 const ns = globalThis[globalNamespace] || (globalThis[globalNamespace] = {});
 ns.hitLimit = inject('hitLimit');
@@ -85,7 +86,7 @@ function collectTestName({
     nameParts.unshift(currentSuite.name);
     currentSuite = currentSuite.suite;
   }
-  return nameParts.join(' ').trim();
+  return nameParts.join(testNameSeparator).trim();
 }
 
 function toRawTestId(test: RunnerTestCase): string {
@@ -100,6 +101,7 @@ declare module 'vitest' {
     mutantActivation: MutantActivation;
     activeMutant: string | undefined;
     mode: 'mutant' | 'dry-run';
+    testNameSeparator: string;
     isGreaterThanVitest4Point1: boolean;
   }
   interface TaskMeta {

--- a/packages/vitest-runner/src/test-helpers.ts
+++ b/packages/vitest-runner/src/test-helpers.ts
@@ -4,22 +4,25 @@ import type { RunnerTestCase, RunnerTestSuite } from 'vitest';
 // This file is used from the testing environment (via stryker-setup.js) and thus could be loaded into the browser (when using vitest with browser mode).
 // Thus we should avoid unnecessary dependencies in this file.
 
-export function collectTestName({
-  name,
-  suite,
-}: {
-  name: string;
-  suite?: RunnerTestSuite;
-}): string {
+export function collectTestName(
+  {
+    name,
+    suite,
+  }: {
+    name: string;
+    suite?: RunnerTestSuite;
+  },
+  separator = ' ',
+): string {
   const nameParts = [name];
   let currentSuite = suite;
   while (currentSuite) {
     nameParts.unshift(currentSuite.name);
     currentSuite = currentSuite.suite;
   }
-  return nameParts.join(' ').trim();
+  return nameParts.join(separator).trim();
 }
 
-export function toRawTestId(test: RunnerTestCase): string {
-  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test)}`;
+export function toRawTestId(test: RunnerTestCase, separator = ' '): string {
+  return `${test.file?.filepath ?? 'unknown.js'}#${collectTestName(test, separator)}`;
 }

--- a/packages/vitest-runner/src/vitest-helpers.ts
+++ b/packages/vitest-runner/src/vitest-helpers.ts
@@ -30,11 +30,14 @@ function convertTaskStateToTestStatus(
   return TestStatus.Failed;
 }
 
-export function convertTestToTestResult(test: RunnerTestCase): TestResult {
+export function convertTestToTestResult(
+  test: RunnerTestCase,
+  separator = ' ',
+): TestResult {
   const status = convertTaskStateToTestStatus(test.result?.state, test.mode);
   const baseTestResult: BaseTestResult = {
-    id: normalizeTestId(toRawTestId(test)),
-    name: collectTestName(test),
+    id: normalizeTestId(toRawTestId(test, separator)),
+    name: collectTestName(test, separator),
     timeSpentMs: test.result?.duration ?? 0,
     fileName: test.file?.filepath && path.resolve(test.file.filepath),
   };

--- a/packages/vitest-runner/src/vitest-test-runner.ts
+++ b/packages/vitest-runner/src/vitest-test-runner.ts
@@ -74,6 +74,7 @@ export class VitestTestRunner implements TestRunner {
     'globalNamespace',
   ] as const;
   private ctx?: Vitest;
+  private testNameSeparator = ' ';
   private readonly options: VitestRunnerOptionsWithStrykerOptions;
   private localSetupFile = path.resolve(
     `./stryker-setup-${process.env.STRYKER_MUTATOR_WORKER ?? 0}.js`,
@@ -150,6 +151,9 @@ export class VitestTestRunner implements TestRunner {
       bail: this.options.disableBail ? 0 : 1,
       onConsoleLog: () => false,
     });
+    this.testNameSeparator =
+      semver.major(vitestWrapper.version) >= 5 ? ' > ' : ' ';
+    this.ctx.provide('testNameSeparator', this.testNameSeparator);
     this.ctx.provide('globalNamespace', this.globalNamespace);
     this.ctx.provide(
       'isGreaterThanVitest4Point1',
@@ -260,7 +264,7 @@ export class VitestTestRunner implements TestRunner {
 
     let failure = false;
     const testResults = tests.map((test) => {
-      const testResult = convertTestToTestResult(test);
+      const testResult = convertTestToTestResult(test, this.testNameSeparator);
       failure ||= testResult.status === TestStatus.Failed;
       return testResult;
     });

--- a/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
+++ b/packages/vitest-runner/test/integration/vitest-test-runner.it.spec.ts
@@ -140,6 +140,29 @@ describe('VitestRunner integration', () => {
     });
 
     describe(VitestTestRunner.prototype.mutantRun.name, () => {
+      it('should kill a mutant using the test id returned by the dry run', async () => {
+        await sut.init();
+        const dryRun = await sut.dryRun(factory.dryRunOptions());
+        assertions.expectCompleted(dryRun);
+        const test = dryRun.tests.find(({ name }) =>
+          name.endsWith('should be able to add two numbers'),
+        );
+        expect(test).not.eq(undefined);
+        const testId = test!.id;
+        expect(dryRun.mutantCoverage?.perTest[testId]?.['2']).eq(1);
+        const result = await sut.mutantRun(
+          factory.mutantRunOptions({
+            activeMutant: factory.mutant({ id: '2' }),
+            sandboxFileName,
+            mutantActivation: 'runtime',
+            testFilter: [testId],
+          }),
+        );
+        assertions.expectKilled(result);
+        expect(result.killedBy).deep.eq([testId]);
+        expect(result.nrOfTests).eq(1);
+      });
+
       it('should be able to kill a mutant', async () => {
         await sut.init();
         const runResult = await sut.mutantRun(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,23 @@ importers:
 
   e2e/test/use-stryker-programmatically: {}
 
+  e2e/test/vitest-5:
+    dependenciesMeta:
+      '@stryker-mutator/core':
+        injected: true
+      '@stryker-mutator/vitest-runner':
+        injected: true
+    devDependencies:
+      '@stryker-mutator/core':
+        specifier: workspace:*
+        version: file:packages/core(@types/node@24.13.3)
+      '@stryker-mutator/vitest-runner':
+        specifier: workspace:*
+        version: file:packages/vitest-runner(@stryker-mutator/core@file:packages/core(@types/node@24.13.3))(vitest@5.0.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)))
+      vitest:
+        specifier: 5.0.0
+        version: 5.0.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+
   e2e/test/vitest-concurrent-setup-removal:
     devDependencies:
       vitest:
@@ -6754,6 +6771,17 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@5.0.0':
+    resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
@@ -6804,6 +6832,9 @@ packages:
 
   '@vitest/spy@4.1.11':
     resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/spy@5.0.0':
+    resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
@@ -12314,6 +12345,9 @@ packages:
   magic-string@1.2.2:
     resolution: {integrity: sha512-veT/+7iXrXzT39XnEN4lOxtNl72dMgJ8Lp+5Bd6YcMSWpb0n0MjBM8Uuooi6jgJr8dhUW2swQgBmoZVMni5SVg==}
 
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
+
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -13449,6 +13483,10 @@ packages:
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pidtree@0.3.1:
@@ -15673,6 +15711,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinybench@6.1.4:
+    resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
+    engines: {node: '>=20.0.0'}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -16551,6 +16593,47 @@ packages:
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@5.0.0:
+    resolution: {integrity: sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 5.0.0
+      '@vitest/browser-preview': 5.0.0
+      '@vitest/browser-webdriverio': ^5.0.0-beta.5 || >=5.0.0
+      '@vitest/coverage-istanbul': 5.0.0
+      '@vitest/coverage-v8': 5.0.0
+      '@vitest/ui': 5.0.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.4.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -23016,6 +23099,15 @@ snapshots:
       tslib: 2.8.1
       vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
+  '@stryker-mutator/vitest-runner@file:packages/vitest-runner(@stryker-mutator/core@file:packages/core(@types/node@24.13.3))(vitest@5.0.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)))':
+    dependencies:
+      '@stryker-mutator/api': link:packages/api
+      '@stryker-mutator/core': file:packages/core(@types/node@24.13.3)
+      '@stryker-mutator/util': link:packages/util
+      semver: 7.8.5
+      tslib: 2.8.1
+      vitest: 5.0.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -24712,6 +24804,15 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
 
+  '@vitest/mocker@5.0.0(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -24788,6 +24889,8 @@ snapshots:
   '@vitest/spy@4.0.12': {}
 
   '@vitest/spy@4.1.11': {}
+
+  '@vitest/spy@5.0.0': {}
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -32630,6 +32733,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.2.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -34071,6 +34178,8 @@ snapshots:
   picomatch@4.0.1: {}
 
   picomatch@4.0.5: {}
+
+  picomatch@4.0.7: {}
 
   pidtree@0.3.1: {}
 
@@ -36874,6 +36983,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinybench@6.1.4: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.3.0: {}
@@ -37799,6 +37910,28 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@5.0.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@1.21.7)(less@4.2.0)(sass@1.71.1)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
Vitest 5 matches full test names with ` > ` between suites and tests. The runner constructed both reported test IDs and sandbox coverage IDs using spaces, so a successful dry run was followed by filtered mutant runs that executed no covered tests. Supply one version-aware separator to both paths while preserving older Vitest behavior.

Adds an integration test that round-trips a dry-run test ID into a killing mutant run, plus an automatically discovered Vitest 5 E2E fixture covering nested suites and regex punctuation. The fixture checks killed mutants and the corresponding reported test IDs.

