### PR TITLE
fix(instrumenter): crash when mutating ts non null expression in babel >= 8

### DIFF
--- a/packages/instrumenter/src/mutators/update-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/update-operator-mutator.ts
@@ -1,10 +1,6 @@
-import * as babel from '@babel/core';
-
 import { deepCloneNode } from '../util/index.js';
 
 import { NodeMutator } from './index.js';
-
-const { types } = babel;
 
 enum UpdateOperators {
   '++' = '--',
@@ -16,11 +12,10 @@ export const updateOperatorMutator: NodeMutator = {
 
   *mutate(path) {
     if (path.isUpdateExpression()) {
-      yield types.updateExpression(
-        UpdateOperators[path.node.operator],
-        deepCloneNode(path.node.argument),
-        path.node.prefix,
-      );
+      const mutant = deepCloneNode(path.node);
+      mutant.operator = UpdateOperators[path.node.operator];
+
+      yield mutant;
     }
   },
 };

--- a/packages/instrumenter/test/integration/instrumenter.it.spec.ts
+++ b/packages/instrumenter/test/integration/instrumenter.it.spec.ts
@@ -43,6 +43,9 @@ describe('instrumenter integration', () => {
   it('should be able to instrument a lit-html file', async () => {
     await arrangeAndActAssert('lit-html-sample.ts');
   });
+  it('should be able to instrument non-null expressions', async () => {
+    await arrangeAndActAssert('non-null-expression.ts');
+  });
   it('should be able to instrument optional chains', async () => {
     await arrangeAndActAssert('optional-chains.ts');
   });

--- a/packages/instrumenter/testResources/instrumenter/non-null-expression.ts
+++ b/packages/instrumenter/testResources/instrumenter/non-null-expression.ts
@@ -1,0 +1,7 @@
+export function count(letters: string): Int8Array {
+  const c = new Int8Array(26);
+  for (const letter of letters) {
+    c[letter.charCodeAt(0) - 65]!++;
+  }
+  return c;
+}

--- a/packages/instrumenter/testResources/instrumenter/non-null-expression.ts.out.snap
+++ b/packages/instrumenter/testResources/instrumenter/non-null-expression.ts.out.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`instrumenter integration should be able to instrument non-null expressions 1`] = `
+"function stryNS_9fa48() {
+  var g = typeof globalThis === 'object' && globalThis && globalThis.Math === Math && globalThis || new Function(\\"return this\\")();
+  var ns = g.__stryker__ || (g.__stryker__ = {});
+  if (ns.activeMutant === undefined && g.process && g.process.env && g.process.env.__STRYKER_ACTIVE_MUTANT__) {
+    ns.activeMutant = g.process.env.__STRYKER_ACTIVE_MUTANT__;
+  }
+  function retrieveNS() {
+    return ns;
+  }
+  stryNS_9fa48 = retrieveNS;
+  return retrieveNS();
+}
+stryNS_9fa48();
+function stryCov_9fa48() {
+  var ns = stryNS_9fa48();
+  var cov = ns.mutantCoverage || (ns.mutantCoverage = {
+    static: {},
+    perTest: {}
+  });
+  function cover() {
+    var c = cov.static;
+    if (ns.currentTestId) {
+      c = cov.perTest[ns.currentTestId] = cov.perTest[ns.currentTestId] || {};
+    }
+    var a = arguments;
+    for (var i = 0; i < a.length; i++) {
+      c[a[i]] = (c[a[i]] || 0) + 1;
+    }
+  }
+  stryCov_9fa48 = cover;
+  cover.apply(null, arguments);
+}
+function stryMutAct_9fa48(id) {
+  var ns = stryNS_9fa48();
+  function isActive(id) {
+    if (ns.activeMutant === id) {
+      if (ns.hitCount !== void 0 && ++ns.hitCount > ns.hitLimit) {
+        throw new Error('Stryker: Hit count limit reached (' + ns.hitCount + ')');
+      }
+      return true;
+    }
+    return false;
+  }
+  stryMutAct_9fa48 = isActive;
+  return isActive(id);
+}
+export function count(letters: string): Int8Array {
+  if (stryMutAct_9fa48(\\"0\\")) {
+    {}
+  } else {
+    stryCov_9fa48(\\"0\\");
+    const c = new Int8Array(26);
+    for (const letter of letters) {
+      if (stryMutAct_9fa48(\\"1\\")) {
+        {}
+      } else {
+        stryCov_9fa48(\\"1\\");
+        stryMutAct_9fa48(\\"2\\") ? c[letter.charCodeAt(0) - 65]! -- : (stryCov_9fa48(\\"2\\"), c[stryMutAct_9fa48(\\"3\\") ? letter.charCodeAt(0) + 65 : (stryCov_9fa48(\\"3\\"), letter.charCodeAt(0) - 65)]!++);
+      }
+    }
+    return c;
+  }
+}"
+`;


### PR DESCRIPTION
closes: #6185